### PR TITLE
feat: add PHP extension (C++) for zvec with full collection API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,24 @@ tests/*.sh
 /.idea/php.xml
 /.idea/vcs.xml
 /.idea/zvec-php.iml
+
+# PHP extension build artifacts
+php-ext/autom4te.cache/
+php-ext/build/
+php-ext/modules/
+php-ext/config.h
+php-ext/config.h.in
+php-ext/config.log
+php-ext/config.nice
+php-ext/config.status
+php-ext/configure
+php-ext/configure.ac
+php-ext/libtool
+php-ext/Makefile
+php-ext/Makefile.fragments
+php-ext/Makefile.objects
+php-ext/run-tests.php
+php-ext/.libs/
+php-ext/*.lo
+php-ext/*.la
+php-ext/*.dep

--- a/php-ext/build_ext.sh
+++ b/php-ext/build_ext.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+echo "=== Building zvec PHP extension ==="
+
+if [ ! -f "../zvec/build/lib/libzvec_db.a" ]; then
+    echo "ERROR: zvec C++ library not built. Run ./build_zvec.sh first."
+    exit 1
+fi
+
+if [ -f Makefile ]; then
+    echo "--- Cleaning previous build ---"
+    make clean 2>/dev/null || true
+    phpize --clean 2>/dev/null || true
+fi
+
+echo "--- Running phpize ---"
+phpize
+
+echo "--- Configuring ---"
+./configure --enable-zvec
+
+echo "--- Building ---"
+make -j$(sysctl -n hw.ncpu 2>/dev/null || echo 4)
+
+echo ""
+echo "=== Build complete ==="
+echo "Extension: $(pwd)/modules/zvec.so"
+echo ""
+echo "Test with:"
+echo "  php -n -d extension=modules/zvec.so -r 'echo \"zvec loaded: \" . (extension_loaded(\"zvec\") ? \"yes\" : \"no\") . \"\\n\";'"

--- a/php-ext/config.m4
+++ b/php-ext/config.m4
@@ -1,0 +1,78 @@
+PHP_ARG_ENABLE([zvec],
+  [whether to enable zvec support],
+  [AS_HELP_STRING([--enable-zvec],
+    [Enable zvec support])],
+  [no])
+
+if test "$PHP_ZVEC" != "no"; then
+  PHP_REQUIRE_CXX()
+
+  ZVEC_ROOT="$abs_srcdir/../zvec"
+  ZVEC_BUILD="$ZVEC_ROOT/build"
+  ZVEC_INCLUDE="$ZVEC_ROOT/src/include"
+  ZVEC_SPARSEHASH="$ZVEC_ROOT/thirdparty/sparsehash/sparsehash-2.0.4/src"
+  ZVEC_LIB="$ZVEC_BUILD/lib"
+  ZVEC_EXTERNAL_LIB="$ZVEC_BUILD/external/usr/local/lib"
+
+  PHP_ADD_INCLUDE($ZVEC_INCLUDE)
+  PHP_ADD_INCLUDE($ZVEC_SPARSEHASH)
+
+  ZVEC_SOURCES="zvec.cc \
+    zvec_exception.cc \
+    zvec_schema.cc \
+    zvec_doc.cc \
+    zvec_vector_query.cc \
+    zvec_collection.cc \
+    zvec_reranker.cc \
+    zvec_reranked_doc.cc \
+    zvec_rrf_reranker.cc \
+    zvec_weighted_reranker.cc \
+    zvec_embedding_interfaces.cc \
+    zvec_openai_embedding.cc \
+    zvec_qwen_embedding.cc"
+
+  PHP_NEW_EXTENSION(zvec, $ZVEC_SOURCES, $ext_shared,, -std=c++17 -DCOMPILE_DL_ZVEC)
+
+  PHP_ADD_LIBRARY(stdc++, 1, ZVEC_SHARED_LIBADD)
+  PHP_ADD_LIBRARY(z, 1, ZVEC_SHARED_LIBADD)
+  PHP_ADD_LIBRARY(pthread, 1, ZVEC_SHARED_LIBADD)
+  PHP_ADD_LIBRARY(dl, 1, ZVEC_SHARED_LIBADD)
+
+  ZVEC_FORCE_LOAD_LIBS=" \
+    -Wl,-force_load,$ZVEC_LIB/libzvec_db.a \
+    -Wl,-force_load,$ZVEC_LIB/libzvec_ailego.a \
+    -Wl,-force_load,$ZVEC_LIB/libcore_metric.a \
+    -Wl,-force_load,$ZVEC_LIB/libcore_knn_hnsw.a \
+    -Wl,-force_load,$ZVEC_LIB/libcore_knn_hnsw_sparse.a \
+    -Wl,-force_load,$ZVEC_LIB/libcore_knn_flat.a \
+    -Wl,-force_load,$ZVEC_LIB/libcore_knn_flat_sparse.a \
+    -Wl,-force_load,$ZVEC_LIB/libcore_knn_ivf.a \
+    -Wl,-force_load,$ZVEC_LIB/libcore_knn_cluster.a \
+    -Wl,-force_load,$ZVEC_LIB/libcore_quantizer.a \
+    -Wl,-force_load,$ZVEC_LIB/libcore_utility.a \
+    -Wl,-force_load,$ZVEC_LIB/libcore_mix_reducer.a \
+    -Wl,-force_load,$ZVEC_LIB/libcore_framework.a \
+    -Wl,-force_load,$ZVEC_LIB/libcore_interface.a"
+
+  ZVEC_EXTERNAL_LIBS=" \
+    $ZVEC_EXTERNAL_LIB/librocksdb.a \
+    $ZVEC_EXTERNAL_LIB/libarrow.a \
+    $ZVEC_EXTERNAL_LIB/libarrow_acero.a \
+    $ZVEC_EXTERNAL_LIB/libarrow_compute.a \
+    $ZVEC_EXTERNAL_LIB/libarrow_dataset.a \
+    $ZVEC_EXTERNAL_LIB/libarrow_bundled_dependencies.a \
+    $ZVEC_EXTERNAL_LIB/libparquet.a \
+    $ZVEC_EXTERNAL_LIB/libprotobuf.a \
+    $ZVEC_EXTERNAL_LIB/libprotoc.a \
+    $ZVEC_EXTERNAL_LIB/libantlr4-runtime.a \
+    $ZVEC_EXTERNAL_LIB/libglog.a \
+    $ZVEC_EXTERNAL_LIB/libgflags_nothreads.a \
+    $ZVEC_EXTERNAL_LIB/libyaml-cpp.a \
+    $ZVEC_EXTERNAL_LIB/liblz4.a \
+    $ZVEC_EXTERNAL_LIB/libroaring.a"
+
+  ZVEC_FRAMEWORKS="-framework CoreFoundation -framework Security"
+
+  ZVEC_SHARED_LIBADD="$ZVEC_FORCE_LOAD_LIBS $ZVEC_EXTERNAL_LIBS $ZVEC_FRAMEWORKS $ZVEC_SHARED_LIBADD"
+  PHP_SUBST(ZVEC_SHARED_LIBADD)
+fi

--- a/php-ext/php_zvec.h
+++ b/php-ext/php_zvec.h
@@ -1,0 +1,48 @@
+#ifndef PHP_ZVEC_H
+#define PHP_ZVEC_H
+
+extern "C" {
+#include "php.h"
+#include "zend_exceptions.h"
+#include "zend_interfaces.h"
+}
+
+#define PHP_ZVEC_VERSION "0.1.0"
+#define PHP_ZVEC_EXTNAME "zvec"
+
+extern zend_module_entry zvec_module_entry;
+#define phpext_zvec_ptr &zvec_module_entry
+
+PHP_MINIT_FUNCTION(zvec);
+PHP_MSHUTDOWN_FUNCTION(zvec);
+PHP_MINFO_FUNCTION(zvec);
+
+void zvec_register_exception(INIT_FUNC_ARGS);
+void zvec_register_schema(INIT_FUNC_ARGS);
+void zvec_register_doc(INIT_FUNC_ARGS);
+void zvec_register_vector_query(INIT_FUNC_ARGS);
+void zvec_register_collection(INIT_FUNC_ARGS);
+void zvec_register_reranker(INIT_FUNC_ARGS);
+void zvec_register_reranked_doc(INIT_FUNC_ARGS);
+void zvec_register_rrf_reranker(INIT_FUNC_ARGS);
+void zvec_register_weighted_reranker(INIT_FUNC_ARGS);
+void zvec_register_embedding_interfaces(INIT_FUNC_ARGS);
+void zvec_register_openai_embedding(INIT_FUNC_ARGS);
+void zvec_register_qwen_embedding(INIT_FUNC_ARGS);
+
+extern zend_class_entry *zvec_exception_ce;
+extern zend_class_entry *zvec_schema_ce;
+extern zend_class_entry *zvec_doc_ce;
+extern zend_class_entry *zvec_vector_query_ce;
+extern zend_class_entry *zvec_collection_ce;
+extern zend_class_entry *zvec_reranker_ce;
+extern zend_class_entry *zvec_reranked_doc_ce;
+extern zend_class_entry *zvec_rrf_reranker_ce;
+extern zend_class_entry *zvec_weighted_reranker_ce;
+extern zend_class_entry *zvec_dense_embedding_ce;
+extern zend_class_entry *zvec_sparse_embedding_ce;
+extern zend_class_entry *zvec_api_embedding_ce;
+extern zend_class_entry *zvec_openai_embedding_ce;
+extern zend_class_entry *zvec_qwen_embedding_ce;
+
+#endif

--- a/php-ext/zvec.cc
+++ b/php-ext/zvec.cc
@@ -1,0 +1,51 @@
+#include "php_zvec.h"
+
+extern "C" {
+#include "ext/standard/info.h"
+}
+
+PHP_MINIT_FUNCTION(zvec) {
+    zvec_register_exception(INIT_FUNC_ARGS_PASSTHRU);
+    zvec_register_schema(INIT_FUNC_ARGS_PASSTHRU);
+    zvec_register_doc(INIT_FUNC_ARGS_PASSTHRU);
+    zvec_register_vector_query(INIT_FUNC_ARGS_PASSTHRU);
+    zvec_register_collection(INIT_FUNC_ARGS_PASSTHRU);
+    zvec_register_reranker(INIT_FUNC_ARGS_PASSTHRU);
+    zvec_register_reranked_doc(INIT_FUNC_ARGS_PASSTHRU);
+    zvec_register_rrf_reranker(INIT_FUNC_ARGS_PASSTHRU);
+    zvec_register_weighted_reranker(INIT_FUNC_ARGS_PASSTHRU);
+    zvec_register_embedding_interfaces(INIT_FUNC_ARGS_PASSTHRU);
+    zvec_register_openai_embedding(INIT_FUNC_ARGS_PASSTHRU);
+    zvec_register_qwen_embedding(INIT_FUNC_ARGS_PASSTHRU);
+    return SUCCESS;
+}
+
+PHP_MSHUTDOWN_FUNCTION(zvec) {
+    return SUCCESS;
+}
+
+PHP_MINFO_FUNCTION(zvec) {
+    php_info_print_table_start();
+    php_info_print_table_header(2, "zvec support", "enabled");
+    php_info_print_table_row(2, "zvec extension version", PHP_ZVEC_VERSION);
+    php_info_print_table_end();
+}
+
+zend_module_entry zvec_module_entry = {
+    STANDARD_MODULE_HEADER,
+    PHP_ZVEC_EXTNAME,
+    nullptr,
+    PHP_MINIT(zvec),
+    PHP_MSHUTDOWN(zvec),
+    nullptr,
+    nullptr,
+    PHP_MINFO(zvec),
+    PHP_ZVEC_VERSION,
+    STANDARD_MODULE_PROPERTIES
+};
+
+#ifdef COMPILE_DL_ZVEC
+extern "C" {
+    ZEND_GET_MODULE(zvec)
+}
+#endif

--- a/php-ext/zvec_collection.cc
+++ b/php-ext/zvec_collection.cc
@@ -1,0 +1,1556 @@
+#include "zvec_exception.h"
+#include "zvec_vector_query.h"
+#include "zvec_reranker.h"
+
+#pragma push_macro("IS_NULL")
+#undef IS_NULL
+
+#include "zvec_collection.h"
+#include "zvec_schema.h"
+#include "zvec_doc.h"
+#include <zvec/db/collection.h>
+#include <zvec/db/doc.h>
+#include <zvec/db/schema.h>
+#include <zvec/db/index_params.h>
+#include <zvec/db/options.h>
+#include <zvec/db/config.h>
+#include <zvec/db/status.h>
+#include <zvec/ailego/utility/float_helper.h>
+
+#pragma pop_macro("IS_NULL")
+
+#include <vector>
+#include <string>
+#include <cstring>
+
+using namespace zvec;
+
+zend_class_entry *zvec_collection_ce = nullptr;
+static zend_object_handlers zvec_collection_handlers;
+
+static zend_object *zvec_collection_create_object_handler(zend_class_entry *ce) {
+    auto *intern = static_cast<zvec_collection_object *>(
+        ecalloc(1, sizeof(zvec_collection_object) + zend_object_properties_size(ce)));
+    new (&intern->collection) Collection::Ptr(nullptr);
+    intern->closed = true;
+    zend_object_std_init(&intern->std, ce);
+    object_properties_init(&intern->std, ce);
+    intern->std.handlers = &zvec_collection_handlers;
+    return &intern->std;
+}
+
+static void zvec_collection_free_object(zend_object *obj) {
+    auto *intern = zvec_collection_from_obj(obj);
+    intern->collection.reset();
+    intern->collection.~shared_ptr();
+    zend_object_std_dtor(obj);
+}
+
+static inline void check_closed(zvec_collection_object *intern) {
+    if (intern->closed) {
+        zvec_throw_exception(0, "Collection is closed or destroyed");
+    }
+}
+
+static inline bool check_status(const Status &s) {
+    if (!s.ok()) {
+        zvec_throw_exception(static_cast<int>(s.code()), "%s", s.message().c_str());
+        return false;
+    }
+    return true;
+}
+
+static MetricType to_metric_type(uint32_t v) {
+    switch (v) {
+        case 1: return MetricType::L2;
+        case 2: return MetricType::IP;
+        case 3: return MetricType::COSINE;
+        default: return MetricType::IP;
+    }
+}
+
+static QuantizeType to_quantize_type(uint32_t v) {
+    switch (v) {
+        case 0: return QuantizeType::UNDEFINED;
+        case 1: return QuantizeType::FP16;
+        case 2: return QuantizeType::INT8;
+        case 3: return QuantizeType::INT4;
+        default: return QuantizeType::UNDEFINED;
+    }
+}
+
+static std::vector<Doc> docs_from_args(zval *args, uint32_t argc) {
+    std::vector<Doc> doc_vec;
+    doc_vec.reserve(argc);
+    for (uint32_t i = 0; i < argc; i++) {
+        zval *z = &args[i];
+        if (Z_TYPE_P(z) != IS_OBJECT || !instanceof_function(Z_OBJCE_P(z), zvec_doc_ce)) {
+            zvec_throw_exception(0, "Argument %d must be a ZVecDoc instance", i + 1);
+            return {};
+        }
+        auto *doc_obj = Z_ZVEC_DOC_P(z);
+        doc_vec.push_back(*doc_obj->doc);
+    }
+    return doc_vec;
+}
+
+PHP_METHOD(ZVec, init) {
+    zend_long log_type = 0, log_level = 2;
+    char *log_dir = nullptr; size_t log_dir_len = 0;
+    char *log_basename = nullptr; size_t log_basename_len = 0;
+    zend_long log_file_size = 0, log_overdue_days = 0;
+    zend_long query_threads = 0, optimize_threads = 0;
+    double invert_ratio = 0.0, brute_ratio = 0.0;
+    zend_long memory_limit = 0;
+
+    ZEND_PARSE_PARAMETERS_START(0, 11)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_LONG(log_type)
+        Z_PARAM_LONG(log_level)
+        Z_PARAM_STRING_OR_NULL(log_dir, log_dir_len)
+        Z_PARAM_STRING_OR_NULL(log_basename, log_basename_len)
+        Z_PARAM_LONG(log_file_size)
+        Z_PARAM_LONG(log_overdue_days)
+        Z_PARAM_LONG(query_threads)
+        Z_PARAM_LONG(optimize_threads)
+        Z_PARAM_DOUBLE(invert_ratio)
+        Z_PARAM_DOUBLE(brute_ratio)
+        Z_PARAM_LONG(memory_limit)
+    ZEND_PARSE_PARAMETERS_END();
+
+    GlobalConfig::ConfigData config;
+    auto lvl = static_cast<GlobalConfig::LogLevel>(log_level);
+
+    if (log_type == 1) {
+        config.log_config = std::make_shared<GlobalConfig::FileLogConfig>(
+            lvl,
+            log_dir ? log_dir : DEFAULT_LOG_DIR,
+            log_basename ? log_basename : DEFAULT_LOG_BASENAME,
+            log_file_size > 0 ? static_cast<uint32_t>(log_file_size) : DEFAULT_LOG_FILE_SIZE,
+            log_overdue_days > 0 ? static_cast<uint32_t>(log_overdue_days) : DEFAULT_LOG_OVERDUE_DAYS);
+    } else {
+        config.log_config = std::make_shared<GlobalConfig::ConsoleLogConfig>(lvl);
+    }
+
+    if (query_threads > 0) config.query_thread_count = static_cast<uint32_t>(query_threads);
+    if (optimize_threads > 0) config.optimize_thread_count = static_cast<uint32_t>(optimize_threads);
+    if (invert_ratio > 0.0) config.invert_to_forward_scan_ratio = static_cast<float>(invert_ratio);
+    if (brute_ratio > 0.0) config.brute_force_by_keys_ratio = static_cast<float>(brute_ratio);
+    if (memory_limit > 0) config.memory_limit_bytes = static_cast<uint64_t>(memory_limit) * 1024ULL * 1024ULL;
+
+    auto &gc = GlobalConfig::Instance();
+    check_status(gc.Initialize(config));
+}
+
+PHP_METHOD(ZVec, create) {
+    char *path; size_t path_len;
+    zval *schema_zv;
+    zend_bool read_only = 0, enable_mmap = 1;
+    zend_long max_buffer_size = 67108864;
+
+    ZEND_PARSE_PARAMETERS_START(2, 5)
+        Z_PARAM_STRING(path, path_len)
+        Z_PARAM_OBJECT_OF_CLASS(schema_zv, zvec_schema_ce)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_BOOL(read_only)
+        Z_PARAM_BOOL(enable_mmap)
+        Z_PARAM_LONG(max_buffer_size)
+    ZEND_PARSE_PARAMETERS_END();
+
+    auto *schema = zvec_schema_get_native(schema_zv);
+    CollectionOptions opts{(bool)read_only, (bool)enable_mmap, static_cast<uint32_t>(max_buffer_size)};
+    auto result = Collection::CreateAndOpen(std::string(path, path_len), *schema, opts);
+    if (!result.has_value()) {
+        check_status(result.error());
+        RETURN_THROWS();
+    }
+
+    object_init_ex(return_value, zvec_collection_ce);
+    auto *intern = Z_ZVEC_COLLECTION_P(return_value);
+    intern->collection = std::move(result).value();
+    intern->closed = false;
+}
+
+PHP_METHOD(ZVec, open) {
+    char *path; size_t path_len;
+    zend_bool read_only = 0, enable_mmap = 1;
+    zend_long max_buffer_size = 67108864;
+
+    ZEND_PARSE_PARAMETERS_START(1, 4)
+        Z_PARAM_STRING(path, path_len)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_BOOL(read_only)
+        Z_PARAM_BOOL(enable_mmap)
+        Z_PARAM_LONG(max_buffer_size)
+    ZEND_PARSE_PARAMETERS_END();
+
+    CollectionOptions opts{(bool)read_only, (bool)enable_mmap, static_cast<uint32_t>(max_buffer_size)};
+    auto result = Collection::Open(std::string(path, path_len), opts);
+    if (!result.has_value()) {
+        check_status(result.error());
+        RETURN_THROWS();
+    }
+
+    object_init_ex(return_value, zvec_collection_ce);
+    auto *intern = Z_ZVEC_COLLECTION_P(return_value);
+    intern->collection = std::move(result).value();
+    intern->closed = false;
+}
+
+PHP_METHOD(ZVec, close) {
+    ZEND_PARSE_PARAMETERS_NONE();
+    auto *intern = Z_ZVEC_COLLECTION_P(ZEND_THIS);
+    if (!intern->closed) {
+        intern->collection.reset();
+        intern->closed = true;
+    }
+}
+
+PHP_METHOD(ZVec, __destruct) {
+    ZEND_PARSE_PARAMETERS_NONE();
+    auto *intern = Z_ZVEC_COLLECTION_P(ZEND_THIS);
+    if (!intern->closed) {
+        intern->collection.reset();
+        intern->closed = true;
+    }
+}
+
+PHP_METHOD(ZVec, flush) {
+    ZEND_PARSE_PARAMETERS_NONE();
+    auto *intern = Z_ZVEC_COLLECTION_P(ZEND_THIS);
+    check_closed(intern);
+    if (EG(exception)) RETURN_THROWS();
+    check_status(intern->collection->Flush());
+}
+
+PHP_METHOD(ZVec, optimize) {
+    zend_long concurrency = 0;
+    ZEND_PARSE_PARAMETERS_START(0, 1)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_LONG(concurrency)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_COLLECTION_P(ZEND_THIS);
+    check_closed(intern);
+    if (EG(exception)) RETURN_THROWS();
+    OptimizeOptions opts;
+    if (concurrency > 0) opts.concurrency_ = static_cast<int>(concurrency);
+    check_status(intern->collection->Optimize(opts));
+}
+
+PHP_METHOD(ZVec, destroy) {
+    ZEND_PARSE_PARAMETERS_NONE();
+    auto *intern = Z_ZVEC_COLLECTION_P(ZEND_THIS);
+    if (!intern->closed) {
+        auto status = intern->collection->Destroy();
+        intern->collection.reset();
+        intern->closed = true;
+        check_status(status);
+    }
+}
+
+PHP_METHOD(ZVec, schema) {
+    ZEND_PARSE_PARAMETERS_NONE();
+    auto *intern = Z_ZVEC_COLLECTION_P(ZEND_THIS);
+    check_closed(intern);
+    if (EG(exception)) RETURN_THROWS();
+    auto res = intern->collection->Schema();
+    if (!res.has_value()) { check_status(res.error()); RETURN_THROWS(); }
+    auto str = res.value().to_string();
+    RETURN_STRINGL(str.c_str(), str.length());
+}
+
+PHP_METHOD(ZVec, path) {
+    ZEND_PARSE_PARAMETERS_NONE();
+    auto *intern = Z_ZVEC_COLLECTION_P(ZEND_THIS);
+    check_closed(intern);
+    if (EG(exception)) RETURN_THROWS();
+    auto res = intern->collection->Path();
+    if (!res.has_value()) { check_status(res.error()); RETURN_THROWS(); }
+    RETURN_STRINGL(res.value().c_str(), res.value().length());
+}
+
+PHP_METHOD(ZVec, options) {
+    ZEND_PARSE_PARAMETERS_NONE();
+    auto *intern = Z_ZVEC_COLLECTION_P(ZEND_THIS);
+    check_closed(intern);
+    if (EG(exception)) RETURN_THROWS();
+    auto res = intern->collection->Options();
+    if (!res.has_value()) { check_status(res.error()); RETURN_THROWS(); }
+    array_init(return_value);
+    add_assoc_bool(return_value, "read_only", res.value().read_only_);
+    add_assoc_bool(return_value, "enable_mmap", res.value().enable_mmap_);
+    add_assoc_long(return_value, "max_buffer_size", static_cast<zend_long>(res.value().max_buffer_size_));
+}
+
+PHP_METHOD(ZVec, stats) {
+    ZEND_PARSE_PARAMETERS_NONE();
+    auto *intern = Z_ZVEC_COLLECTION_P(ZEND_THIS);
+    check_closed(intern);
+    if (EG(exception)) RETURN_THROWS();
+    auto res = intern->collection->Stats();
+    if (!res.has_value()) { check_status(res.error()); RETURN_THROWS(); }
+    auto str = res.value().to_string();
+    RETURN_STRINGL(str.c_str(), str.length());
+}
+
+// --- Column DDL ---
+
+#define ZVEC_ADD_COLUMN_METHOD(php_name, data_type, default_expr_val) \
+PHP_METHOD(ZVec, php_name) { \
+    char *name; size_t name_len; \
+    zend_bool nullable = 1; \
+    char *default_expr = nullptr; size_t default_expr_len = 0; \
+    zend_long concurrency = 0; \
+    ZEND_PARSE_PARAMETERS_START(1, 4) \
+        Z_PARAM_STRING(name, name_len) \
+        Z_PARAM_OPTIONAL \
+        Z_PARAM_BOOL(nullable) \
+        Z_PARAM_STRING(default_expr, default_expr_len) \
+        Z_PARAM_LONG(concurrency) \
+    ZEND_PARSE_PARAMETERS_END(); \
+    auto *intern = Z_ZVEC_COLLECTION_P(ZEND_THIS); \
+    check_closed(intern); \
+    if (EG(exception)) RETURN_THROWS(); \
+    intern->collection->Flush(); \
+    auto field = std::make_shared<FieldSchema>(std::string(name, name_len), data_type, (bool)nullable); \
+    AddColumnOptions opts; \
+    if (concurrency > 0) opts.concurrency_ = static_cast<int>(concurrency); \
+    check_status(intern->collection->AddColumn(field, default_expr ? default_expr : default_expr_val, opts)); \
+}
+
+ZVEC_ADD_COLUMN_METHOD(addColumnInt64, DataType::INT64, "0")
+ZVEC_ADD_COLUMN_METHOD(addColumnFloat, DataType::FLOAT, "0")
+ZVEC_ADD_COLUMN_METHOD(addColumnDouble, DataType::DOUBLE, "0")
+ZVEC_ADD_COLUMN_METHOD(addColumnString, DataType::STRING, "")
+ZVEC_ADD_COLUMN_METHOD(addColumnBool, DataType::BOOL, "false")
+ZVEC_ADD_COLUMN_METHOD(addColumnInt32, DataType::INT32, "0")
+ZVEC_ADD_COLUMN_METHOD(addColumnUint32, DataType::UINT32, "0")
+ZVEC_ADD_COLUMN_METHOD(addColumnUint64, DataType::UINT64, "0")
+
+PHP_METHOD(ZVec, dropColumn) {
+    char *name; size_t name_len;
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_STRING(name, name_len)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_COLLECTION_P(ZEND_THIS);
+    check_closed(intern);
+    if (EG(exception)) RETURN_THROWS();
+    intern->collection->Flush();
+    check_status(intern->collection->DropColumn(std::string(name, name_len)));
+}
+
+PHP_METHOD(ZVec, renameColumn) {
+    char *old_name; size_t old_name_len;
+    char *new_name; size_t new_name_len;
+    zend_long concurrency = 0;
+    ZEND_PARSE_PARAMETERS_START(2, 3)
+        Z_PARAM_STRING(old_name, old_name_len)
+        Z_PARAM_STRING(new_name, new_name_len)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_LONG(concurrency)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_COLLECTION_P(ZEND_THIS);
+    check_closed(intern);
+    if (EG(exception)) RETURN_THROWS();
+    intern->collection->Flush();
+    AlterColumnOptions opts;
+    if (concurrency > 0) opts.concurrency_ = static_cast<int>(concurrency);
+    check_status(intern->collection->AlterColumn(
+        std::string(old_name, old_name_len), std::string(new_name, new_name_len), nullptr, opts));
+}
+
+PHP_METHOD(ZVec, alterColumn) {
+    char *col_name; size_t col_name_len;
+    char *new_name = nullptr; size_t new_name_len = 0;
+    zval *new_data_type_zv = nullptr;
+    zval *nullable_zv = nullptr;
+    zend_long concurrency = 0;
+
+    ZEND_PARSE_PARAMETERS_START(1, 5)
+        Z_PARAM_STRING(col_name, col_name_len)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_STRING_OR_NULL(new_name, new_name_len)
+        Z_PARAM_ZVAL_OR_NULL(new_data_type_zv)
+        Z_PARAM_ZVAL_OR_NULL(nullable_zv)
+        Z_PARAM_LONG(concurrency)
+    ZEND_PARSE_PARAMETERS_END();
+
+    auto *intern = Z_ZVEC_COLLECTION_P(ZEND_THIS);
+    check_closed(intern);
+    if (EG(exception)) RETURN_THROWS();
+    intern->collection->Flush();
+
+    uint32_t data_type = 0;
+    if (new_data_type_zv && Z_TYPE_P(new_data_type_zv) == IS_LONG) {
+        data_type = static_cast<uint32_t>(Z_LVAL_P(new_data_type_zv));
+    }
+
+    bool is_nullable = false;
+    if (nullable_zv && Z_TYPE_P(nullable_zv) != IS_NULL) {
+        is_nullable = zend_is_true(nullable_zv);
+    }
+
+    DataType dt = DataType::UNDEFINED;
+    switch (data_type) {
+        case 4: dt = DataType::INT32; break;
+        case 5: dt = DataType::INT64; break;
+        case 6: dt = DataType::UINT32; break;
+        case 7: dt = DataType::UINT64; break;
+        case 8: dt = DataType::FLOAT; break;
+        case 9: dt = DataType::DOUBLE; break;
+    }
+
+    FieldSchema::Ptr new_schema = nullptr;
+    if (dt != DataType::UNDEFINED) {
+        new_schema = std::make_shared<FieldSchema>(std::string(col_name, col_name_len), dt, is_nullable);
+    }
+
+    std::string rename_str = new_name ? std::string(new_name, new_name_len) : "";
+    AlterColumnOptions opts;
+    if (concurrency > 0) opts.concurrency_ = static_cast<int>(concurrency);
+    check_status(intern->collection->AlterColumn(
+        std::string(col_name, col_name_len), rename_str, new_schema, opts));
+}
+
+// --- Index DDL ---
+
+PHP_METHOD(ZVec, createInvertIndex) {
+    char *field; size_t field_len;
+    zend_bool enable_range = 1, enable_wildcard = 0;
+    ZEND_PARSE_PARAMETERS_START(1, 3)
+        Z_PARAM_STRING(field, field_len)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_BOOL(enable_range)
+        Z_PARAM_BOOL(enable_wildcard)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_COLLECTION_P(ZEND_THIS);
+    check_closed(intern);
+    if (EG(exception)) RETURN_THROWS();
+    auto params = std::make_shared<InvertIndexParams>((bool)enable_range, (bool)enable_wildcard);
+    check_status(intern->collection->CreateIndex(std::string(field, field_len), params));
+}
+
+PHP_METHOD(ZVec, createHnswIndex) {
+    char *field; size_t field_len;
+    zend_long metric_type = 2, m = 50, ef_construction = 500, quantize_type = 0, concurrency = 0;
+    ZEND_PARSE_PARAMETERS_START(1, 6)
+        Z_PARAM_STRING(field, field_len)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_LONG(metric_type)
+        Z_PARAM_LONG(m)
+        Z_PARAM_LONG(ef_construction)
+        Z_PARAM_LONG(quantize_type)
+        Z_PARAM_LONG(concurrency)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_COLLECTION_P(ZEND_THIS);
+    check_closed(intern);
+    if (EG(exception)) RETURN_THROWS();
+    auto params = std::make_shared<HnswIndexParams>(
+        to_metric_type(static_cast<uint32_t>(metric_type)),
+        static_cast<int>(m), static_cast<int>(ef_construction),
+        to_quantize_type(static_cast<uint32_t>(quantize_type)));
+    CreateIndexOptions opts;
+    if (concurrency > 0) opts.concurrency_ = static_cast<int>(concurrency);
+    check_status(intern->collection->CreateIndex(std::string(field, field_len), params, opts));
+}
+
+PHP_METHOD(ZVec, createFlatIndex) {
+    char *field; size_t field_len;
+    zend_long metric_type = 2, quantize_type = 0, concurrency = 0;
+    ZEND_PARSE_PARAMETERS_START(1, 4)
+        Z_PARAM_STRING(field, field_len)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_LONG(metric_type)
+        Z_PARAM_LONG(quantize_type)
+        Z_PARAM_LONG(concurrency)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_COLLECTION_P(ZEND_THIS);
+    check_closed(intern);
+    if (EG(exception)) RETURN_THROWS();
+    auto params = std::make_shared<FlatIndexParams>(
+        to_metric_type(static_cast<uint32_t>(metric_type)),
+        to_quantize_type(static_cast<uint32_t>(quantize_type)));
+    CreateIndexOptions opts;
+    if (concurrency > 0) opts.concurrency_ = static_cast<int>(concurrency);
+    check_status(intern->collection->CreateIndex(std::string(field, field_len), params, opts));
+}
+
+PHP_METHOD(ZVec, createIvfIndex) {
+    char *field; size_t field_len;
+    zend_long metric_type = 2, n_list = 1024, n_iters = 10, quantize_type = 0, concurrency = 0;
+    zend_bool use_soar = 0;
+    ZEND_PARSE_PARAMETERS_START(1, 7)
+        Z_PARAM_STRING(field, field_len)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_LONG(metric_type)
+        Z_PARAM_LONG(n_list)
+        Z_PARAM_LONG(n_iters)
+        Z_PARAM_BOOL(use_soar)
+        Z_PARAM_LONG(quantize_type)
+        Z_PARAM_LONG(concurrency)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_COLLECTION_P(ZEND_THIS);
+    check_closed(intern);
+    if (EG(exception)) RETURN_THROWS();
+    auto params = std::make_shared<IVFIndexParams>(
+        to_metric_type(static_cast<uint32_t>(metric_type)),
+        static_cast<int>(n_list), static_cast<int>(n_iters),
+        (bool)use_soar, to_quantize_type(static_cast<uint32_t>(quantize_type)));
+    CreateIndexOptions opts;
+    if (concurrency > 0) opts.concurrency_ = static_cast<int>(concurrency);
+    check_status(intern->collection->CreateIndex(std::string(field, field_len), params, opts));
+}
+
+PHP_METHOD(ZVec, dropIndex) {
+    char *field; size_t field_len;
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_STRING(field, field_len)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_COLLECTION_P(ZEND_THIS);
+    check_closed(intern);
+    if (EG(exception)) RETURN_THROWS();
+    check_status(intern->collection->DropIndex(std::string(field, field_len)));
+}
+
+// --- Insert / Upsert / Update ---
+
+PHP_METHOD(ZVec, insert) {
+    zval *args; uint32_t argc;
+    ZEND_PARSE_PARAMETERS_START(1, -1)
+        Z_PARAM_VARIADIC('+', args, argc)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_COLLECTION_P(ZEND_THIS);
+    check_closed(intern);
+    if (EG(exception)) RETURN_THROWS();
+    auto doc_vec = docs_from_args(args, argc);
+    if (EG(exception)) RETURN_THROWS();
+    auto res = intern->collection->Insert(doc_vec);
+    if (!res.has_value()) { check_status(res.error()); RETURN_THROWS(); }
+    for (const auto &s : res.value()) {
+        if (!s.ok()) { check_status(s); RETURN_THROWS(); }
+    }
+}
+
+PHP_METHOD(ZVec, upsert) {
+    zval *args; uint32_t argc;
+    ZEND_PARSE_PARAMETERS_START(1, -1)
+        Z_PARAM_VARIADIC('+', args, argc)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_COLLECTION_P(ZEND_THIS);
+    check_closed(intern);
+    if (EG(exception)) RETURN_THROWS();
+    auto doc_vec = docs_from_args(args, argc);
+    if (EG(exception)) RETURN_THROWS();
+    auto res = intern->collection->Upsert(doc_vec);
+    if (!res.has_value()) { check_status(res.error()); RETURN_THROWS(); }
+    for (const auto &s : res.value()) {
+        if (!s.ok()) { check_status(s); RETURN_THROWS(); }
+    }
+}
+
+PHP_METHOD(ZVec, update) {
+    zval *args; uint32_t argc;
+    ZEND_PARSE_PARAMETERS_START(1, -1)
+        Z_PARAM_VARIADIC('+', args, argc)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_COLLECTION_P(ZEND_THIS);
+    check_closed(intern);
+    if (EG(exception)) RETURN_THROWS();
+    auto doc_vec = docs_from_args(args, argc);
+    if (EG(exception)) RETURN_THROWS();
+    auto res = intern->collection->Update(doc_vec);
+    if (!res.has_value()) { check_status(res.error()); RETURN_THROWS(); }
+    for (const auto &s : res.value()) {
+        if (!s.ok()) { check_status(s); RETURN_THROWS(); }
+    }
+}
+
+// --- Batch operations ---
+
+template<typename F>
+static void do_batch_op(INTERNAL_FUNCTION_PARAMETERS, F op) {
+    zval *args; uint32_t argc;
+    ZEND_PARSE_PARAMETERS_START(1, -1)
+        Z_PARAM_VARIADIC('+', args, argc)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_COLLECTION_P(ZEND_THIS);
+    check_closed(intern);
+    if (EG(exception)) RETURN_THROWS();
+
+    std::vector<std::string> pks;
+    std::vector<Doc> doc_vec;
+    doc_vec.reserve(argc);
+    pks.reserve(argc);
+    for (uint32_t i = 0; i < argc; i++) {
+        zval *z = &args[i];
+        if (Z_TYPE_P(z) != IS_OBJECT || !instanceof_function(Z_OBJCE_P(z), zvec_doc_ce)) {
+            zvec_throw_exception(0, "Argument %d must be a ZVecDoc instance", i + 1);
+            RETURN_THROWS();
+        }
+        auto *doc_obj = Z_ZVEC_DOC_P(z);
+        doc_vec.push_back(*doc_obj->doc);
+        pks.push_back(doc_obj->doc->pk());
+    }
+
+    auto res = op(intern->collection.get(), doc_vec);
+    if (!res.has_value()) { check_status(res.error()); RETURN_THROWS(); }
+
+    const auto &statuses = res.value();
+    array_init_size(return_value, statuses.size());
+    for (size_t i = 0; i < statuses.size(); i++) {
+        zval entry;
+        array_init(&entry);
+        add_assoc_string(&entry, "pk", pks[i].c_str());
+        add_assoc_bool(&entry, "ok", statuses[i].ok());
+        if (!statuses[i].ok()) {
+            add_assoc_string(&entry, "error", statuses[i].message().c_str());
+        } else {
+            add_assoc_null(&entry, "error");
+        }
+        add_next_index_zval(return_value, &entry);
+    }
+}
+
+PHP_METHOD(ZVec, insertBatch) {
+    do_batch_op(INTERNAL_FUNCTION_PARAM_PASSTHRU,
+        [](Collection *c, std::vector<Doc> &docs) { return c->Insert(docs); });
+}
+
+PHP_METHOD(ZVec, upsertBatch) {
+    do_batch_op(INTERNAL_FUNCTION_PARAM_PASSTHRU,
+        [](Collection *c, std::vector<Doc> &docs) { return c->Upsert(docs); });
+}
+
+PHP_METHOD(ZVec, updateBatch) {
+    do_batch_op(INTERNAL_FUNCTION_PARAM_PASSTHRU,
+        [](Collection *c, std::vector<Doc> &docs) { return c->Update(docs); });
+}
+
+// --- Delete ---
+
+PHP_METHOD(ZVec, delete) {
+    zval *args; uint32_t argc;
+    ZEND_PARSE_PARAMETERS_START(1, -1)
+        Z_PARAM_VARIADIC('+', args, argc)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_COLLECTION_P(ZEND_THIS);
+    check_closed(intern);
+    if (EG(exception)) RETURN_THROWS();
+    std::vector<std::string> pks;
+    pks.reserve(argc);
+    for (uint32_t i = 0; i < argc; i++) {
+        if (Z_TYPE(args[i]) != IS_STRING) {
+            zvec_throw_exception(0, "Argument %d must be a string", i + 1);
+            RETURN_THROWS();
+        }
+        pks.emplace_back(Z_STRVAL(args[i]), Z_STRLEN(args[i]));
+    }
+    auto res = intern->collection->Delete(pks);
+    if (!res.has_value()) { check_status(res.error()); RETURN_THROWS(); }
+}
+
+PHP_METHOD(ZVec, deleteByFilter) {
+    char *filter; size_t filter_len;
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_STRING(filter, filter_len)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_COLLECTION_P(ZEND_THIS);
+    check_closed(intern);
+    if (EG(exception)) RETURN_THROWS();
+    check_status(intern->collection->DeleteByFilter(std::string(filter, filter_len)));
+}
+
+// --- Fetch ---
+
+PHP_METHOD(ZVec, fetch) {
+    zval *args; uint32_t argc;
+    ZEND_PARSE_PARAMETERS_START(1, -1)
+        Z_PARAM_VARIADIC('+', args, argc)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_COLLECTION_P(ZEND_THIS);
+    check_closed(intern);
+    if (EG(exception)) RETURN_THROWS();
+    std::vector<std::string> pks;
+    pks.reserve(argc);
+    for (uint32_t i = 0; i < argc; i++) {
+        if (Z_TYPE(args[i]) != IS_STRING) {
+            zvec_throw_exception(0, "Argument %d must be a string", i + 1);
+            RETURN_THROWS();
+        }
+        pks.emplace_back(Z_STRVAL(args[i]), Z_STRLEN(args[i]));
+    }
+    auto res = intern->collection->Fetch(pks);
+    if (!res.has_value()) { check_status(res.error()); RETURN_THROWS(); }
+
+    array_init(return_value);
+    for (auto &[k, v] : res.value()) {
+        if (v) {
+            auto *doc = new Doc(*v);
+            zend_object *obj = zvec_doc_create_from_native(doc, true);
+            zval zv;
+            ZVAL_OBJ(&zv, obj);
+            add_next_index_zval(return_value, &zv);
+        }
+    }
+}
+
+// --- Query helpers ---
+
+static void apply_output_fields(VectorQuery &query, zval *output_fields) {
+    if (!output_fields || Z_TYPE_P(output_fields) != IS_ARRAY) return;
+    HashTable *ht = Z_ARRVAL_P(output_fields);
+    std::vector<std::string> fields;
+    zval *val;
+    ZEND_HASH_FOREACH_VAL(ht, val) {
+        fields.emplace_back(Z_STRVAL_P(val), Z_STRLEN_P(val));
+    } ZEND_HASH_FOREACH_END();
+    query.output_fields_ = std::move(fields);
+}
+
+static void apply_query_params(VectorQuery &query, int type, int hnsw_ef, int ivf_nprobe,
+                               float radius, bool is_linear, bool is_using_refiner) {
+    if (type == 1) {
+        query.query_params_ = std::make_shared<HnswQueryParams>(hnsw_ef, radius, is_linear, is_using_refiner);
+    } else if (type == 2) {
+        auto params = std::make_shared<IVFQueryParams>(ivf_nprobe, is_using_refiner);
+        params->set_radius(radius);
+        params->set_is_linear(is_linear);
+        query.query_params_ = params;
+    } else if (type == 3) {
+        auto params = std::make_shared<FlatQueryParams>(is_using_refiner);
+        params->set_radius(radius);
+        params->set_is_linear(is_linear);
+        query.query_params_ = params;
+    }
+}
+
+static void fill_results(zval *return_value, const DocPtrList &doc_list) {
+    array_init_size(return_value, doc_list.size());
+    for (size_t i = 0; i < doc_list.size(); i++) {
+        auto *doc = new Doc(*doc_list[i]);
+        zend_object *obj = zvec_doc_create_from_native(doc, true);
+        zval zv;
+        ZVAL_OBJ(&zv, obj);
+        add_next_index_zval(return_value, &zv);
+    }
+}
+
+static bool validate_query_param_type(Collection *c, const std::string &field_name, int query_param_type) {
+    if (query_param_type == 0) return true;
+    auto schema_res = c->Schema();
+    if (!schema_res.has_value()) { check_status(schema_res.error()); return false; }
+    const auto &schema = schema_res.value();
+    const FieldSchema *field = schema.get_field(field_name);
+    if (!field) {
+        zvec_throw_exception(static_cast<int>(StatusCode::INVALID_ARGUMENT), "Field not found: %s", field_name.c_str());
+        return false;
+    }
+    IndexType actual = field->index_type();
+    IndexType expected = IndexType::UNDEFINED;
+    switch (query_param_type) {
+        case 1: expected = IndexType::HNSW; break;
+        case 2: expected = IndexType::IVF; break;
+        case 3: expected = IndexType::FLAT; break;
+    }
+    if (expected != IndexType::UNDEFINED && actual != IndexType::UNDEFINED && actual != expected) {
+        zvec_throw_exception(static_cast<int>(StatusCode::INVALID_ARGUMENT),
+            "Query parameter type mismatch for field '%s': index type does not match query_param_type",
+            field_name.c_str());
+        return false;
+    }
+    return true;
+}
+
+// --- Query ---
+
+PHP_METHOD(ZVec, query) {
+    zval *field_name_zv;
+    zval *query_vector_zv = nullptr;
+    zend_long topk = 10;
+    zend_bool include_vector = 0;
+    char *filter = nullptr; size_t filter_len = 0;
+    zval *output_fields = nullptr;
+    zend_long query_param_type = 0, hnsw_ef = 200, ivf_nprobe = 10;
+    double radius = 0.0;
+    zend_bool is_linear = 0, is_using_refiner = 0;
+    zval *reranker_zv = nullptr;
+
+    ZEND_PARSE_PARAMETERS_START(1, 13)
+        Z_PARAM_ZVAL(field_name_zv)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_ARRAY(query_vector_zv)
+        Z_PARAM_LONG(topk)
+        Z_PARAM_BOOL(include_vector)
+        Z_PARAM_STRING_OR_NULL(filter, filter_len)
+        Z_PARAM_ARRAY_OR_NULL(output_fields)
+        Z_PARAM_LONG(query_param_type)
+        Z_PARAM_LONG(hnsw_ef)
+        Z_PARAM_LONG(ivf_nprobe)
+        Z_PARAM_DOUBLE(radius)
+        Z_PARAM_BOOL(is_linear)
+        Z_PARAM_BOOL(is_using_refiner)
+        Z_PARAM_ZVAL_OR_NULL(reranker_zv)
+    ZEND_PARSE_PARAMETERS_END();
+
+    if (reranker_zv && Z_TYPE_P(reranker_zv) != IS_NULL &&
+        (Z_TYPE_P(reranker_zv) != IS_OBJECT || !instanceof_function(Z_OBJCE_P(reranker_zv), zvec_reranker_ce))) {
+        zend_type_error("ZVec::query(): Argument #14 ($reranker) must be of type ?ZVecReRanker, %s given",
+            zend_zval_value_name(reranker_zv));
+        RETURN_THROWS();
+    }
+    if (reranker_zv && Z_TYPE_P(reranker_zv) == IS_NULL) {
+        reranker_zv = nullptr;
+    }
+
+    auto *intern = Z_ZVEC_COLLECTION_P(ZEND_THIS);
+    check_closed(intern);
+    if (EG(exception)) RETURN_THROWS();
+
+    std::string field_name_str;
+    std::vector<float> vec_data;
+
+    if (Z_TYPE_P(field_name_zv) == IS_OBJECT && instanceof_function(Z_OBJCE_P(field_name_zv), zvec_vector_query_ce)) {
+        zval *fn = zend_read_property(zvec_vector_query_ce, Z_OBJ_P(field_name_zv), "fieldName", sizeof("fieldName") - 1, 1, nullptr);
+        field_name_str = std::string(Z_STRVAL_P(fn), Z_STRLEN_P(fn));
+        zval *vec = zend_read_property(zvec_vector_query_ce, Z_OBJ_P(field_name_zv), "vector", sizeof("vector") - 1, 1, nullptr);
+        if (Z_TYPE_P(vec) == IS_ARRAY) {
+            zval *v;
+            ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(vec), v) {
+                vec_data.push_back(static_cast<float>(zval_get_double(v)));
+            } ZEND_HASH_FOREACH_END();
+        }
+        zval *qpt = zend_read_property(zvec_vector_query_ce, Z_OBJ_P(field_name_zv), "queryParamType", sizeof("queryParamType") - 1, 1, nullptr);
+        query_param_type = Z_LVAL_P(qpt);
+        zval *ef = zend_read_property(zvec_vector_query_ce, Z_OBJ_P(field_name_zv), "hnswEf", sizeof("hnswEf") - 1, 1, nullptr);
+        hnsw_ef = Z_LVAL_P(ef);
+        zval *np = zend_read_property(zvec_vector_query_ce, Z_OBJ_P(field_name_zv), "ivfNprobe", sizeof("ivfNprobe") - 1, 1, nullptr);
+        ivf_nprobe = Z_LVAL_P(np);
+        zval *rad = zend_read_property(zvec_vector_query_ce, Z_OBJ_P(field_name_zv), "radius", sizeof("radius") - 1, 1, nullptr);
+        radius = Z_DVAL_P(rad);
+        zval *lin = zend_read_property(zvec_vector_query_ce, Z_OBJ_P(field_name_zv), "isLinear", sizeof("isLinear") - 1, 1, nullptr);
+        is_linear = zend_is_true(lin);
+        zval *ref = zend_read_property(zvec_vector_query_ce, Z_OBJ_P(field_name_zv), "isUsingRefiner", sizeof("isUsingRefiner") - 1, 1, nullptr);
+        is_using_refiner = zend_is_true(ref);
+
+        zval *did = zend_read_property(zvec_vector_query_ce, Z_OBJ_P(field_name_zv), "docId", sizeof("docId") - 1, 1, nullptr);
+        if (Z_TYPE_P(did) == IS_STRING) {
+            zvec_throw_exception(0, "query() with docId not yet implemented. Use queryById() or fetch the vector first.");
+            RETURN_THROWS();
+        }
+    } else if (Z_TYPE_P(field_name_zv) == IS_STRING) {
+        field_name_str = std::string(Z_STRVAL_P(field_name_zv), Z_STRLEN_P(field_name_zv));
+        if (query_vector_zv && Z_TYPE_P(query_vector_zv) == IS_ARRAY) {
+            zval *v;
+            ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(query_vector_zv), v) {
+                vec_data.push_back(static_cast<float>(zval_get_double(v)));
+            } ZEND_HASH_FOREACH_END();
+        }
+    } else {
+        zvec_throw_exception(0, "First argument must be a string or ZVecVectorQuery");
+        RETURN_THROWS();
+    }
+
+    zend_long fetch_topk = (reranker_zv != nullptr) ? std::max(topk * 2, (zend_long)100) : topk;
+
+    if (!validate_query_param_type(intern->collection.get(), field_name_str, static_cast<int>(query_param_type))) {
+        RETURN_THROWS();
+    }
+
+    VectorQuery query;
+    query.topk_ = static_cast<int>(fetch_topk);
+    query.field_name_ = field_name_str;
+    query.include_vector_ = (bool)include_vector;
+    query.query_vector_.assign(reinterpret_cast<const char *>(vec_data.data()), vec_data.size() * sizeof(float));
+    if (filter && filter[0] != '\0') {
+        query.filter_ = std::string(filter, filter_len);
+    }
+    if (output_fields) apply_output_fields(query, output_fields);
+    if (query_param_type != 0) {
+        apply_query_params(query, static_cast<int>(query_param_type),
+            static_cast<int>(hnsw_ef), static_cast<int>(ivf_nprobe),
+            static_cast<float>(radius), (bool)is_linear, (bool)is_using_refiner);
+    }
+
+    auto res = intern->collection->Query(query);
+    if (!res.has_value()) { check_status(res.error()); RETURN_THROWS(); }
+
+    if (reranker_zv != nullptr && Z_TYPE_P(reranker_zv) == IS_OBJECT) {
+        zval docs_arr;
+        fill_results(&docs_arr, res.value());
+
+        zval query_results;
+        array_init(&query_results);
+        Z_TRY_ADDREF(docs_arr);
+        add_assoc_zval(&query_results, field_name_str.c_str(), &docs_arr);
+
+        zval rerank_args[1];
+        ZVAL_COPY_VALUE(&rerank_args[0], &query_results);
+
+        zval rerank_result;
+        ZVAL_UNDEF(&rerank_result);
+        zval method_name;
+        ZVAL_STRING(&method_name, "rerank");
+        int ret = call_user_function(NULL, reranker_zv, &method_name, &rerank_result, 1, rerank_args);
+        zval_ptr_dtor(&method_name);
+        zval_ptr_dtor(&docs_arr);
+        zval_ptr_dtor(&query_results);
+
+        if (ret == FAILURE || EG(exception)) {
+            zval_ptr_dtor(&rerank_result);
+            if (!EG(exception)) {
+                zvec_throw_exception(0, "Failed to call reranker->rerank()");
+            }
+            RETURN_THROWS();
+        }
+
+        RETURN_COPY_VALUE(&rerank_result);
+    }
+
+    fill_results(return_value, res.value());
+}
+
+// --- queryFp16 ---
+
+PHP_METHOD(ZVec, queryFp16) {
+    char *field; size_t field_len;
+    zval *query_vector_zv;
+    zend_long topk = 10;
+    zend_bool include_vector = 0;
+    char *filter = nullptr; size_t filter_len = 0;
+
+    ZEND_PARSE_PARAMETERS_START(2, 5)
+        Z_PARAM_STRING(field, field_len)
+        Z_PARAM_ARRAY(query_vector_zv)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_LONG(topk)
+        Z_PARAM_BOOL(include_vector)
+        Z_PARAM_STRING_OR_NULL(filter, filter_len)
+    ZEND_PARSE_PARAMETERS_END();
+
+    auto *intern = Z_ZVEC_COLLECTION_P(ZEND_THIS);
+    check_closed(intern);
+    if (EG(exception)) RETURN_THROWS();
+
+    HashTable *ht = Z_ARRVAL_P(query_vector_zv);
+    uint32_t dim = zend_hash_num_elements(ht);
+    std::vector<ailego::Float16> fp16_vec;
+    fp16_vec.reserve(dim);
+    zval *v;
+    ZEND_HASH_FOREACH_VAL(ht, v) {
+        fp16_vec.push_back(ailego::FloatHelper::ToFP32(static_cast<uint16_t>(zval_get_long(v))));
+    } ZEND_HASH_FOREACH_END();
+
+    VectorQuery query;
+    query.topk_ = static_cast<int>(topk);
+    query.field_name_ = std::string(field, field_len);
+    query.include_vector_ = (bool)include_vector;
+    query.query_vector_.assign(reinterpret_cast<const char *>(fp16_vec.data()), dim * sizeof(ailego::Float16));
+    if (filter && filter[0] != '\0') query.filter_ = std::string(filter, filter_len);
+
+    auto res = intern->collection->Query(query);
+    if (!res.has_value()) { check_status(res.error()); RETURN_THROWS(); }
+    fill_results(return_value, res.value());
+}
+
+// --- queryMulti ---
+
+PHP_METHOD(ZVec, queryMulti) {
+    zval *queries_zv, *reranker_zv;
+    zend_long topk = 10;
+    char *filter = nullptr; size_t filter_len = 0;
+    zval *output_fields = nullptr;
+
+    ZEND_PARSE_PARAMETERS_START(2, 5)
+        Z_PARAM_ARRAY(queries_zv)
+        Z_PARAM_OBJECT(reranker_zv)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_LONG(topk)
+        Z_PARAM_STRING_OR_NULL(filter, filter_len)
+        Z_PARAM_ARRAY_OR_NULL(output_fields)
+    ZEND_PARSE_PARAMETERS_END();
+
+    auto *intern = Z_ZVEC_COLLECTION_P(ZEND_THIS);
+    check_closed(intern);
+    if (EG(exception)) RETURN_THROWS();
+
+    if (zend_hash_num_elements(Z_ARRVAL_P(queries_zv)) == 0) {
+        zvec_throw_exception(0, "At least one vector query is required");
+        RETURN_THROWS();
+    }
+
+    zval query_results;
+    array_init(&query_results);
+
+    zval *vq_zv;
+    ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(queries_zv), vq_zv) {
+        if (Z_TYPE_P(vq_zv) != IS_OBJECT || !instanceof_function(Z_OBJCE_P(vq_zv), zvec_vector_query_ce)) {
+            zvec_throw_exception(0, "All queries must be ZVecVectorQuery instances");
+            zval_ptr_dtor(&query_results);
+            RETURN_THROWS();
+        }
+
+        zval *fn = zend_read_property(zvec_vector_query_ce, Z_OBJ_P(vq_zv), "fieldName", sizeof("fieldName") - 1, 1, nullptr);
+        zval *vec = zend_read_property(zvec_vector_query_ce, Z_OBJ_P(vq_zv), "vector", sizeof("vector") - 1, 1, nullptr);
+        zval *qpt = zend_read_property(zvec_vector_query_ce, Z_OBJ_P(vq_zv), "queryParamType", sizeof("queryParamType") - 1, 1, nullptr);
+        zval *ef = zend_read_property(zvec_vector_query_ce, Z_OBJ_P(vq_zv), "hnswEf", sizeof("hnswEf") - 1, 1, nullptr);
+        zval *np = zend_read_property(zvec_vector_query_ce, Z_OBJ_P(vq_zv), "ivfNprobe", sizeof("ivfNprobe") - 1, 1, nullptr);
+        zval *rad = zend_read_property(zvec_vector_query_ce, Z_OBJ_P(vq_zv), "radius", sizeof("radius") - 1, 1, nullptr);
+        zval *lin = zend_read_property(zvec_vector_query_ce, Z_OBJ_P(vq_zv), "isLinear", sizeof("isLinear") - 1, 1, nullptr);
+        zval *ref = zend_read_property(zvec_vector_query_ce, Z_OBJ_P(vq_zv), "isUsingRefiner", sizeof("isUsingRefiner") - 1, 1, nullptr);
+
+        std::string field_name(Z_STRVAL_P(fn), Z_STRLEN_P(fn));
+        std::vector<float> vec_data;
+        if (Z_TYPE_P(vec) == IS_ARRAY) {
+            zval *v;
+            ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(vec), v) {
+                vec_data.push_back(static_cast<float>(zval_get_double(v)));
+            } ZEND_HASH_FOREACH_END();
+        }
+
+        zend_long fetch_topk = std::max(topk * 2, (zend_long)100);
+
+        VectorQuery query;
+        query.topk_ = static_cast<int>(fetch_topk);
+        query.field_name_ = field_name;
+        query.include_vector_ = false;
+        query.query_vector_.assign(reinterpret_cast<const char *>(vec_data.data()), vec_data.size() * sizeof(float));
+        if (filter && filter[0] != '\0') query.filter_ = std::string(filter, filter_len);
+        if (output_fields) apply_output_fields(query, output_fields);
+        int pt = static_cast<int>(Z_LVAL_P(qpt));
+        if (pt != 0) {
+            apply_query_params(query, pt, static_cast<int>(Z_LVAL_P(ef)),
+                static_cast<int>(Z_LVAL_P(np)), static_cast<float>(Z_DVAL_P(rad)),
+                zend_is_true(lin), zend_is_true(ref));
+        }
+
+        auto res = intern->collection->Query(query);
+        if (!res.has_value()) {
+            check_status(res.error());
+            zval_ptr_dtor(&query_results);
+            RETURN_THROWS();
+        }
+
+        zval docs_arr;
+        fill_results(&docs_arr, res.value());
+        add_assoc_zval(&query_results, field_name.c_str(), &docs_arr);
+    } ZEND_HASH_FOREACH_END();
+
+    zval func_name;
+    ZVAL_STRING(&func_name, "rerank");
+    zval retval;
+    zval params[1];
+    ZVAL_COPY_VALUE(&params[0], &query_results);
+    if (call_user_function(NULL, reranker_zv, &func_name, &retval, 1, params) == SUCCESS) {
+        ZVAL_COPY_VALUE(return_value, &retval);
+    }
+    zval_ptr_dtor(&func_name);
+    zval_ptr_dtor(&query_results);
+}
+
+// --- queryByFilter ---
+
+PHP_METHOD(ZVec, queryByFilter) {
+    char *filter; size_t filter_len;
+    zend_long topk = 100;
+    zval *output_fields = nullptr;
+
+    ZEND_PARSE_PARAMETERS_START(1, 3)
+        Z_PARAM_STRING(filter, filter_len)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_LONG(topk)
+        Z_PARAM_ARRAY_OR_NULL(output_fields)
+    ZEND_PARSE_PARAMETERS_END();
+
+    auto *intern = Z_ZVEC_COLLECTION_P(ZEND_THIS);
+    check_closed(intern);
+    if (EG(exception)) RETURN_THROWS();
+
+    VectorQuery query;
+    query.topk_ = static_cast<int>(topk);
+    query.filter_ = std::string(filter, filter_len);
+    if (output_fields) apply_output_fields(query, output_fields);
+
+    auto res = intern->collection->Query(query);
+    if (!res.has_value()) { check_status(res.error()); RETURN_THROWS(); }
+    fill_results(return_value, res.value());
+}
+
+// --- queryById ---
+
+PHP_METHOD(ZVec, queryById) {
+    char *field; size_t field_len;
+    char *doc_id; size_t doc_id_len;
+    zend_long topk = 10;
+    zend_bool include_vector = 0;
+    char *filter = nullptr; size_t filter_len = 0;
+    zval *output_fields = nullptr;
+    zend_long query_param_type = 0, hnsw_ef = 200, ivf_nprobe = 10;
+    double radius = 0.0;
+    zend_bool is_linear = 0, is_using_refiner = 0;
+
+    ZEND_PARSE_PARAMETERS_START(2, 12)
+        Z_PARAM_STRING(field, field_len)
+        Z_PARAM_STRING(doc_id, doc_id_len)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_LONG(topk)
+        Z_PARAM_BOOL(include_vector)
+        Z_PARAM_STRING_OR_NULL(filter, filter_len)
+        Z_PARAM_ARRAY_OR_NULL(output_fields)
+        Z_PARAM_LONG(query_param_type)
+        Z_PARAM_LONG(hnsw_ef)
+        Z_PARAM_LONG(ivf_nprobe)
+        Z_PARAM_DOUBLE(radius)
+        Z_PARAM_BOOL(is_linear)
+        Z_PARAM_BOOL(is_using_refiner)
+    ZEND_PARSE_PARAMETERS_END();
+
+    auto *intern = Z_ZVEC_COLLECTION_P(ZEND_THIS);
+    check_closed(intern);
+    if (EG(exception)) RETURN_THROWS();
+
+    std::vector<std::string> pks = {std::string(doc_id, doc_id_len)};
+    auto fetch_res = intern->collection->Fetch(pks);
+    if (!fetch_res.has_value()) { check_status(fetch_res.error()); RETURN_THROWS(); }
+
+    Doc *found_doc = nullptr;
+    for (auto &[k, v] : fetch_res.value()) {
+        if (v) { found_doc = v.get(); break; }
+    }
+    if (!found_doc) {
+        zvec_throw_exception(0, "Document not found: %s", doc_id);
+        RETURN_THROWS();
+    }
+
+    std::string fname(field, field_len);
+    auto vec_result = found_doc->get_field<std::vector<float>>(fname);
+    if (!vec_result.ok()) {
+        zvec_throw_exception(0, "Vector field '%s' not found in document: %s", field, doc_id);
+        RETURN_THROWS();
+    }
+    const auto &vec = vec_result.value();
+
+    if (!validate_query_param_type(intern->collection.get(), fname, static_cast<int>(query_param_type))) {
+        RETURN_THROWS();
+    }
+
+    VectorQuery query;
+    query.topk_ = static_cast<int>(topk);
+    query.field_name_ = fname;
+    query.include_vector_ = (bool)include_vector;
+    query.query_vector_.assign(reinterpret_cast<const char *>(vec.data()), vec.size() * sizeof(float));
+    if (filter && filter[0] != '\0') query.filter_ = std::string(filter, filter_len);
+    if (output_fields) apply_output_fields(query, output_fields);
+    if (query_param_type != 0) {
+        apply_query_params(query, static_cast<int>(query_param_type),
+            static_cast<int>(hnsw_ef), static_cast<int>(ivf_nprobe),
+            static_cast<float>(radius), (bool)is_linear, (bool)is_using_refiner);
+    }
+
+    auto res = intern->collection->Query(query);
+    if (!res.has_value()) { check_status(res.error()); RETURN_THROWS(); }
+    fill_results(return_value, res.value());
+}
+
+// --- groupByQuery ---
+
+PHP_METHOD(ZVec, groupByQuery) {
+    zval *field_name_zv;
+    zval *query_vector_zv;
+    char *group_by_field; size_t group_by_field_len;
+    zend_long group_count = 2, group_topk = 3;
+    zend_bool include_vector = 0;
+    char *filter = nullptr; size_t filter_len = 0;
+    zval *output_fields = nullptr;
+    zend_long query_param_type = 0, hnsw_ef = 200, ivf_nprobe = 10;
+    double radius = 0.0;
+    zend_bool is_linear = 0, is_using_refiner = 0;
+
+    ZEND_PARSE_PARAMETERS_START(3, 14)
+        Z_PARAM_ZVAL(field_name_zv)
+        Z_PARAM_ARRAY(query_vector_zv)
+        Z_PARAM_STRING(group_by_field, group_by_field_len)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_LONG(group_count)
+        Z_PARAM_LONG(group_topk)
+        Z_PARAM_BOOL(include_vector)
+        Z_PARAM_STRING_OR_NULL(filter, filter_len)
+        Z_PARAM_ARRAY_OR_NULL(output_fields)
+        Z_PARAM_LONG(query_param_type)
+        Z_PARAM_LONG(hnsw_ef)
+        Z_PARAM_LONG(ivf_nprobe)
+        Z_PARAM_DOUBLE(radius)
+        Z_PARAM_BOOL(is_linear)
+        Z_PARAM_BOOL(is_using_refiner)
+    ZEND_PARSE_PARAMETERS_END();
+
+    auto *intern = Z_ZVEC_COLLECTION_P(ZEND_THIS);
+    check_closed(intern);
+    if (EG(exception)) RETURN_THROWS();
+
+    std::string field_name_str;
+    std::vector<float> vec_data;
+    if (Z_TYPE_P(field_name_zv) == IS_OBJECT && instanceof_function(Z_OBJCE_P(field_name_zv), zvec_vector_query_ce)) {
+        zval *fn = zend_read_property(zvec_vector_query_ce, Z_OBJ_P(field_name_zv), "fieldName", sizeof("fieldName") - 1, 1, nullptr);
+        field_name_str = std::string(Z_STRVAL_P(fn), Z_STRLEN_P(fn));
+        zval *vec = zend_read_property(zvec_vector_query_ce, Z_OBJ_P(field_name_zv), "vector", sizeof("vector") - 1, 1, nullptr);
+        if (Z_TYPE_P(vec) == IS_ARRAY) {
+            zval *v;
+            ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(vec), v) {
+                vec_data.push_back(static_cast<float>(zval_get_double(v)));
+            } ZEND_HASH_FOREACH_END();
+        }
+        zval *qpt = zend_read_property(zvec_vector_query_ce, Z_OBJ_P(field_name_zv), "queryParamType", sizeof("queryParamType") - 1, 1, nullptr);
+        query_param_type = Z_LVAL_P(qpt);
+        zval *ef = zend_read_property(zvec_vector_query_ce, Z_OBJ_P(field_name_zv), "hnswEf", sizeof("hnswEf") - 1, 1, nullptr);
+        hnsw_ef = Z_LVAL_P(ef);
+        zval *np = zend_read_property(zvec_vector_query_ce, Z_OBJ_P(field_name_zv), "ivfNprobe", sizeof("ivfNprobe") - 1, 1, nullptr);
+        ivf_nprobe = Z_LVAL_P(np);
+        zval *rad = zend_read_property(zvec_vector_query_ce, Z_OBJ_P(field_name_zv), "radius", sizeof("radius") - 1, 1, nullptr);
+        radius = Z_DVAL_P(rad);
+        zval *lin = zend_read_property(zvec_vector_query_ce, Z_OBJ_P(field_name_zv), "isLinear", sizeof("isLinear") - 1, 1, nullptr);
+        is_linear = zend_is_true(lin);
+        zval *ref = zend_read_property(zvec_vector_query_ce, Z_OBJ_P(field_name_zv), "isUsingRefiner", sizeof("isUsingRefiner") - 1, 1, nullptr);
+        is_using_refiner = zend_is_true(ref);
+    } else {
+        field_name_str = std::string(Z_STRVAL_P(field_name_zv), Z_STRLEN_P(field_name_zv));
+        zval *v;
+        ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(query_vector_zv), v) {
+            vec_data.push_back(static_cast<float>(zval_get_double(v)));
+        } ZEND_HASH_FOREACH_END();
+    }
+
+    GroupByVectorQuery query;
+    query.field_name_ = field_name_str;
+    query.query_vector_.assign(reinterpret_cast<const char *>(vec_data.data()), vec_data.size() * sizeof(float));
+    query.group_by_field_name_ = std::string(group_by_field, group_by_field_len);
+    query.group_count_ = static_cast<uint32_t>(group_count);
+    query.group_topk_ = static_cast<uint32_t>(group_topk);
+    query.include_vector_ = (bool)include_vector;
+    if (filter && filter[0] != '\0') query.filter_ = std::string(filter, filter_len);
+    if (output_fields) {
+        HashTable *ht = Z_ARRVAL_P(output_fields);
+        std::vector<std::string> fields;
+        zval *val;
+        ZEND_HASH_FOREACH_VAL(ht, val) {
+            fields.emplace_back(Z_STRVAL_P(val), Z_STRLEN_P(val));
+        } ZEND_HASH_FOREACH_END();
+        query.output_fields_ = std::move(fields);
+    }
+    if (query_param_type != 0) {
+        if (!validate_query_param_type(intern->collection.get(), field_name_str, static_cast<int>(query_param_type))) {
+            RETURN_THROWS();
+        }
+    }
+
+    if (query_param_type == 1) {
+        query.query_params_ = std::make_shared<HnswQueryParams>(
+            static_cast<int>(hnsw_ef), static_cast<float>(radius), (bool)is_linear, (bool)is_using_refiner);
+    } else if (query_param_type == 2) {
+        auto params = std::make_shared<IVFQueryParams>(static_cast<int>(ivf_nprobe), (bool)is_using_refiner);
+        params->set_radius(static_cast<float>(radius));
+        params->set_is_linear((bool)is_linear);
+        query.query_params_ = params;
+    } else if (query_param_type == 3) {
+        auto params = std::make_shared<FlatQueryParams>((bool)is_using_refiner);
+        params->set_radius(static_cast<float>(radius));
+        params->set_is_linear((bool)is_linear);
+        query.query_params_ = params;
+    }
+
+    auto res = intern->collection->GroupByQuery(query);
+    if (!res.has_value()) { check_status(res.error()); RETURN_THROWS(); }
+
+    auto &groups = res.value();
+    array_init_size(return_value, groups.size());
+    for (size_t i = 0; i < groups.size(); i++) {
+        zval group_zv;
+        array_init(&group_zv);
+        add_assoc_string(&group_zv, "group_value", groups[i].group_by_value_.c_str());
+        zval docs_arr;
+        array_init_size(&docs_arr, groups[i].docs_.size());
+        for (size_t j = 0; j < groups[i].docs_.size(); j++) {
+            auto *doc = new Doc(groups[i].docs_[j]);
+            zend_object *obj = zvec_doc_create_from_native(doc, true);
+            zval dz;
+            ZVAL_OBJ(&dz, obj);
+            add_next_index_zval(&docs_arr, &dz);
+        }
+        add_assoc_zval(&group_zv, "docs", &docs_arr);
+        add_next_index_zval(return_value, &group_zv);
+    }
+}
+
+// --- Arginfo ---
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_zvec_init, 0, 0, 0)
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, logType, IS_LONG, 0, "0")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, logLevel, IS_LONG, 0, "2")
+    ZEND_ARG_TYPE_INFO(0, logDir, IS_STRING, 1)
+    ZEND_ARG_TYPE_INFO(0, logBasename, IS_STRING, 1)
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, logFileSize, IS_LONG, 0, "0")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, logOverdueDays, IS_LONG, 0, "0")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, queryThreads, IS_LONG, 0, "0")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, optimizeThreads, IS_LONG, 0, "0")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, invertToForwardScanRatio, IS_DOUBLE, 0, "0.0")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, bruteForceByKeysRatio, IS_DOUBLE, 0, "0.0")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, memoryLimitMb, IS_LONG, 0, "0")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_zvec_create, 0, 2, ZVec, 0)
+    ZEND_ARG_TYPE_INFO(0, path, IS_STRING, 0)
+    ZEND_ARG_OBJ_INFO(0, schema, ZVecSchema, 0)
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, readOnly, _IS_BOOL, 0, "false")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, enableMmap, _IS_BOOL, 0, "true")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, maxBufferSize, IS_LONG, 0, "67108864")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_zvec_open, 0, 1, ZVec, 0)
+    ZEND_ARG_TYPE_INFO(0, path, IS_STRING, 0)
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, readOnly, _IS_BOOL, 0, "false")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, enableMmap, _IS_BOOL, 0, "true")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, maxBufferSize, IS_LONG, 0, "67108864")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_zvec_void, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_zvec_optimize, 0, 0, 0)
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, concurrency, IS_LONG, 0, "0")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zvec_schema, 0, 0, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zvec_options, 0, 0, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_zvec_add_column, 0, 0, 1)
+    ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, nullable, _IS_BOOL, 0, "true")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, defaultExpr, IS_STRING, 0, "\"0\"")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, concurrency, IS_LONG, 0, "0")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_zvec_drop_column, 0, 0, 1)
+    ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_zvec_rename_column, 0, 0, 2)
+    ZEND_ARG_TYPE_INFO(0, oldName, IS_STRING, 0)
+    ZEND_ARG_TYPE_INFO(0, newName, IS_STRING, 0)
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, concurrency, IS_LONG, 0, "0")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_zvec_alter_column, 0, 0, 1)
+    ZEND_ARG_TYPE_INFO(0, columnName, IS_STRING, 0)
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, newName, IS_STRING, 1, "null")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, newDataType, IS_LONG, 1, "null")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, nullable, _IS_BOOL, 1, "null")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, concurrency, IS_LONG, 0, "0")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_zvec_create_invert_index, 0, 0, 1)
+    ZEND_ARG_TYPE_INFO(0, fieldName, IS_STRING, 0)
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, enableRange, _IS_BOOL, 0, "true")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, enableWildcard, _IS_BOOL, 0, "false")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_zvec_create_hnsw_index, 0, 0, 1)
+    ZEND_ARG_TYPE_INFO(0, fieldName, IS_STRING, 0)
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, metricType, IS_LONG, 0, "2")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, m, IS_LONG, 0, "50")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, efConstruction, IS_LONG, 0, "500")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, quantizeType, IS_LONG, 0, "0")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, concurrency, IS_LONG, 0, "0")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_zvec_create_flat_index, 0, 0, 1)
+    ZEND_ARG_TYPE_INFO(0, fieldName, IS_STRING, 0)
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, metricType, IS_LONG, 0, "2")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, quantizeType, IS_LONG, 0, "0")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, concurrency, IS_LONG, 0, "0")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_zvec_create_ivf_index, 0, 0, 1)
+    ZEND_ARG_TYPE_INFO(0, fieldName, IS_STRING, 0)
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, metricType, IS_LONG, 0, "2")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, nList, IS_LONG, 0, "1024")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, nIters, IS_LONG, 0, "10")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, useSoar, _IS_BOOL, 0, "false")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, quantizeType, IS_LONG, 0, "0")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, concurrency, IS_LONG, 0, "0")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_zvec_variadic_docs, 0, 0, 1)
+    ZEND_ARG_VARIADIC_OBJ_INFO(0, docs, ZVecDoc, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zvec_batch, 0, 1, IS_ARRAY, 0)
+    ZEND_ARG_VARIADIC_OBJ_INFO(0, docs, ZVecDoc, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_zvec_delete, 0, 0, 1)
+    ZEND_ARG_VARIADIC_TYPE_INFO(0, pks, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_zvec_delete_by_filter, 0, 0, 1)
+    ZEND_ARG_TYPE_INFO(0, filter, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zvec_fetch, 0, 1, IS_ARRAY, 0)
+    ZEND_ARG_VARIADIC_TYPE_INFO(0, pks, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zvec_query, 0, 1, IS_ARRAY, 0)
+    ZEND_ARG_INFO(0, fieldName)
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, queryVector, IS_ARRAY, 0, "[]")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, topk, IS_LONG, 0, "10")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, includeVector, _IS_BOOL, 0, "false")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, filter, IS_STRING, 1, "null")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, outputFields, IS_ARRAY, 1, "null")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, queryParamType, IS_LONG, 0, "0")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, hnswEf, IS_LONG, 0, "200")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, ivfNprobe, IS_LONG, 0, "10")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, radius, IS_DOUBLE, 0, "0.0")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, isLinear, _IS_BOOL, 0, "false")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, isUsingRefiner, _IS_BOOL, 0, "false")
+    ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, reranker, "null")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zvec_query_fp16, 0, 2, IS_ARRAY, 0)
+    ZEND_ARG_TYPE_INFO(0, fieldName, IS_STRING, 0)
+    ZEND_ARG_TYPE_INFO(0, queryVector, IS_ARRAY, 0)
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, topk, IS_LONG, 0, "10")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, includeVector, _IS_BOOL, 0, "false")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, filter, IS_STRING, 1, "null")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zvec_query_multi, 0, 2, IS_ARRAY, 0)
+    ZEND_ARG_TYPE_INFO(0, vectorQueries, IS_ARRAY, 0)
+    ZEND_ARG_OBJ_INFO(0, reranker, ZVecReRanker, 0)
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, topk, IS_LONG, 0, "10")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, filter, IS_STRING, 1, "null")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, outputFields, IS_ARRAY, 1, "null")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zvec_query_by_filter, 0, 1, IS_ARRAY, 0)
+    ZEND_ARG_TYPE_INFO(0, filter, IS_STRING, 0)
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, topk, IS_LONG, 0, "100")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, outputFields, IS_ARRAY, 1, "null")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zvec_query_by_id, 0, 2, IS_ARRAY, 0)
+    ZEND_ARG_TYPE_INFO(0, fieldName, IS_STRING, 0)
+    ZEND_ARG_TYPE_INFO(0, docId, IS_STRING, 0)
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, topk, IS_LONG, 0, "10")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, includeVector, _IS_BOOL, 0, "false")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, filter, IS_STRING, 1, "null")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, outputFields, IS_ARRAY, 1, "null")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, queryParamType, IS_LONG, 0, "0")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, hnswEf, IS_LONG, 0, "200")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, ivfNprobe, IS_LONG, 0, "10")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, radius, IS_DOUBLE, 0, "0.0")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, isLinear, _IS_BOOL, 0, "false")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, isUsingRefiner, _IS_BOOL, 0, "false")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zvec_group_by_query, 0, 3, IS_ARRAY, 0)
+    ZEND_ARG_INFO(0, fieldName)
+    ZEND_ARG_TYPE_INFO(0, queryVector, IS_ARRAY, 0)
+    ZEND_ARG_TYPE_INFO(0, groupByField, IS_STRING, 0)
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, groupCount, IS_LONG, 0, "10")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, groupTopk, IS_LONG, 0, "10")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, includeVector, _IS_BOOL, 0, "false")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, filter, IS_STRING, 1, "null")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, outputFields, IS_ARRAY, 1, "null")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, queryParamType, IS_LONG, 0, "0")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, hnswEf, IS_LONG, 0, "200")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, ivfNprobe, IS_LONG, 0, "10")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, radius, IS_DOUBLE, 0, "0.0")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, isLinear, _IS_BOOL, 0, "false")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, isUsingRefiner, _IS_BOOL, 0, "false")
+ZEND_END_ARG_INFO()
+
+static const zend_function_entry zvec_collection_methods[] = {
+    PHP_ME(ZVec, init, arginfo_zvec_init, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+    PHP_ME(ZVec, create, arginfo_zvec_create, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+    PHP_ME(ZVec, open, arginfo_zvec_open, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+    PHP_ME(ZVec, close, arginfo_zvec_void, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVec, __destruct, arginfo_zvec_void, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVec, flush, arginfo_zvec_void, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVec, optimize, arginfo_zvec_optimize, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVec, destroy, arginfo_zvec_void, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVec, schema, arginfo_zvec_schema, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVec, path, arginfo_zvec_schema, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVec, options, arginfo_zvec_options, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVec, stats, arginfo_zvec_schema, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVec, addColumnInt64, arginfo_zvec_add_column, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVec, addColumnFloat, arginfo_zvec_add_column, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVec, addColumnDouble, arginfo_zvec_add_column, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVec, addColumnString, arginfo_zvec_add_column, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVec, addColumnBool, arginfo_zvec_add_column, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVec, addColumnInt32, arginfo_zvec_add_column, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVec, addColumnUint32, arginfo_zvec_add_column, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVec, addColumnUint64, arginfo_zvec_add_column, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVec, dropColumn, arginfo_zvec_drop_column, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVec, renameColumn, arginfo_zvec_rename_column, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVec, alterColumn, arginfo_zvec_alter_column, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVec, createInvertIndex, arginfo_zvec_create_invert_index, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVec, createHnswIndex, arginfo_zvec_create_hnsw_index, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVec, createFlatIndex, arginfo_zvec_create_flat_index, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVec, createIvfIndex, arginfo_zvec_create_ivf_index, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVec, dropIndex, arginfo_zvec_drop_column, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVec, insert, arginfo_zvec_variadic_docs, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVec, upsert, arginfo_zvec_variadic_docs, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVec, update, arginfo_zvec_variadic_docs, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVec, insertBatch, arginfo_zvec_batch, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVec, upsertBatch, arginfo_zvec_batch, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVec, updateBatch, arginfo_zvec_batch, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVec, delete, arginfo_zvec_delete, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVec, deleteByFilter, arginfo_zvec_delete_by_filter, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVec, fetch, arginfo_zvec_fetch, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVec, query, arginfo_zvec_query, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVec, queryFp16, arginfo_zvec_query_fp16, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVec, queryMulti, arginfo_zvec_query_multi, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVec, queryByFilter, arginfo_zvec_query_by_filter, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVec, queryById, arginfo_zvec_query_by_id, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVec, groupByQuery, arginfo_zvec_group_by_query, ZEND_ACC_PUBLIC)
+    PHP_FE_END
+};
+
+void zvec_register_collection(INIT_FUNC_ARGS) {
+    zend_class_entry ce;
+    INIT_CLASS_ENTRY(ce, "ZVec", zvec_collection_methods);
+    zvec_collection_ce = zend_register_internal_class(&ce);
+    zvec_collection_ce->create_object = zvec_collection_create_object_handler;
+
+    memcpy(&zvec_collection_handlers, &std_object_handlers, sizeof(zend_object_handlers));
+    zvec_collection_handlers.offset = XtOffsetOf(zvec_collection_object, std);
+    zvec_collection_handlers.free_obj = zvec_collection_free_object;
+
+    zend_declare_class_constant_long(zvec_collection_ce, "QUERY_PARAM_NONE", sizeof("QUERY_PARAM_NONE") - 1, 0);
+    zend_declare_class_constant_long(zvec_collection_ce, "QUERY_PARAM_HNSW", sizeof("QUERY_PARAM_HNSW") - 1, 1);
+    zend_declare_class_constant_long(zvec_collection_ce, "QUERY_PARAM_IVF", sizeof("QUERY_PARAM_IVF") - 1, 2);
+    zend_declare_class_constant_long(zvec_collection_ce, "QUERY_PARAM_FLAT", sizeof("QUERY_PARAM_FLAT") - 1, 3);
+
+    zend_declare_class_constant_long(zvec_collection_ce, "LOG_CONSOLE", sizeof("LOG_CONSOLE") - 1, 0);
+    zend_declare_class_constant_long(zvec_collection_ce, "LOG_FILE", sizeof("LOG_FILE") - 1, 1);
+    zend_declare_class_constant_long(zvec_collection_ce, "LOG_DEBUG", sizeof("LOG_DEBUG") - 1, 0);
+    zend_declare_class_constant_long(zvec_collection_ce, "LOG_INFO", sizeof("LOG_INFO") - 1, 1);
+    zend_declare_class_constant_long(zvec_collection_ce, "LOG_WARN", sizeof("LOG_WARN") - 1, 2);
+    zend_declare_class_constant_long(zvec_collection_ce, "LOG_ERROR", sizeof("LOG_ERROR") - 1, 3);
+    zend_declare_class_constant_long(zvec_collection_ce, "LOG_FATAL", sizeof("LOG_FATAL") - 1, 4);
+
+    zend_declare_class_constant_long(zvec_collection_ce, "TYPE_BOOL", sizeof("TYPE_BOOL") - 1, 3);
+    zend_declare_class_constant_long(zvec_collection_ce, "TYPE_INT32", sizeof("TYPE_INT32") - 1, 4);
+    zend_declare_class_constant_long(zvec_collection_ce, "TYPE_INT64", sizeof("TYPE_INT64") - 1, 5);
+    zend_declare_class_constant_long(zvec_collection_ce, "TYPE_UINT32", sizeof("TYPE_UINT32") - 1, 6);
+    zend_declare_class_constant_long(zvec_collection_ce, "TYPE_UINT64", sizeof("TYPE_UINT64") - 1, 7);
+    zend_declare_class_constant_long(zvec_collection_ce, "TYPE_FLOAT", sizeof("TYPE_FLOAT") - 1, 8);
+    zend_declare_class_constant_long(zvec_collection_ce, "TYPE_DOUBLE", sizeof("TYPE_DOUBLE") - 1, 9);
+
+    zend_declare_class_constant_long(zvec_collection_ce, "QUANTIZE_UNDEFINED", sizeof("QUANTIZE_UNDEFINED") - 1, 0);
+    zend_declare_class_constant_long(zvec_collection_ce, "QUANTIZE_FP16", sizeof("QUANTIZE_FP16") - 1, 1);
+    zend_declare_class_constant_long(zvec_collection_ce, "QUANTIZE_INT8", sizeof("QUANTIZE_INT8") - 1, 2);
+    zend_declare_class_constant_long(zvec_collection_ce, "QUANTIZE_INT4", sizeof("QUANTIZE_INT4") - 1, 3);
+}

--- a/php-ext/zvec_collection.h
+++ b/php-ext/zvec_collection.h
@@ -1,0 +1,24 @@
+#ifndef ZVEC_COLLECTION_H
+#define ZVEC_COLLECTION_H
+
+#include "php_zvec.h"
+
+#pragma push_macro("IS_NULL")
+#undef IS_NULL
+#include <zvec/db/collection.h>
+#pragma pop_macro("IS_NULL")
+
+struct zvec_collection_object {
+    zvec::Collection::Ptr collection;
+    bool closed;
+    zend_object std;
+};
+
+static inline zvec_collection_object *zvec_collection_from_obj(zend_object *obj) {
+    return reinterpret_cast<zvec_collection_object *>(
+        reinterpret_cast<char *>(obj) - XtOffsetOf(zvec_collection_object, std));
+}
+
+#define Z_ZVEC_COLLECTION_P(zv) zvec_collection_from_obj(Z_OBJ_P(zv))
+
+#endif

--- a/php-ext/zvec_doc.cc
+++ b/php-ext/zvec_doc.cc
@@ -1,0 +1,584 @@
+#include "zvec_doc.h"
+#include "zvec_exception.h"
+#include <zvec/db/doc.h>
+#include <zvec/ailego/utility/float_helper.h>
+#include <vector>
+#include <string>
+#include <cstring>
+
+using namespace zvec;
+
+zend_class_entry *zvec_doc_ce = nullptr;
+static zend_object_handlers zvec_doc_handlers;
+
+static zend_object *zvec_doc_create_object_handler(zend_class_entry *ce) {
+    auto *intern = static_cast<zvec_doc_object *>(
+        ecalloc(1, sizeof(zvec_doc_object) + zend_object_properties_size(ce)));
+    intern->doc = nullptr;
+    intern->owns_handle = true;
+    zend_object_std_init(&intern->std, ce);
+    object_properties_init(&intern->std, ce);
+    intern->std.handlers = &zvec_doc_handlers;
+    return &intern->std;
+}
+
+static void zvec_doc_free_object(zend_object *obj) {
+    auto *intern = zvec_doc_from_obj(obj);
+    if (intern->doc && intern->owns_handle) {
+        delete intern->doc;
+    }
+    intern->doc = nullptr;
+    zend_object_std_dtor(obj);
+}
+
+zend_object *zvec_doc_create_from_native(Doc *doc, bool owns) {
+    zval zv;
+    object_init_ex(&zv, zvec_doc_ce);
+    auto *intern = Z_ZVEC_DOC_P(&zv);
+    intern->doc = doc;
+    intern->owns_handle = owns;
+    return Z_OBJ(zv);
+}
+
+PHP_METHOD(ZVecDoc, __construct) {
+    char *pk;
+    size_t pk_len;
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_STRING(pk, pk_len)
+    ZEND_PARSE_PARAMETERS_END();
+
+    auto *intern = Z_ZVEC_DOC_P(ZEND_THIS);
+    intern->doc = new Doc();
+    intern->doc->set_pk(std::string(pk, pk_len));
+    intern->owns_handle = true;
+}
+
+PHP_METHOD(ZVecDoc, setInt64) {
+    char *field; size_t field_len;
+    zend_long value;
+    ZEND_PARSE_PARAMETERS_START(2, 2)
+        Z_PARAM_STRING(field, field_len)
+        Z_PARAM_LONG(value)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_DOC_P(ZEND_THIS);
+    intern->doc->set<int64_t>(std::string(field, field_len), static_cast<int64_t>(value));
+    RETURN_ZVAL(ZEND_THIS, 1, 0);
+}
+
+PHP_METHOD(ZVecDoc, setString) {
+    char *field; size_t field_len;
+    char *value; size_t value_len;
+    ZEND_PARSE_PARAMETERS_START(2, 2)
+        Z_PARAM_STRING(field, field_len)
+        Z_PARAM_STRING(value, value_len)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_DOC_P(ZEND_THIS);
+    intern->doc->set<std::string>(std::string(field, field_len), std::string(value, value_len));
+    RETURN_ZVAL(ZEND_THIS, 1, 0);
+}
+
+PHP_METHOD(ZVecDoc, setFloat) {
+    char *field; size_t field_len;
+    double value;
+    ZEND_PARSE_PARAMETERS_START(2, 2)
+        Z_PARAM_STRING(field, field_len)
+        Z_PARAM_DOUBLE(value)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_DOC_P(ZEND_THIS);
+    intern->doc->set<float>(std::string(field, field_len), static_cast<float>(value));
+    RETURN_ZVAL(ZEND_THIS, 1, 0);
+}
+
+PHP_METHOD(ZVecDoc, setDouble) {
+    char *field; size_t field_len;
+    double value;
+    ZEND_PARSE_PARAMETERS_START(2, 2)
+        Z_PARAM_STRING(field, field_len)
+        Z_PARAM_DOUBLE(value)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_DOC_P(ZEND_THIS);
+    intern->doc->set<double>(std::string(field, field_len), value);
+    RETURN_ZVAL(ZEND_THIS, 1, 0);
+}
+
+PHP_METHOD(ZVecDoc, setBool) {
+    char *field; size_t field_len;
+    zend_bool value;
+    ZEND_PARSE_PARAMETERS_START(2, 2)
+        Z_PARAM_STRING(field, field_len)
+        Z_PARAM_BOOL(value)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_DOC_P(ZEND_THIS);
+    intern->doc->set<bool>(std::string(field, field_len), static_cast<bool>(value));
+    RETURN_ZVAL(ZEND_THIS, 1, 0);
+}
+
+PHP_METHOD(ZVecDoc, setInt32) {
+    char *field; size_t field_len;
+    zend_long value;
+    ZEND_PARSE_PARAMETERS_START(2, 2)
+        Z_PARAM_STRING(field, field_len)
+        Z_PARAM_LONG(value)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_DOC_P(ZEND_THIS);
+    intern->doc->set<int32_t>(std::string(field, field_len), static_cast<int32_t>(value));
+    RETURN_ZVAL(ZEND_THIS, 1, 0);
+}
+
+PHP_METHOD(ZVecDoc, setUint32) {
+    char *field; size_t field_len;
+    zend_long value;
+    ZEND_PARSE_PARAMETERS_START(2, 2)
+        Z_PARAM_STRING(field, field_len)
+        Z_PARAM_LONG(value)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_DOC_P(ZEND_THIS);
+    intern->doc->set<uint32_t>(std::string(field, field_len), static_cast<uint32_t>(value));
+    RETURN_ZVAL(ZEND_THIS, 1, 0);
+}
+
+PHP_METHOD(ZVecDoc, setUint64) {
+    char *field; size_t field_len;
+    zend_long value;
+    ZEND_PARSE_PARAMETERS_START(2, 2)
+        Z_PARAM_STRING(field, field_len)
+        Z_PARAM_LONG(value)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_DOC_P(ZEND_THIS);
+    intern->doc->set<uint64_t>(std::string(field, field_len), static_cast<uint64_t>(value));
+    RETURN_ZVAL(ZEND_THIS, 1, 0);
+}
+
+PHP_METHOD(ZVecDoc, setVectorFp32) {
+    char *field; size_t field_len;
+    zval *arr;
+    ZEND_PARSE_PARAMETERS_START(2, 2)
+        Z_PARAM_STRING(field, field_len)
+        Z_PARAM_ARRAY(arr)
+    ZEND_PARSE_PARAMETERS_END();
+
+    HashTable *ht = Z_ARRVAL_P(arr);
+    uint32_t dim = zend_hash_num_elements(ht);
+    std::vector<float> vec;
+    vec.reserve(dim);
+    zval *val;
+    ZEND_HASH_FOREACH_VAL(ht, val) {
+        vec.push_back(static_cast<float>(zval_get_double(val)));
+    } ZEND_HASH_FOREACH_END();
+
+    auto *intern = Z_ZVEC_DOC_P(ZEND_THIS);
+    intern->doc->set<std::vector<float>>(std::string(field, field_len), std::move(vec));
+    RETURN_ZVAL(ZEND_THIS, 1, 0);
+}
+
+PHP_METHOD(ZVecDoc, setVectorInt8) {
+    char *field; size_t field_len;
+    zval *arr;
+    ZEND_PARSE_PARAMETERS_START(2, 2)
+        Z_PARAM_STRING(field, field_len)
+        Z_PARAM_ARRAY(arr)
+    ZEND_PARSE_PARAMETERS_END();
+
+    HashTable *ht = Z_ARRVAL_P(arr);
+    uint32_t dim = zend_hash_num_elements(ht);
+    std::vector<int8_t> vec;
+    vec.reserve(dim);
+    zval *val;
+    ZEND_HASH_FOREACH_VAL(ht, val) {
+        vec.push_back(static_cast<int8_t>(zval_get_long(val)));
+    } ZEND_HASH_FOREACH_END();
+
+    auto *intern = Z_ZVEC_DOC_P(ZEND_THIS);
+    intern->doc->set<std::vector<int8_t>>(std::string(field, field_len), std::move(vec));
+    RETURN_ZVAL(ZEND_THIS, 1, 0);
+}
+
+PHP_METHOD(ZVecDoc, setVectorFp16) {
+    char *field; size_t field_len;
+    zval *arr;
+    ZEND_PARSE_PARAMETERS_START(2, 2)
+        Z_PARAM_STRING(field, field_len)
+        Z_PARAM_ARRAY(arr)
+    ZEND_PARSE_PARAMETERS_END();
+
+    HashTable *ht = Z_ARRVAL_P(arr);
+    uint32_t dim = zend_hash_num_elements(ht);
+    std::vector<ailego::Float16> vec;
+    vec.reserve(dim);
+    zval *val;
+    ZEND_HASH_FOREACH_VAL(ht, val) {
+        vec.push_back(ailego::FloatHelper::ToFP32(static_cast<uint16_t>(zval_get_long(val))));
+    } ZEND_HASH_FOREACH_END();
+
+    auto *intern = Z_ZVEC_DOC_P(ZEND_THIS);
+    intern->doc->set<std::vector<ailego::Float16>>(std::string(field, field_len), std::move(vec));
+    RETURN_ZVAL(ZEND_THIS, 1, 0);
+}
+
+PHP_METHOD(ZVecDoc, setSparseVectorFp32) {
+    char *field; size_t field_len;
+    zval *indices_arr, *values_arr;
+    ZEND_PARSE_PARAMETERS_START(3, 3)
+        Z_PARAM_STRING(field, field_len)
+        Z_PARAM_ARRAY(indices_arr)
+        Z_PARAM_ARRAY(values_arr)
+    ZEND_PARSE_PARAMETERS_END();
+
+    HashTable *idx_ht = Z_ARRVAL_P(indices_arr);
+    HashTable *val_ht = Z_ARRVAL_P(values_arr);
+    uint32_t idx_count = zend_hash_num_elements(idx_ht);
+    uint32_t val_count = zend_hash_num_elements(val_ht);
+
+    if (idx_count != val_count) {
+        zvec_throw_exception(0, "Indices and values arrays must have the same length");
+        RETURN_THROWS();
+    }
+
+    std::vector<uint32_t> indices;
+    std::vector<float> values;
+    indices.reserve(idx_count);
+    values.reserve(val_count);
+
+    zval *v;
+    ZEND_HASH_FOREACH_VAL(idx_ht, v) {
+        indices.push_back(static_cast<uint32_t>(zval_get_long(v)));
+    } ZEND_HASH_FOREACH_END();
+    ZEND_HASH_FOREACH_VAL(val_ht, v) {
+        values.push_back(static_cast<float>(zval_get_double(v)));
+    } ZEND_HASH_FOREACH_END();
+
+    auto *intern = Z_ZVEC_DOC_P(ZEND_THIS);
+    auto sparse_pair = std::make_pair(std::move(indices), std::move(values));
+    intern->doc->set<std::pair<std::vector<uint32_t>, std::vector<float>>>(
+        std::string(field, field_len), std::move(sparse_pair));
+    RETURN_ZVAL(ZEND_THIS, 1, 0);
+}
+
+PHP_METHOD(ZVecDoc, getPk) {
+    ZEND_PARSE_PARAMETERS_NONE();
+    auto *intern = Z_ZVEC_DOC_P(ZEND_THIS);
+    std::string pk = intern->doc->pk();
+    RETURN_STRINGL(pk.c_str(), pk.length());
+}
+
+PHP_METHOD(ZVecDoc, getScore) {
+    ZEND_PARSE_PARAMETERS_NONE();
+    auto *intern = Z_ZVEC_DOC_P(ZEND_THIS);
+    RETURN_DOUBLE(static_cast<double>(intern->doc->score()));
+}
+
+PHP_METHOD(ZVecDoc, getInt64) {
+    char *field; size_t field_len;
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_STRING(field, field_len)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_DOC_P(ZEND_THIS);
+    auto val = intern->doc->get<int64_t>(std::string(field, field_len));
+    if (val.has_value()) {
+        RETURN_LONG(static_cast<zend_long>(val.value()));
+    }
+    RETURN_NULL();
+}
+
+PHP_METHOD(ZVecDoc, getString) {
+    char *field; size_t field_len;
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_STRING(field, field_len)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_DOC_P(ZEND_THIS);
+    auto result = intern->doc->get_field<std::string>(std::string(field, field_len));
+    if (result.ok()) {
+        const auto &s = result.value();
+        RETURN_STRINGL(s.c_str(), s.length());
+    }
+    RETURN_NULL();
+}
+
+PHP_METHOD(ZVecDoc, getFloat) {
+    char *field; size_t field_len;
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_STRING(field, field_len)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_DOC_P(ZEND_THIS);
+    auto val = intern->doc->get<float>(std::string(field, field_len));
+    if (val.has_value()) {
+        RETURN_DOUBLE(static_cast<double>(val.value()));
+    }
+    RETURN_NULL();
+}
+
+PHP_METHOD(ZVecDoc, getDouble) {
+    char *field; size_t field_len;
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_STRING(field, field_len)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_DOC_P(ZEND_THIS);
+    auto val = intern->doc->get<double>(std::string(field, field_len));
+    if (val.has_value()) {
+        RETURN_DOUBLE(val.value());
+    }
+    RETURN_NULL();
+}
+
+PHP_METHOD(ZVecDoc, getBool) {
+    char *field; size_t field_len;
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_STRING(field, field_len)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_DOC_P(ZEND_THIS);
+    auto val = intern->doc->get<bool>(std::string(field, field_len));
+    if (val.has_value()) {
+        RETURN_BOOL(val.value());
+    }
+    RETURN_NULL();
+}
+
+PHP_METHOD(ZVecDoc, getInt32) {
+    char *field; size_t field_len;
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_STRING(field, field_len)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_DOC_P(ZEND_THIS);
+    auto val = intern->doc->get<int32_t>(std::string(field, field_len));
+    if (val.has_value()) {
+        RETURN_LONG(static_cast<zend_long>(val.value()));
+    }
+    RETURN_NULL();
+}
+
+PHP_METHOD(ZVecDoc, getUint32) {
+    char *field; size_t field_len;
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_STRING(field, field_len)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_DOC_P(ZEND_THIS);
+    auto val = intern->doc->get<uint32_t>(std::string(field, field_len));
+    if (val.has_value()) {
+        RETURN_LONG(static_cast<zend_long>(val.value()));
+    }
+    RETURN_NULL();
+}
+
+PHP_METHOD(ZVecDoc, getUint64) {
+    char *field; size_t field_len;
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_STRING(field, field_len)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_DOC_P(ZEND_THIS);
+    auto val = intern->doc->get<uint64_t>(std::string(field, field_len));
+    if (val.has_value()) {
+        RETURN_LONG(static_cast<zend_long>(val.value()));
+    }
+    RETURN_NULL();
+}
+
+PHP_METHOD(ZVecDoc, getVectorFp32) {
+    char *field; size_t field_len;
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_STRING(field, field_len)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_DOC_P(ZEND_THIS);
+    auto result = intern->doc->get_field<std::vector<float>>(std::string(field, field_len));
+    if (result.ok()) {
+        const auto &vec = result.value();
+        array_init_size(return_value, vec.size());
+        for (size_t i = 0; i < vec.size(); i++) {
+            add_next_index_double(return_value, static_cast<double>(vec[i]));
+        }
+        return;
+    }
+    RETURN_NULL();
+}
+
+PHP_METHOD(ZVecDoc, getVectorInt8) {
+    char *field; size_t field_len;
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_STRING(field, field_len)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_DOC_P(ZEND_THIS);
+    auto result = intern->doc->get_field<std::vector<int8_t>>(std::string(field, field_len));
+    if (result.ok()) {
+        const auto &vec = result.value();
+        array_init_size(return_value, vec.size());
+        for (size_t i = 0; i < vec.size(); i++) {
+            add_next_index_long(return_value, static_cast<zend_long>(vec[i]));
+        }
+        return;
+    }
+    RETURN_NULL();
+}
+
+PHP_METHOD(ZVecDoc, getVectorFp16) {
+    char *field; size_t field_len;
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_STRING(field, field_len)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_DOC_P(ZEND_THIS);
+    auto result = intern->doc->get_field<std::vector<ailego::Float16>>(std::string(field, field_len));
+    if (result.ok()) {
+        const auto &vec = result.value();
+        array_init_size(return_value, vec.size());
+        for (size_t i = 0; i < vec.size(); i++) {
+            add_next_index_long(return_value,
+                static_cast<zend_long>(ailego::FloatHelper::ToFP16(static_cast<float>(vec[i]))));
+        }
+        return;
+    }
+    RETURN_NULL();
+}
+
+PHP_METHOD(ZVecDoc, getSparseVectorFp32) {
+    char *field; size_t field_len;
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_STRING(field, field_len)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_DOC_P(ZEND_THIS);
+    auto result = intern->doc->get_field<std::pair<std::vector<uint32_t>, std::vector<float>>>(
+        std::string(field, field_len));
+    if (result.ok()) {
+        const auto &pair = result.value();
+        array_init(return_value);
+
+        zval indices_arr, values_arr;
+        array_init_size(&indices_arr, pair.first.size());
+        array_init_size(&values_arr, pair.second.size());
+        for (size_t i = 0; i < pair.first.size(); i++) {
+            add_next_index_long(&indices_arr, static_cast<zend_long>(pair.first[i]));
+        }
+        for (size_t i = 0; i < pair.second.size(); i++) {
+            add_next_index_double(&values_arr, static_cast<double>(pair.second[i]));
+        }
+        add_assoc_zval(return_value, "indices", &indices_arr);
+        add_assoc_zval(return_value, "values", &values_arr);
+        return;
+    }
+    RETURN_NULL();
+}
+
+PHP_METHOD(ZVecDoc, hasField) {
+    char *field; size_t field_len;
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_STRING(field, field_len)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_DOC_P(ZEND_THIS);
+    RETURN_BOOL(intern->doc->has(std::string(field, field_len)));
+}
+
+PHP_METHOD(ZVecDoc, hasVector) {
+    char *field; size_t field_len;
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_STRING(field, field_len)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_DOC_P(ZEND_THIS);
+    std::string fname(field, field_len);
+    if (!intern->doc->has(fname)) {
+        RETURN_FALSE;
+    }
+    auto result = intern->doc->get_field<std::vector<float>>(fname);
+    RETURN_BOOL(result.ok());
+}
+
+PHP_METHOD(ZVecDoc, fieldNames) {
+    ZEND_PARSE_PARAMETERS_NONE();
+    auto *intern = Z_ZVEC_DOC_P(ZEND_THIS);
+    auto names = intern->doc->field_names();
+    array_init(return_value);
+    for (const auto &name : names) {
+        if (intern->doc->get_field<std::vector<float>>(name).ok()) continue;
+        add_next_index_stringl(return_value, name.c_str(), name.length());
+    }
+}
+
+PHP_METHOD(ZVecDoc, vectorNames) {
+    ZEND_PARSE_PARAMETERS_NONE();
+    auto *intern = Z_ZVEC_DOC_P(ZEND_THIS);
+    auto names = intern->doc->field_names();
+    array_init(return_value);
+    for (const auto &name : names) {
+        if (!intern->doc->get_field<std::vector<float>>(name).ok()) continue;
+        add_next_index_stringl(return_value, name.c_str(), name.length());
+    }
+}
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_zvec_doc___construct, 0, 0, 1)
+    ZEND_ARG_TYPE_INFO(0, pk, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_zvec_doc_set_scalar, 0, 2, ZVecDoc, 0)
+    ZEND_ARG_TYPE_INFO(0, field, IS_STRING, 0)
+    ZEND_ARG_INFO(0, value)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_zvec_doc_set_vector, 0, 2, ZVecDoc, 0)
+    ZEND_ARG_TYPE_INFO(0, field, IS_STRING, 0)
+    ZEND_ARG_TYPE_INFO(0, vector, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_zvec_doc_set_sparse, 0, 3, ZVecDoc, 0)
+    ZEND_ARG_TYPE_INFO(0, field, IS_STRING, 0)
+    ZEND_ARG_TYPE_INFO(0, indices, IS_ARRAY, 0)
+    ZEND_ARG_TYPE_INFO(0, values, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zvec_doc_get_pk, 0, 0, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zvec_doc_get_score, 0, 0, IS_DOUBLE, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_zvec_doc_get_field, 0, 0, 1)
+    ZEND_ARG_TYPE_INFO(0, field, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zvec_doc_has_field, 0, 1, _IS_BOOL, 0)
+    ZEND_ARG_TYPE_INFO(0, field, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zvec_doc_names, 0, 0, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+static const zend_function_entry zvec_doc_methods[] = {
+    PHP_ME(ZVecDoc, __construct, arginfo_zvec_doc___construct, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecDoc, setInt64, arginfo_zvec_doc_set_scalar, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecDoc, setString, arginfo_zvec_doc_set_scalar, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecDoc, setFloat, arginfo_zvec_doc_set_scalar, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecDoc, setDouble, arginfo_zvec_doc_set_scalar, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecDoc, setBool, arginfo_zvec_doc_set_scalar, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecDoc, setInt32, arginfo_zvec_doc_set_scalar, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecDoc, setUint32, arginfo_zvec_doc_set_scalar, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecDoc, setUint64, arginfo_zvec_doc_set_scalar, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecDoc, setVectorFp32, arginfo_zvec_doc_set_vector, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecDoc, setVectorInt8, arginfo_zvec_doc_set_vector, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecDoc, setVectorFp16, arginfo_zvec_doc_set_vector, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecDoc, setSparseVectorFp32, arginfo_zvec_doc_set_sparse, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecDoc, getPk, arginfo_zvec_doc_get_pk, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecDoc, getScore, arginfo_zvec_doc_get_score, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecDoc, getInt64, arginfo_zvec_doc_get_field, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecDoc, getString, arginfo_zvec_doc_get_field, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecDoc, getFloat, arginfo_zvec_doc_get_field, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecDoc, getDouble, arginfo_zvec_doc_get_field, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecDoc, getBool, arginfo_zvec_doc_get_field, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecDoc, getInt32, arginfo_zvec_doc_get_field, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecDoc, getUint32, arginfo_zvec_doc_get_field, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecDoc, getUint64, arginfo_zvec_doc_get_field, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecDoc, getVectorFp32, arginfo_zvec_doc_get_field, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecDoc, getVectorInt8, arginfo_zvec_doc_get_field, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecDoc, getVectorFp16, arginfo_zvec_doc_get_field, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecDoc, getSparseVectorFp32, arginfo_zvec_doc_get_field, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecDoc, hasField, arginfo_zvec_doc_has_field, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecDoc, hasVector, arginfo_zvec_doc_has_field, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecDoc, fieldNames, arginfo_zvec_doc_names, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecDoc, vectorNames, arginfo_zvec_doc_names, ZEND_ACC_PUBLIC)
+    PHP_FE_END
+};
+
+void zvec_register_doc(INIT_FUNC_ARGS) {
+    zend_class_entry ce;
+    INIT_CLASS_ENTRY(ce, "ZVecDoc", zvec_doc_methods);
+    zvec_doc_ce = zend_register_internal_class(&ce);
+    zvec_doc_ce->create_object = zvec_doc_create_object_handler;
+
+    memcpy(&zvec_doc_handlers, &std_object_handlers, sizeof(zend_object_handlers));
+    zvec_doc_handlers.offset = XtOffsetOf(zvec_doc_object, std);
+    zvec_doc_handlers.free_obj = zvec_doc_free_object;
+}

--- a/php-ext/zvec_doc.h
+++ b/php-ext/zvec_doc.h
@@ -1,0 +1,26 @@
+#ifndef ZVEC_DOC_H
+#define ZVEC_DOC_H
+
+#include "php_zvec.h"
+
+#pragma push_macro("IS_NULL")
+#undef IS_NULL
+#include <zvec/db/doc.h>
+#pragma pop_macro("IS_NULL")
+
+struct zvec_doc_object {
+    zvec::Doc *doc;
+    bool owns_handle;
+    zend_object std;
+};
+
+static inline zvec_doc_object *zvec_doc_from_obj(zend_object *obj) {
+    return reinterpret_cast<zvec_doc_object *>(
+        reinterpret_cast<char *>(obj) - XtOffsetOf(zvec_doc_object, std));
+}
+
+#define Z_ZVEC_DOC_P(zv) zvec_doc_from_obj(Z_OBJ_P(zv))
+
+zend_object *zvec_doc_create_from_native(zvec::Doc *doc, bool owns);
+
+#endif

--- a/php-ext/zvec_embedding_interfaces.cc
+++ b/php-ext/zvec_embedding_interfaces.cc
@@ -1,0 +1,292 @@
+#include "zvec_embedding_interfaces.h"
+#include "zvec_exception.h"
+
+extern "C" {
+#include "zend_smart_str.h"
+#include "ext/json/php_json.h"
+}
+
+zend_class_entry *zvec_dense_embedding_ce = nullptr;
+zend_class_entry *zvec_sparse_embedding_ce = nullptr;
+zend_class_entry *zvec_api_embedding_ce = nullptr;
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_dense_embed, 0, 1, IS_ARRAY, 0)
+    ZEND_ARG_TYPE_INFO(0, input, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_dense_embed_batch, 0, 1, IS_ARRAY, 0)
+    ZEND_ARG_TYPE_INFO(0, inputs, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_dense_get_dimension, 0, 0, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+static const zend_function_entry zvec_dense_embedding_methods[] = {
+    PHP_ABSTRACT_ME(DenseEmbeddingFunction, embed, arginfo_dense_embed)
+    PHP_ABSTRACT_ME(DenseEmbeddingFunction, embedBatch, arginfo_dense_embed_batch)
+    PHP_ABSTRACT_ME(DenseEmbeddingFunction, getDimension, arginfo_dense_get_dimension)
+    PHP_FE_END
+};
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sparse_embed, 0, 1, IS_ARRAY, 0)
+    ZEND_ARG_TYPE_INFO(0, input, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sparse_embed_batch, 0, 1, IS_ARRAY, 0)
+    ZEND_ARG_TYPE_INFO(0, inputs, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+static const zend_function_entry zvec_sparse_embedding_methods[] = {
+    PHP_ABSTRACT_ME(SparseEmbeddingFunction, embed, arginfo_sparse_embed)
+    PHP_ABSTRACT_ME(SparseEmbeddingFunction, embedBatch, arginfo_sparse_embed_batch)
+    PHP_FE_END
+};
+
+PHP_METHOD(ApiEmbeddingFunction, __construct) {
+    char *api_key; size_t api_key_len;
+    char *base_url = nullptr; size_t base_url_len = 0;
+    zend_long timeout = 30;
+    char *proxy = nullptr; size_t proxy_len = 0;
+    ZEND_PARSE_PARAMETERS_START(1, 4)
+        Z_PARAM_STRING(api_key, api_key_len)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_STRING_OR_NULL(base_url, base_url_len)
+        Z_PARAM_LONG(timeout)
+        Z_PARAM_STRING_OR_NULL(proxy, proxy_len)
+    ZEND_PARSE_PARAMETERS_END();
+
+    zend_update_property_stringl(zvec_api_embedding_ce, Z_OBJ_P(ZEND_THIS), "apiKey", sizeof("apiKey") - 1, api_key, api_key_len);
+
+    if (base_url) {
+        zend_update_property_stringl(zvec_api_embedding_ce, Z_OBJ_P(ZEND_THIS), "baseUrl", sizeof("baseUrl") - 1, base_url, base_url_len);
+    } else {
+        zval retval;
+        zend_call_method_with_0_params(Z_OBJ_P(ZEND_THIS), Z_OBJCE_P(ZEND_THIS), nullptr, "getdefaultbaseurl", &retval);
+        if (Z_TYPE(retval) == IS_STRING) {
+            zend_update_property(zvec_api_embedding_ce, Z_OBJ_P(ZEND_THIS), "baseUrl", sizeof("baseUrl") - 1, &retval);
+        }
+        zval_ptr_dtor(&retval);
+    }
+
+    zend_update_property_long(zvec_api_embedding_ce, Z_OBJ_P(ZEND_THIS), "timeout", sizeof("timeout") - 1, timeout);
+
+    if (proxy) {
+        zend_update_property_stringl(zvec_api_embedding_ce, Z_OBJ_P(ZEND_THIS), "proxy", sizeof("proxy") - 1, proxy, proxy_len);
+    } else {
+        zend_update_property_null(zvec_api_embedding_ce, Z_OBJ_P(ZEND_THIS), "proxy", sizeof("proxy") - 1);
+    }
+}
+
+PHP_METHOD(ApiEmbeddingFunction, post) {
+    char *endpoint; size_t endpoint_len;
+    zval *data;
+    ZEND_PARSE_PARAMETERS_START(2, 2)
+        Z_PARAM_STRING(endpoint, endpoint_len)
+        Z_PARAM_ARRAY(data)
+    ZEND_PARSE_PARAMETERS_END();
+
+    zval *base_url_zv = zend_read_property(zvec_api_embedding_ce, Z_OBJ_P(ZEND_THIS), "baseUrl", sizeof("baseUrl") - 1, 1, nullptr);
+    zval *timeout_zv = zend_read_property(zvec_api_embedding_ce, Z_OBJ_P(ZEND_THIS), "timeout", sizeof("timeout") - 1, 1, nullptr);
+    zval *proxy_zv = zend_read_property(zvec_api_embedding_ce, Z_OBJ_P(ZEND_THIS), "proxy", sizeof("proxy") - 1, 1, nullptr);
+
+    zend_string *base_url = Z_STR_P(base_url_zv);
+    size_t bu_len = ZSTR_LEN(base_url);
+    while (bu_len > 0 && ZSTR_VAL(base_url)[bu_len - 1] == '/') bu_len--;
+    size_t ep_start = 0;
+    while (ep_start < endpoint_len && endpoint[ep_start] == '/') ep_start++;
+
+    zend_string *url = zend_string_alloc(bu_len + 1 + (endpoint_len - ep_start), 0);
+    memcpy(ZSTR_VAL(url), ZSTR_VAL(base_url), bu_len);
+    ZSTR_VAL(url)[bu_len] = '/';
+    memcpy(ZSTR_VAL(url) + bu_len + 1, endpoint + ep_start, endpoint_len - ep_start);
+    ZSTR_VAL(url)[bu_len + 1 + endpoint_len - ep_start] = '\0';
+    ZSTR_LEN(url) = bu_len + 1 + (endpoint_len - ep_start);
+
+    smart_str json_buf = {0};
+    php_json_encode(&json_buf, data, PHP_JSON_UNESCAPED_UNICODE);
+    smart_str_0(&json_buf);
+
+    zval headers_retval;
+    zend_call_method_with_0_params(Z_OBJ_P(ZEND_THIS), Z_OBJCE_P(ZEND_THIS), nullptr, "getheaders", &headers_retval);
+
+    zval curl_fn;
+    ZVAL_STRING(&curl_fn, "curl_init");
+    zval curl_args[1];
+    ZVAL_STR(&curl_args[0], url);
+    zval ch;
+    call_user_function(nullptr, nullptr, &curl_fn, &ch, 1, curl_args);
+    zval_ptr_dtor(&curl_fn);
+
+    zval setopt_fn;
+    ZVAL_STRING(&setopt_fn, "curl_setopt");
+
+    auto set_opt = [&](zend_long opt, zval *val) {
+        zval args[3];
+        ZVAL_COPY(&args[0], &ch);
+        ZVAL_LONG(&args[1], opt);
+        ZVAL_COPY(&args[2], val);
+        zval ret;
+        call_user_function(nullptr, nullptr, &setopt_fn, &ret, 3, args);
+        zval_ptr_dtor(&ret);
+        zval_ptr_dtor(&args[0]);
+        zval_ptr_dtor(&args[2]);
+    };
+
+    zval opt_val;
+    ZVAL_TRUE(&opt_val);
+    set_opt(19913, &opt_val); // CURLOPT_RETURNTRANSFER
+
+    ZVAL_TRUE(&opt_val);
+    set_opt(47, &opt_val); // CURLOPT_POST
+
+    zval postfields;
+    ZVAL_STR(&postfields, json_buf.s ? json_buf.s : ZSTR_EMPTY_ALLOC());
+    set_opt(10015, &postfields); // CURLOPT_POSTFIELDS
+    zval_ptr_dtor(&postfields);
+
+    ZVAL_LONG(&opt_val, Z_LVAL_P(timeout_zv));
+    set_opt(13, &opt_val); // CURLOPT_TIMEOUT
+
+    set_opt(10023, &headers_retval); // CURLOPT_HTTPHEADER
+    zval_ptr_dtor(&headers_retval);
+
+    if (Z_TYPE_P(proxy_zv) == IS_STRING) {
+        set_opt(10004, proxy_zv); // CURLOPT_PROXY
+    }
+
+    zval exec_fn;
+    ZVAL_STRING(&exec_fn, "curl_exec");
+    zval exec_args[1];
+    ZVAL_COPY(&exec_args[0], &ch);
+    zval response;
+    call_user_function(nullptr, nullptr, &exec_fn, &response, 1, exec_args);
+    zval_ptr_dtor(&exec_fn);
+    zval_ptr_dtor(&exec_args[0]);
+
+    zval getinfo_fn;
+    ZVAL_STRING(&getinfo_fn, "curl_getinfo");
+    zval getinfo_args[2];
+    ZVAL_COPY(&getinfo_args[0], &ch);
+    ZVAL_LONG(&getinfo_args[1], 2097154); // CURLINFO_HTTP_CODE
+    zval http_code;
+    call_user_function(nullptr, nullptr, &getinfo_fn, &http_code, 2, getinfo_args);
+    zval_ptr_dtor(&getinfo_fn);
+    zval_ptr_dtor(&getinfo_args[0]);
+
+    zval error_fn;
+    ZVAL_STRING(&error_fn, "curl_error");
+    zval error_args[1];
+    ZVAL_COPY(&error_args[0], &ch);
+    zval curl_error;
+    call_user_function(nullptr, nullptr, &error_fn, &curl_error, 1, error_args);
+    zval_ptr_dtor(&error_fn);
+    zval_ptr_dtor(&error_args[0]);
+
+    zval close_fn;
+    ZVAL_STRING(&close_fn, "curl_close");
+    zval close_args[1];
+    ZVAL_COPY(&close_args[0], &ch);
+    zval close_ret;
+    call_user_function(nullptr, nullptr, &close_fn, &close_ret, 1, close_args);
+    zval_ptr_dtor(&close_fn);
+    zval_ptr_dtor(&close_ret);
+    zval_ptr_dtor(&close_args[0]);
+
+    zval_ptr_dtor(&setopt_fn);
+    zval_ptr_dtor(&ch);
+    zend_string_release(url);
+
+    if (Z_TYPE(curl_error) == IS_STRING && Z_STRLEN(curl_error) > 0) {
+        zend_throw_exception_ex(zvec_exception_ce, 0, "HTTP request failed: %s", Z_STRVAL(curl_error));
+        zval_ptr_dtor(&curl_error);
+        zval_ptr_dtor(&response);
+        zval_ptr_dtor(&http_code);
+        return;
+    }
+    zval_ptr_dtor(&curl_error);
+
+    if (Z_TYPE(response) == IS_FALSE) {
+        zend_throw_exception(zvec_exception_ce, "HTTP request returned false", 0);
+        zval_ptr_dtor(&response);
+        zval_ptr_dtor(&http_code);
+        return;
+    }
+
+    zval decoded;
+    php_json_decode(&decoded, Z_STRVAL(response), Z_STRLEN(response), 1, 512);
+
+    zend_long code = Z_LVAL(http_code);
+    if (code != 200) {
+        const char *err_msg = "Unknown error";
+        if (Z_TYPE(decoded) == IS_ARRAY) {
+            zval *error = zend_hash_str_find(Z_ARRVAL(decoded), "error", sizeof("error") - 1);
+            if (error && Z_TYPE_P(error) == IS_ARRAY) {
+                zval *msg = zend_hash_str_find(Z_ARRVAL_P(error), "message", sizeof("message") - 1);
+                if (msg && Z_TYPE_P(msg) == IS_STRING) {
+                    err_msg = Z_STRVAL_P(msg);
+                }
+            }
+        }
+        zend_throw_exception_ex(zvec_exception_ce, (int)code, "API error: %s", err_msg);
+        zval_ptr_dtor(&decoded);
+        zval_ptr_dtor(&response);
+        zval_ptr_dtor(&http_code);
+        return;
+    }
+
+    zval_ptr_dtor(&response);
+    zval_ptr_dtor(&http_code);
+
+    if (Z_TYPE(decoded) != IS_ARRAY) {
+        zend_throw_exception(zvec_exception_ce, "Invalid JSON response", 0);
+        zval_ptr_dtor(&decoded);
+        return;
+    }
+
+    RETURN_ZVAL(&decoded, 0, 0);
+}
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_api___construct, 0, 0, 1)
+    ZEND_ARG_TYPE_INFO(0, apiKey, IS_STRING, 0)
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, baseUrl, IS_STRING, 1, "null")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, timeout, IS_LONG, 0, "30")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, proxy, IS_STRING, 1, "null")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_api_post, 0, 2, IS_ARRAY, 0)
+    ZEND_ARG_TYPE_INFO(0, endpoint, IS_STRING, 0)
+    ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_api_get_default_base_url, 0, 0, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_api_get_headers, 0, 0, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+static const zend_function_entry zvec_api_embedding_methods[] = {
+    PHP_ME(ApiEmbeddingFunction, __construct, arginfo_api___construct, ZEND_ACC_PUBLIC)
+    PHP_ME(ApiEmbeddingFunction, post, arginfo_api_post, ZEND_ACC_PROTECTED)
+    ZEND_ABSTRACT_ME_WITH_FLAGS(ApiEmbeddingFunction, getDefaultBaseUrl, arginfo_api_get_default_base_url, ZEND_ACC_ABSTRACT | ZEND_ACC_PROTECTED)
+    ZEND_ABSTRACT_ME_WITH_FLAGS(ApiEmbeddingFunction, getHeaders, arginfo_api_get_headers, ZEND_ACC_ABSTRACT | ZEND_ACC_PROTECTED)
+    PHP_FE_END
+};
+
+void zvec_register_embedding_interfaces(INIT_FUNC_ARGS) {
+    zend_class_entry ce;
+
+    INIT_CLASS_ENTRY(ce, "DenseEmbeddingFunction", zvec_dense_embedding_methods);
+    zvec_dense_embedding_ce = zend_register_internal_interface(&ce);
+
+    INIT_CLASS_ENTRY(ce, "SparseEmbeddingFunction", zvec_sparse_embedding_methods);
+    zvec_sparse_embedding_ce = zend_register_internal_interface(&ce);
+
+    INIT_CLASS_ENTRY(ce, "ApiEmbeddingFunction", zvec_api_embedding_methods);
+    zvec_api_embedding_ce = zend_register_internal_class(&ce);
+    zvec_api_embedding_ce->ce_flags |= ZEND_ACC_ABSTRACT;
+
+    zend_declare_property_null(zvec_api_embedding_ce, "apiKey", sizeof("apiKey") - 1, ZEND_ACC_PROTECTED);
+    zend_declare_property_null(zvec_api_embedding_ce, "baseUrl", sizeof("baseUrl") - 1, ZEND_ACC_PROTECTED);
+    zend_declare_property_long(zvec_api_embedding_ce, "timeout", sizeof("timeout") - 1, 30, ZEND_ACC_PROTECTED);
+    zend_declare_property_null(zvec_api_embedding_ce, "proxy", sizeof("proxy") - 1, ZEND_ACC_PROTECTED);
+}

--- a/php-ext/zvec_embedding_interfaces.h
+++ b/php-ext/zvec_embedding_interfaces.h
@@ -1,0 +1,6 @@
+#ifndef ZVEC_EMBEDDING_INTERFACES_H
+#define ZVEC_EMBEDDING_INTERFACES_H
+
+#include "php_zvec.h"
+
+#endif

--- a/php-ext/zvec_exception.cc
+++ b/php-ext/zvec_exception.cc
@@ -1,0 +1,23 @@
+#include "zvec_exception.h"
+#include <cstdarg>
+
+extern "C" {
+#include "ext/spl/spl_exceptions.h"
+}
+
+zend_class_entry *zvec_exception_ce = nullptr;
+
+void zvec_throw_exception(int code, const char *format, ...) {
+    char buf[512];
+    va_list args;
+    va_start(args, format);
+    vsnprintf(buf, sizeof(buf), format, args);
+    va_end(args);
+    zend_throw_exception_ex(zvec_exception_ce, code, "%s", buf);
+}
+
+void zvec_register_exception(INIT_FUNC_ARGS) {
+    zend_class_entry ce;
+    INIT_CLASS_ENTRY(ce, "ZVecException", nullptr);
+    zvec_exception_ce = zend_register_internal_class_ex(&ce, spl_ce_RuntimeException);
+}

--- a/php-ext/zvec_exception.h
+++ b/php-ext/zvec_exception.h
@@ -1,0 +1,8 @@
+#ifndef ZVEC_EXCEPTION_H
+#define ZVEC_EXCEPTION_H
+
+#include "php_zvec.h"
+
+void zvec_throw_exception(int code, const char *format, ...);
+
+#endif

--- a/php-ext/zvec_openai_embedding.cc
+++ b/php-ext/zvec_openai_embedding.cc
@@ -1,0 +1,270 @@
+#include "zvec_openai_embedding.h"
+#include "zvec_exception.h"
+
+zend_class_entry *zvec_openai_embedding_ce = nullptr;
+
+PHP_METHOD(OpenAIDenseEmbedding, __construct) {
+    char *api_key; size_t api_key_len;
+    char *model = nullptr; size_t model_len = 0;
+    zval *dimensions = nullptr;
+    char *base_url = nullptr; size_t base_url_len = 0;
+    zend_long timeout = 30;
+    char *proxy = nullptr; size_t proxy_len = 0;
+    ZEND_PARSE_PARAMETERS_START(1, 6)
+        Z_PARAM_STRING(api_key, api_key_len)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_STRING(model, model_len)
+        Z_PARAM_ZVAL_OR_NULL(dimensions)
+        Z_PARAM_STRING_OR_NULL(base_url, base_url_len)
+        Z_PARAM_LONG(timeout)
+        Z_PARAM_STRING_OR_NULL(proxy, proxy_len)
+    ZEND_PARSE_PARAMETERS_END();
+
+    zval parent_args[4];
+    ZVAL_STRINGL(&parent_args[0], api_key, api_key_len);
+    if (base_url) {
+        ZVAL_STRINGL(&parent_args[1], base_url, base_url_len);
+    } else {
+        ZVAL_NULL(&parent_args[1]);
+    }
+    ZVAL_LONG(&parent_args[2], timeout);
+    if (proxy) {
+        ZVAL_STRINGL(&parent_args[3], proxy, proxy_len);
+    } else {
+        ZVAL_NULL(&parent_args[3]);
+    }
+    zend_call_method_with_0_params(Z_OBJ_P(ZEND_THIS), zvec_api_embedding_ce, nullptr, "__construct", nullptr);
+
+    zend_update_property_stringl(zvec_api_embedding_ce, Z_OBJ_P(ZEND_THIS), "apiKey", sizeof("apiKey") - 1, api_key, api_key_len);
+    if (base_url) {
+        zend_update_property_stringl(zvec_api_embedding_ce, Z_OBJ_P(ZEND_THIS), "baseUrl", sizeof("baseUrl") - 1, base_url, base_url_len);
+    } else {
+        zend_update_property_string(zvec_api_embedding_ce, Z_OBJ_P(ZEND_THIS), "baseUrl", sizeof("baseUrl") - 1, "https://api.openai.com/v1");
+    }
+    zend_update_property_long(zvec_api_embedding_ce, Z_OBJ_P(ZEND_THIS), "timeout", sizeof("timeout") - 1, timeout);
+    if (proxy) {
+        zend_update_property_stringl(zvec_api_embedding_ce, Z_OBJ_P(ZEND_THIS), "proxy", sizeof("proxy") - 1, proxy, proxy_len);
+    } else {
+        zend_update_property_null(zvec_api_embedding_ce, Z_OBJ_P(ZEND_THIS), "proxy", sizeof("proxy") - 1);
+    }
+
+    for (int i = 0; i < 4; i++) zval_ptr_dtor(&parent_args[i]);
+
+    if (model && model_len > 0) {
+        zend_update_property_stringl(zvec_openai_embedding_ce, Z_OBJ_P(ZEND_THIS), "model", sizeof("model") - 1, model, model_len);
+    } else {
+        zend_update_property_string(zvec_openai_embedding_ce, Z_OBJ_P(ZEND_THIS), "model", sizeof("model") - 1, "text-embedding-3-small");
+    }
+
+    if (dimensions && Z_TYPE_P(dimensions) == IS_LONG) {
+        zend_update_property_long(zvec_openai_embedding_ce, Z_OBJ_P(ZEND_THIS), "dimensions", sizeof("dimensions") - 1, Z_LVAL_P(dimensions));
+    } else {
+        zend_update_property_null(zvec_openai_embedding_ce, Z_OBJ_P(ZEND_THIS), "dimensions", sizeof("dimensions") - 1);
+    }
+}
+
+PHP_METHOD(OpenAIDenseEmbedding, getDefaultBaseUrl) {
+    ZEND_PARSE_PARAMETERS_NONE();
+    RETURN_STRING("https://api.openai.com/v1");
+}
+
+PHP_METHOD(OpenAIDenseEmbedding, getHeaders) {
+    ZEND_PARSE_PARAMETERS_NONE();
+
+    zval *api_key = zend_read_property(zvec_api_embedding_ce, Z_OBJ_P(ZEND_THIS), "apiKey", sizeof("apiKey") - 1, 1, nullptr);
+
+    array_init(return_value);
+    zend_string *auth = zend_strpprintf(0, "Authorization: Bearer %s", Z_STRVAL_P(api_key));
+    add_next_index_str(return_value, auth);
+    add_next_index_string(return_value, "Content-Type: application/json");
+}
+
+PHP_METHOD(OpenAIDenseEmbedding, getDimension) {
+    ZEND_PARSE_PARAMETERS_NONE();
+
+    zval *dims = zend_read_property(zvec_openai_embedding_ce, Z_OBJ_P(ZEND_THIS), "dimensions", sizeof("dimensions") - 1, 1, nullptr);
+    if (Z_TYPE_P(dims) == IS_LONG) {
+        RETURN_LONG(Z_LVAL_P(dims));
+    }
+
+    zval *model = zend_read_property(zvec_openai_embedding_ce, Z_OBJ_P(ZEND_THIS), "model", sizeof("model") - 1, 1, nullptr);
+    if (Z_TYPE_P(model) == IS_STRING) {
+        if (strcmp(Z_STRVAL_P(model), "text-embedding-3-large") == 0) {
+            RETURN_LONG(3072);
+        }
+    }
+    RETURN_LONG(1536);
+}
+
+PHP_METHOD(OpenAIDenseEmbedding, embed) {
+    char *input; size_t input_len;
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_STRING(input, input_len)
+    ZEND_PARSE_PARAMETERS_END();
+
+    zval inputs;
+    array_init(&inputs);
+    add_next_index_stringl(&inputs, input, input_len);
+
+    zval batch_result;
+    zend_call_method_with_1_params(Z_OBJ_P(ZEND_THIS), Z_OBJCE_P(ZEND_THIS), nullptr, "embedbatch", &batch_result, &inputs);
+    zval_ptr_dtor(&inputs);
+
+    if (EG(exception)) {
+        zval_ptr_dtor(&batch_result);
+        return;
+    }
+
+    if (Z_TYPE(batch_result) == IS_ARRAY) {
+        zval *first = zend_hash_index_find(Z_ARRVAL(batch_result), 0);
+        if (first) {
+            RETVAL_ZVAL(first, 1, 0);
+            zval_ptr_dtor(&batch_result);
+            return;
+        }
+    }
+    zval_ptr_dtor(&batch_result);
+    array_init(return_value);
+}
+
+PHP_METHOD(OpenAIDenseEmbedding, embedBatch) {
+    zval *inputs;
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_ARRAY(inputs)
+    ZEND_PARSE_PARAMETERS_END();
+
+    if (zend_hash_num_elements(Z_ARRVAL_P(inputs)) == 0) {
+        array_init(return_value);
+        return;
+    }
+
+    if (zend_hash_num_elements(Z_ARRVAL_P(inputs)) > 2048) {
+        zend_throw_exception(zvec_exception_ce, "Maximum batch size is 2048 inputs", 0);
+        return;
+    }
+
+    zval *model = zend_read_property(zvec_openai_embedding_ce, Z_OBJ_P(ZEND_THIS), "model", sizeof("model") - 1, 1, nullptr);
+    zval *dims = zend_read_property(zvec_openai_embedding_ce, Z_OBJ_P(ZEND_THIS), "dimensions", sizeof("dimensions") - 1, 1, nullptr);
+
+    zval payload;
+    array_init(&payload);
+    Z_ADDREF_P(model);
+    zend_hash_str_update(Z_ARRVAL(payload), "model", sizeof("model") - 1, model);
+    Z_ADDREF_P(inputs);
+    zend_hash_str_update(Z_ARRVAL(payload), "input", sizeof("input") - 1, inputs);
+
+    if (Z_TYPE_P(dims) == IS_LONG) {
+        zval d;
+        ZVAL_LONG(&d, Z_LVAL_P(dims));
+        zend_hash_str_update(Z_ARRVAL(payload), "dimensions", sizeof("dimensions") - 1, &d);
+    }
+
+    zval endpoint;
+    ZVAL_STRING(&endpoint, "/embeddings");
+    zval response;
+    zend_call_method_with_2_params(Z_OBJ_P(ZEND_THIS), Z_OBJCE_P(ZEND_THIS), nullptr, "post", &response, &endpoint, &payload);
+    zval_ptr_dtor(&endpoint);
+    zval_ptr_dtor(&payload);
+
+    if (EG(exception)) {
+        zval_ptr_dtor(&response);
+        return;
+    }
+
+    if (Z_TYPE(response) != IS_ARRAY) {
+        zend_throw_exception(zvec_exception_ce, "Invalid response format", 0);
+        zval_ptr_dtor(&response);
+        return;
+    }
+
+    zval *data = zend_hash_str_find(Z_ARRVAL(response), "data", sizeof("data") - 1);
+    if (!data || Z_TYPE_P(data) != IS_ARRAY) {
+        zend_throw_exception(zvec_exception_ce, "Invalid response format: missing data array", 0);
+        zval_ptr_dtor(&response);
+        return;
+    }
+
+    array_init(return_value);
+    zval *item;
+    ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(data), item) {
+        if (Z_TYPE_P(item) != IS_ARRAY) continue;
+        zval *embedding = zend_hash_str_find(Z_ARRVAL_P(item), "embedding", sizeof("embedding") - 1);
+        if (!embedding || Z_TYPE_P(embedding) != IS_ARRAY) {
+            zend_throw_exception(zvec_exception_ce, "Invalid response format: missing embedding array", 0);
+            zval_ptr_dtor(&response);
+            return;
+        }
+
+        zval float_arr;
+        array_init(&float_arr);
+        zval *v;
+        ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(embedding), v) {
+            zval fv;
+            ZVAL_DOUBLE(&fv, zval_get_double(v));
+            add_next_index_zval(&float_arr, &fv);
+        } ZEND_HASH_FOREACH_END();
+        add_next_index_zval(return_value, &float_arr);
+    } ZEND_HASH_FOREACH_END();
+
+    zval_ptr_dtor(&response);
+}
+
+PHP_METHOD(OpenAIDenseEmbedding, getModel) {
+    ZEND_PARSE_PARAMETERS_NONE();
+    zval *model = zend_read_property(zvec_openai_embedding_ce, Z_OBJ_P(ZEND_THIS), "model", sizeof("model") - 1, 1, nullptr);
+    RETURN_ZVAL(model, 1, 0);
+}
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_openai___construct, 0, 0, 1)
+    ZEND_ARG_TYPE_INFO(0, apiKey, IS_STRING, 0)
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, model, IS_STRING, 0, "\"text-embedding-3-small\"")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, dimensions, IS_LONG, 1, "null")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, baseUrl, IS_STRING, 1, "null")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, timeout, IS_LONG, 0, "30")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, proxy, IS_STRING, 1, "null")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_openai_embed, 0, 1, IS_ARRAY, 0)
+    ZEND_ARG_TYPE_INFO(0, input, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_openai_embed_batch, 0, 1, IS_ARRAY, 0)
+    ZEND_ARG_TYPE_INFO(0, inputs, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_openai_get_dimension, 0, 0, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_openai_get_default_base_url, 0, 0, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_openai_get_headers, 0, 0, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_openai_get_model, 0, 0, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+static const zend_function_entry zvec_openai_embedding_methods[] = {
+    PHP_ME(OpenAIDenseEmbedding, __construct, arginfo_openai___construct, ZEND_ACC_PUBLIC)
+    PHP_ME(OpenAIDenseEmbedding, getDefaultBaseUrl, arginfo_openai_get_default_base_url, ZEND_ACC_PROTECTED)
+    PHP_ME(OpenAIDenseEmbedding, getHeaders, arginfo_openai_get_headers, ZEND_ACC_PROTECTED)
+    PHP_ME(OpenAIDenseEmbedding, getDimension, arginfo_openai_get_dimension, ZEND_ACC_PUBLIC)
+    PHP_ME(OpenAIDenseEmbedding, embed, arginfo_openai_embed, ZEND_ACC_PUBLIC)
+    PHP_ME(OpenAIDenseEmbedding, embedBatch, arginfo_openai_embed_batch, ZEND_ACC_PUBLIC)
+    PHP_ME(OpenAIDenseEmbedding, getModel, arginfo_openai_get_model, ZEND_ACC_PUBLIC)
+    PHP_FE_END
+};
+
+void zvec_register_openai_embedding(INIT_FUNC_ARGS) {
+    zend_class_entry ce;
+    INIT_CLASS_ENTRY(ce, "OpenAIDenseEmbedding", zvec_openai_embedding_methods);
+    zvec_openai_embedding_ce = zend_register_internal_class_ex(&ce, zvec_api_embedding_ce);
+    zend_class_implements(zvec_openai_embedding_ce, 1, zvec_dense_embedding_ce);
+
+    zend_declare_class_constant_string(zvec_openai_embedding_ce, "MODEL_SMALL", sizeof("MODEL_SMALL") - 1, "text-embedding-3-small");
+    zend_declare_class_constant_string(zvec_openai_embedding_ce, "MODEL_LARGE", sizeof("MODEL_LARGE") - 1, "text-embedding-3-large");
+    zend_declare_class_constant_string(zvec_openai_embedding_ce, "MODEL_ADA", sizeof("MODEL_ADA") - 1, "text-embedding-ada-002");
+
+    zend_declare_property_string(zvec_openai_embedding_ce, "model", sizeof("model") - 1, "text-embedding-3-small", ZEND_ACC_PRIVATE);
+    zend_declare_property_null(zvec_openai_embedding_ce, "dimensions", sizeof("dimensions") - 1, ZEND_ACC_PRIVATE);
+}

--- a/php-ext/zvec_openai_embedding.h
+++ b/php-ext/zvec_openai_embedding.h
@@ -1,0 +1,6 @@
+#ifndef ZVEC_OPENAI_EMBEDDING_H
+#define ZVEC_OPENAI_EMBEDDING_H
+
+#include "php_zvec.h"
+
+#endif

--- a/php-ext/zvec_qwen_embedding.cc
+++ b/php-ext/zvec_qwen_embedding.cc
@@ -1,0 +1,253 @@
+#include "zvec_qwen_embedding.h"
+#include "zvec_exception.h"
+
+zend_class_entry *zvec_qwen_embedding_ce = nullptr;
+
+PHP_METHOD(QwenDenseEmbedding, __construct) {
+    char *api_key; size_t api_key_len;
+    char *model = nullptr; size_t model_len = 0;
+    char *base_url = nullptr; size_t base_url_len = 0;
+    zend_long timeout = 30;
+    char *proxy = nullptr; size_t proxy_len = 0;
+    ZEND_PARSE_PARAMETERS_START(1, 5)
+        Z_PARAM_STRING(api_key, api_key_len)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_STRING(model, model_len)
+        Z_PARAM_STRING_OR_NULL(base_url, base_url_len)
+        Z_PARAM_LONG(timeout)
+        Z_PARAM_STRING_OR_NULL(proxy, proxy_len)
+    ZEND_PARSE_PARAMETERS_END();
+
+    zend_update_property_stringl(zvec_api_embedding_ce, Z_OBJ_P(ZEND_THIS), "apiKey", sizeof("apiKey") - 1, api_key, api_key_len);
+    if (base_url) {
+        zend_update_property_stringl(zvec_api_embedding_ce, Z_OBJ_P(ZEND_THIS), "baseUrl", sizeof("baseUrl") - 1, base_url, base_url_len);
+    } else {
+        zend_update_property_string(zvec_api_embedding_ce, Z_OBJ_P(ZEND_THIS), "baseUrl", sizeof("baseUrl") - 1, "https://dashscope.aliyuncs.com/api/v1");
+    }
+    zend_update_property_long(zvec_api_embedding_ce, Z_OBJ_P(ZEND_THIS), "timeout", sizeof("timeout") - 1, timeout);
+    if (proxy) {
+        zend_update_property_stringl(zvec_api_embedding_ce, Z_OBJ_P(ZEND_THIS), "proxy", sizeof("proxy") - 1, proxy, proxy_len);
+    } else {
+        zend_update_property_null(zvec_api_embedding_ce, Z_OBJ_P(ZEND_THIS), "proxy", sizeof("proxy") - 1);
+    }
+
+    if (model && model_len > 0) {
+        zend_update_property_stringl(zvec_qwen_embedding_ce, Z_OBJ_P(ZEND_THIS), "model", sizeof("model") - 1, model, model_len);
+    } else {
+        zend_update_property_string(zvec_qwen_embedding_ce, Z_OBJ_P(ZEND_THIS), "model", sizeof("model") - 1, "text-embedding-v4");
+    }
+}
+
+PHP_METHOD(QwenDenseEmbedding, getDefaultBaseUrl) {
+    ZEND_PARSE_PARAMETERS_NONE();
+    RETURN_STRING("https://dashscope.aliyuncs.com/api/v1");
+}
+
+PHP_METHOD(QwenDenseEmbedding, getHeaders) {
+    ZEND_PARSE_PARAMETERS_NONE();
+
+    zval *api_key = zend_read_property(zvec_api_embedding_ce, Z_OBJ_P(ZEND_THIS), "apiKey", sizeof("apiKey") - 1, 1, nullptr);
+
+    array_init(return_value);
+    zend_string *auth = zend_strpprintf(0, "Authorization: Bearer %s", Z_STRVAL_P(api_key));
+    add_next_index_str(return_value, auth);
+    add_next_index_string(return_value, "Content-Type: application/json");
+}
+
+PHP_METHOD(QwenDenseEmbedding, getDimension) {
+    ZEND_PARSE_PARAMETERS_NONE();
+
+    zval *model = zend_read_property(zvec_qwen_embedding_ce, Z_OBJ_P(ZEND_THIS), "model", sizeof("model") - 1, 1, nullptr);
+    if (Z_TYPE_P(model) == IS_STRING) {
+        if (strcmp(Z_STRVAL_P(model), "text-embedding-v4") == 0) RETURN_LONG(1792);
+        if (strcmp(Z_STRVAL_P(model), "text-embedding-v3") == 0) RETURN_LONG(1024);
+    }
+    RETURN_LONG(1536);
+}
+
+PHP_METHOD(QwenDenseEmbedding, embed) {
+    char *input; size_t input_len;
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_STRING(input, input_len)
+    ZEND_PARSE_PARAMETERS_END();
+
+    zval inputs;
+    array_init(&inputs);
+    add_next_index_stringl(&inputs, input, input_len);
+
+    zval batch_result;
+    zend_call_method_with_1_params(Z_OBJ_P(ZEND_THIS), Z_OBJCE_P(ZEND_THIS), nullptr, "embedbatch", &batch_result, &inputs);
+    zval_ptr_dtor(&inputs);
+
+    if (EG(exception)) {
+        zval_ptr_dtor(&batch_result);
+        return;
+    }
+
+    if (Z_TYPE(batch_result) == IS_ARRAY) {
+        zval *first = zend_hash_index_find(Z_ARRVAL(batch_result), 0);
+        if (first) {
+            RETVAL_ZVAL(first, 1, 0);
+            zval_ptr_dtor(&batch_result);
+            return;
+        }
+    }
+    zval_ptr_dtor(&batch_result);
+    array_init(return_value);
+}
+
+PHP_METHOD(QwenDenseEmbedding, embedBatch) {
+    zval *inputs;
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_ARRAY(inputs)
+    ZEND_PARSE_PARAMETERS_END();
+
+    if (zend_hash_num_elements(Z_ARRVAL_P(inputs)) == 0) {
+        array_init(return_value);
+        return;
+    }
+
+    if (zend_hash_num_elements(Z_ARRVAL_P(inputs)) > 25) {
+        zend_throw_exception(zvec_exception_ce, "Maximum batch size is 25 inputs for DashScope", 0);
+        return;
+    }
+
+    zval *model = zend_read_property(zvec_qwen_embedding_ce, Z_OBJ_P(ZEND_THIS), "model", sizeof("model") - 1, 1, nullptr);
+
+    zval texts;
+    array_init(&texts);
+    zval *input_str;
+    ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(inputs), input_str) {
+        zval text_obj;
+        array_init(&text_obj);
+        zval text_copy;
+        ZVAL_COPY(&text_copy, input_str);
+        zend_hash_str_update(Z_ARRVAL(text_obj), "text", sizeof("text") - 1, &text_copy);
+        add_next_index_zval(&texts, &text_obj);
+    } ZEND_HASH_FOREACH_END();
+
+    zval input_wrapper;
+    array_init(&input_wrapper);
+    zend_hash_str_update(Z_ARRVAL(input_wrapper), "texts", sizeof("texts") - 1, &texts);
+
+    zval payload;
+    array_init(&payload);
+    Z_ADDREF_P(model);
+    zend_hash_str_update(Z_ARRVAL(payload), "model", sizeof("model") - 1, model);
+    zend_hash_str_update(Z_ARRVAL(payload), "input", sizeof("input") - 1, &input_wrapper);
+
+    zval endpoint;
+    ZVAL_STRING(&endpoint, "/services/embeddings/text-embedding");
+    zval response;
+    zend_call_method_with_2_params(Z_OBJ_P(ZEND_THIS), Z_OBJCE_P(ZEND_THIS), nullptr, "post", &response, &endpoint, &payload);
+    zval_ptr_dtor(&endpoint);
+    zval_ptr_dtor(&payload);
+
+    if (EG(exception)) {
+        zval_ptr_dtor(&response);
+        return;
+    }
+
+    if (Z_TYPE(response) != IS_ARRAY) {
+        zend_throw_exception(zvec_exception_ce, "Invalid response format", 0);
+        zval_ptr_dtor(&response);
+        return;
+    }
+
+    zval *output = zend_hash_str_find(Z_ARRVAL(response), "output", sizeof("output") - 1);
+    if (!output || Z_TYPE_P(output) != IS_ARRAY) {
+        zend_throw_exception(zvec_exception_ce, "Invalid response format: missing embeddings array", 0);
+        zval_ptr_dtor(&response);
+        return;
+    }
+
+    zval *embeddings = zend_hash_str_find(Z_ARRVAL_P(output), "embeddings", sizeof("embeddings") - 1);
+    if (!embeddings || Z_TYPE_P(embeddings) != IS_ARRAY) {
+        zend_throw_exception(zvec_exception_ce, "Invalid response format: missing embeddings array", 0);
+        zval_ptr_dtor(&response);
+        return;
+    }
+
+    array_init(return_value);
+    zval *item;
+    ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(embeddings), item) {
+        if (Z_TYPE_P(item) != IS_ARRAY) continue;
+        zval *embedding = zend_hash_str_find(Z_ARRVAL_P(item), "embedding", sizeof("embedding") - 1);
+        if (!embedding || Z_TYPE_P(embedding) != IS_ARRAY) {
+            zend_throw_exception(zvec_exception_ce, "Invalid response format: missing embedding array", 0);
+            zval_ptr_dtor(&response);
+            return;
+        }
+
+        zval float_arr;
+        array_init(&float_arr);
+        zval *v;
+        ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(embedding), v) {
+            zval fv;
+            ZVAL_DOUBLE(&fv, zval_get_double(v));
+            add_next_index_zval(&float_arr, &fv);
+        } ZEND_HASH_FOREACH_END();
+        add_next_index_zval(return_value, &float_arr);
+    } ZEND_HASH_FOREACH_END();
+
+    zval_ptr_dtor(&response);
+}
+
+PHP_METHOD(QwenDenseEmbedding, getModel) {
+    ZEND_PARSE_PARAMETERS_NONE();
+    zval *model = zend_read_property(zvec_qwen_embedding_ce, Z_OBJ_P(ZEND_THIS), "model", sizeof("model") - 1, 1, nullptr);
+    RETURN_ZVAL(model, 1, 0);
+}
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_qwen___construct, 0, 0, 1)
+    ZEND_ARG_TYPE_INFO(0, apiKey, IS_STRING, 0)
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, model, IS_STRING, 0, "\"text-embedding-v4\"")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, baseUrl, IS_STRING, 1, "null")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, timeout, IS_LONG, 0, "30")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, proxy, IS_STRING, 1, "null")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_qwen_embed, 0, 1, IS_ARRAY, 0)
+    ZEND_ARG_TYPE_INFO(0, input, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_qwen_embed_batch, 0, 1, IS_ARRAY, 0)
+    ZEND_ARG_TYPE_INFO(0, inputs, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_qwen_get_dimension, 0, 0, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_qwen_get_default_base_url, 0, 0, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_qwen_get_headers, 0, 0, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_qwen_get_model, 0, 0, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+static const zend_function_entry zvec_qwen_embedding_methods[] = {
+    PHP_ME(QwenDenseEmbedding, __construct, arginfo_qwen___construct, ZEND_ACC_PUBLIC)
+    PHP_ME(QwenDenseEmbedding, getDefaultBaseUrl, arginfo_qwen_get_default_base_url, ZEND_ACC_PROTECTED)
+    PHP_ME(QwenDenseEmbedding, getHeaders, arginfo_qwen_get_headers, ZEND_ACC_PROTECTED)
+    PHP_ME(QwenDenseEmbedding, getDimension, arginfo_qwen_get_dimension, ZEND_ACC_PUBLIC)
+    PHP_ME(QwenDenseEmbedding, embed, arginfo_qwen_embed, ZEND_ACC_PUBLIC)
+    PHP_ME(QwenDenseEmbedding, embedBatch, arginfo_qwen_embed_batch, ZEND_ACC_PUBLIC)
+    PHP_ME(QwenDenseEmbedding, getModel, arginfo_qwen_get_model, ZEND_ACC_PUBLIC)
+    PHP_FE_END
+};
+
+void zvec_register_qwen_embedding(INIT_FUNC_ARGS) {
+    zend_class_entry ce;
+    INIT_CLASS_ENTRY(ce, "QwenDenseEmbedding", zvec_qwen_embedding_methods);
+    zvec_qwen_embedding_ce = zend_register_internal_class_ex(&ce, zvec_api_embedding_ce);
+    zend_class_implements(zvec_qwen_embedding_ce, 1, zvec_dense_embedding_ce);
+
+    zend_declare_class_constant_string(zvec_qwen_embedding_ce, "MODEL_V4", sizeof("MODEL_V4") - 1, "text-embedding-v4");
+    zend_declare_class_constant_string(zvec_qwen_embedding_ce, "MODEL_V3", sizeof("MODEL_V3") - 1, "text-embedding-v3");
+    zend_declare_class_constant_string(zvec_qwen_embedding_ce, "MODEL_V2", sizeof("MODEL_V2") - 1, "text-embedding-v2");
+    zend_declare_class_constant_string(zvec_qwen_embedding_ce, "MODEL_V1", sizeof("MODEL_V1") - 1, "text-embedding-v1");
+
+    zend_declare_property_string(zvec_qwen_embedding_ce, "model", sizeof("model") - 1, "text-embedding-v4", ZEND_ACC_PRIVATE);
+}

--- a/php-ext/zvec_qwen_embedding.h
+++ b/php-ext/zvec_qwen_embedding.h
@@ -1,0 +1,6 @@
+#ifndef ZVEC_QWEN_EMBEDDING_H
+#define ZVEC_QWEN_EMBEDDING_H
+
+#include "php_zvec.h"
+
+#endif

--- a/php-ext/zvec_reranked_doc.cc
+++ b/php-ext/zvec_reranked_doc.cc
@@ -1,0 +1,91 @@
+#include "zvec_reranked_doc.h"
+
+zend_class_entry *zvec_reranked_doc_ce = nullptr;
+
+PHP_METHOD(ZVecRerankedDoc, __construct) {
+    zval *doc;
+    double combined_score;
+    zval *source_ranks = nullptr;
+    zval *source_scores = nullptr;
+    ZEND_PARSE_PARAMETERS_START(2, 4)
+        Z_PARAM_OBJECT_OF_CLASS(doc, zvec_doc_ce)
+        Z_PARAM_DOUBLE(combined_score)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_ARRAY(source_ranks)
+        Z_PARAM_ARRAY(source_scores)
+    ZEND_PARSE_PARAMETERS_END();
+
+    zend_update_property(zvec_reranked_doc_ce, Z_OBJ_P(ZEND_THIS), "doc", sizeof("doc") - 1, doc);
+    zend_update_property_double(zvec_reranked_doc_ce, Z_OBJ_P(ZEND_THIS), "combinedScore", sizeof("combinedScore") - 1, combined_score);
+
+    if (source_ranks) {
+        zend_update_property(zvec_reranked_doc_ce, Z_OBJ_P(ZEND_THIS), "sourceRanks", sizeof("sourceRanks") - 1, source_ranks);
+    } else {
+        zval empty;
+        array_init(&empty);
+        zend_update_property(zvec_reranked_doc_ce, Z_OBJ_P(ZEND_THIS), "sourceRanks", sizeof("sourceRanks") - 1, &empty);
+        zval_ptr_dtor(&empty);
+    }
+
+    if (source_scores) {
+        zend_update_property(zvec_reranked_doc_ce, Z_OBJ_P(ZEND_THIS), "sourceScores", sizeof("sourceScores") - 1, source_scores);
+    } else {
+        zval empty;
+        array_init(&empty);
+        zend_update_property(zvec_reranked_doc_ce, Z_OBJ_P(ZEND_THIS), "sourceScores", sizeof("sourceScores") - 1, &empty);
+        zval_ptr_dtor(&empty);
+    }
+}
+
+PHP_METHOD(ZVecRerankedDoc, getPk) {
+    ZEND_PARSE_PARAMETERS_NONE();
+
+    zval *doc = zend_read_property(zvec_reranked_doc_ce, Z_OBJ_P(ZEND_THIS), "doc", sizeof("doc") - 1, 1, nullptr);
+    if (!doc || Z_TYPE_P(doc) != IS_OBJECT) {
+        RETURN_EMPTY_STRING();
+    }
+
+    zend_call_method_with_0_params(Z_OBJ_P(doc), Z_OBJCE_P(doc), nullptr, "getpk", return_value);
+}
+
+PHP_METHOD(ZVecRerankedDoc, getOriginalScore) {
+    ZEND_PARSE_PARAMETERS_NONE();
+
+    zval *doc = zend_read_property(zvec_reranked_doc_ce, Z_OBJ_P(ZEND_THIS), "doc", sizeof("doc") - 1, 1, nullptr);
+    if (!doc || Z_TYPE_P(doc) != IS_OBJECT) {
+        RETURN_DOUBLE(0.0);
+    }
+
+    zend_call_method_with_0_params(Z_OBJ_P(doc), Z_OBJCE_P(doc), nullptr, "getscore", return_value);
+}
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_zvec_rd___construct, 0, 0, 2)
+    ZEND_ARG_OBJ_INFO(0, doc, ZVecDoc, 0)
+    ZEND_ARG_TYPE_INFO(0, combinedScore, IS_DOUBLE, 0)
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, sourceRanks, IS_ARRAY, 0, "[]")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, sourceScores, IS_ARRAY, 0, "[]")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zvec_rd_get_pk, 0, 0, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zvec_rd_get_original_score, 0, 0, IS_DOUBLE, 0)
+ZEND_END_ARG_INFO()
+
+static const zend_function_entry zvec_reranked_doc_methods[] = {
+    PHP_ME(ZVecRerankedDoc, __construct, arginfo_zvec_rd___construct, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecRerankedDoc, getPk, arginfo_zvec_rd_get_pk, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecRerankedDoc, getOriginalScore, arginfo_zvec_rd_get_original_score, ZEND_ACC_PUBLIC)
+    PHP_FE_END
+};
+
+void zvec_register_reranked_doc(INIT_FUNC_ARGS) {
+    zend_class_entry ce;
+    INIT_CLASS_ENTRY(ce, "ZVecRerankedDoc", zvec_reranked_doc_methods);
+    zvec_reranked_doc_ce = zend_register_internal_class(&ce);
+
+    zend_declare_property_null(zvec_reranked_doc_ce, "doc", sizeof("doc") - 1, ZEND_ACC_PUBLIC);
+    zend_declare_property_double(zvec_reranked_doc_ce, "combinedScore", sizeof("combinedScore") - 1, 0.0, ZEND_ACC_PUBLIC);
+    zend_declare_property_null(zvec_reranked_doc_ce, "sourceRanks", sizeof("sourceRanks") - 1, ZEND_ACC_PUBLIC);
+    zend_declare_property_null(zvec_reranked_doc_ce, "sourceScores", sizeof("sourceScores") - 1, ZEND_ACC_PUBLIC);
+}

--- a/php-ext/zvec_reranked_doc.h
+++ b/php-ext/zvec_reranked_doc.h
@@ -1,0 +1,6 @@
+#ifndef ZVEC_RERANKED_DOC_H
+#define ZVEC_RERANKED_DOC_H
+
+#include "php_zvec.h"
+
+#endif

--- a/php-ext/zvec_reranker.cc
+++ b/php-ext/zvec_reranker.cc
@@ -1,0 +1,18 @@
+#include "zvec_reranker.h"
+
+zend_class_entry *zvec_reranker_ce = nullptr;
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zvec_reranker_rerank, 0, 1, IS_ARRAY, 0)
+    ZEND_ARG_TYPE_INFO(0, queryResults, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+static const zend_function_entry zvec_reranker_methods[] = {
+    PHP_ABSTRACT_ME(ZVecReRanker, rerank, arginfo_zvec_reranker_rerank)
+    PHP_FE_END
+};
+
+void zvec_register_reranker(INIT_FUNC_ARGS) {
+    zend_class_entry ce;
+    INIT_CLASS_ENTRY(ce, "ZVecReRanker", zvec_reranker_methods);
+    zvec_reranker_ce = zend_register_internal_interface(&ce);
+}

--- a/php-ext/zvec_reranker.h
+++ b/php-ext/zvec_reranker.h
@@ -1,0 +1,6 @@
+#ifndef ZVEC_RERANKER_H
+#define ZVEC_RERANKER_H
+
+#include "php_zvec.h"
+
+#endif

--- a/php-ext/zvec_rrf_reranker.cc
+++ b/php-ext/zvec_rrf_reranker.cc
@@ -1,0 +1,185 @@
+#include "zvec_rrf_reranker.h"
+
+zend_class_entry *zvec_rrf_reranker_ce = nullptr;
+
+PHP_METHOD(ZVecRrfReRanker, __construct) {
+    zend_long topn = 10;
+    zend_long rank_constant = 60;
+    ZEND_PARSE_PARAMETERS_START(0, 2)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_LONG(topn)
+        Z_PARAM_LONG(rank_constant)
+    ZEND_PARSE_PARAMETERS_END();
+
+    zend_update_property_long(zvec_rrf_reranker_ce, Z_OBJ_P(ZEND_THIS), "topn", sizeof("topn") - 1, topn);
+    zend_update_property_long(zvec_rrf_reranker_ce, Z_OBJ_P(ZEND_THIS), "rankConstant", sizeof("rankConstant") - 1, rank_constant);
+}
+
+PHP_METHOD(ZVecRrfReRanker, rerank) {
+    zval *query_results;
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_ARRAY(query_results)
+    ZEND_PARSE_PARAMETERS_END();
+
+    HashTable *ht = Z_ARRVAL_P(query_results);
+    if (zend_hash_num_elements(ht) == 0) {
+        array_init(return_value);
+        return;
+    }
+
+    zval *topn_zv = zend_read_property(zvec_rrf_reranker_ce, Z_OBJ_P(ZEND_THIS), "topn", sizeof("topn") - 1, 1, nullptr);
+    zval *rc_zv = zend_read_property(zvec_rrf_reranker_ce, Z_OBJ_P(ZEND_THIS), "rankConstant", sizeof("rankConstant") - 1, 1, nullptr);
+    zend_long topn = Z_LVAL_P(topn_zv);
+    zend_long rank_constant = Z_LVAL_P(rc_zv);
+
+    HashTable doc_scores;
+    zend_hash_init(&doc_scores, 32, nullptr, ZVAL_PTR_DTOR, 0);
+
+    zend_string *field_name;
+    zval *docs_arr;
+    ZEND_HASH_FOREACH_STR_KEY_VAL(ht, field_name, docs_arr) {
+        if (Z_TYPE_P(docs_arr) != IS_ARRAY || !field_name) continue;
+
+        HashTable *docs_ht = Z_ARRVAL_P(docs_arr);
+        zend_long rank_idx = 0;
+        zval *doc_zv;
+        ZEND_HASH_FOREACH_VAL(docs_ht, doc_zv) {
+            if (Z_TYPE_P(doc_zv) != IS_OBJECT || !instanceof_function(Z_OBJCE_P(doc_zv), zvec_doc_ce)) {
+                rank_idx++;
+                continue;
+            }
+
+            zval pk_zv;
+            zend_call_method_with_0_params(Z_OBJ_P(doc_zv), Z_OBJCE_P(doc_zv), nullptr, "getpk", &pk_zv);
+            if (Z_TYPE(pk_zv) != IS_STRING) {
+                zval_ptr_dtor(&pk_zv);
+                rank_idx++;
+                continue;
+            }
+
+            zend_long rank = rank_idx + 1;
+
+            zval score_zv;
+            zend_call_method_with_0_params(Z_OBJ_P(doc_zv), Z_OBJCE_P(doc_zv), nullptr, "getscore", &score_zv);
+            double score = (Z_TYPE(score_zv) == IS_DOUBLE) ? Z_DVAL(score_zv) : 0.0;
+            zval_ptr_dtor(&score_zv);
+
+            zval *existing = zend_hash_find(&doc_scores, Z_STR(pk_zv));
+            if (existing) {
+                HashTable *entry = Z_ARRVAL_P(existing);
+                zval *ranks_zv = zend_hash_str_find(entry, "ranks", sizeof("ranks") - 1);
+                zval *scores_zv = zend_hash_str_find(entry, "scores", sizeof("scores") - 1);
+                zval rank_val;
+                ZVAL_LONG(&rank_val, rank);
+                zend_hash_update(Z_ARRVAL_P(ranks_zv), field_name, &rank_val);
+                zval score_val;
+                ZVAL_DOUBLE(&score_val, score);
+                zend_hash_update(Z_ARRVAL_P(scores_zv), field_name, &score_val);
+            } else {
+                zval entry;
+                array_init(&entry);
+
+                zval ranks;
+                array_init(&ranks);
+                zval rank_val;
+                ZVAL_LONG(&rank_val, rank);
+                zend_hash_update(Z_ARRVAL(ranks), field_name, &rank_val);
+                zend_hash_str_update(Z_ARRVAL(entry), "ranks", sizeof("ranks") - 1, &ranks);
+
+                zval scores;
+                array_init(&scores);
+                zval score_val;
+                ZVAL_DOUBLE(&score_val, score);
+                zend_hash_update(Z_ARRVAL(scores), field_name, &score_val);
+                zend_hash_str_update(Z_ARRVAL(entry), "scores", sizeof("scores") - 1, &scores);
+
+                Z_ADDREF_P(doc_zv);
+                zend_hash_str_update(Z_ARRVAL(entry), "doc", sizeof("doc") - 1, doc_zv);
+
+                zend_hash_update(&doc_scores, Z_STR(pk_zv), &entry);
+            }
+
+            zval_ptr_dtor(&pk_zv);
+            rank_idx++;
+        } ZEND_HASH_FOREACH_END();
+    } ZEND_HASH_FOREACH_END();
+
+    zval reranked;
+    array_init(&reranked);
+
+    zval *entry;
+    ZEND_HASH_FOREACH_VAL(&doc_scores, entry) {
+        HashTable *e = Z_ARRVAL_P(entry);
+        zval *ranks_zv = zend_hash_str_find(e, "ranks", sizeof("ranks") - 1);
+        zval *scores_zv = zend_hash_str_find(e, "scores", sizeof("scores") - 1);
+        zval *doc_zv = zend_hash_str_find(e, "doc", sizeof("doc") - 1);
+
+        double rrf_score = 0.0;
+        zval *rank_val;
+        ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(ranks_zv), rank_val) {
+            rrf_score += 1.0 / (rank_constant + Z_LVAL_P(rank_val));
+        } ZEND_HASH_FOREACH_END();
+
+        zval rd_obj;
+        object_init_ex(&rd_obj, zvec_reranked_doc_ce);
+
+        zend_update_property(zvec_reranked_doc_ce, Z_OBJ(rd_obj), "doc", sizeof("doc") - 1, doc_zv);
+        zend_update_property_double(zvec_reranked_doc_ce, Z_OBJ(rd_obj), "combinedScore", sizeof("combinedScore") - 1, rrf_score);
+        zend_update_property(zvec_reranked_doc_ce, Z_OBJ(rd_obj), "sourceRanks", sizeof("sourceRanks") - 1, ranks_zv);
+        zend_update_property(zvec_reranked_doc_ce, Z_OBJ(rd_obj), "sourceScores", sizeof("sourceScores") - 1, scores_zv);
+
+        add_next_index_zval(&reranked, &rd_obj);
+    } ZEND_HASH_FOREACH_END();
+
+    zend_hash_destroy(&doc_scores);
+
+    HashTable *result_ht = Z_ARRVAL(reranked);
+    zend_hash_sort(result_ht, [](Bucket *a, Bucket *b) -> int {
+        zval *za = &a->val;
+        zval *zb = &b->val;
+        zval *sa = zend_read_property(zvec_reranked_doc_ce, Z_OBJ_P(za), "combinedScore", sizeof("combinedScore") - 1, 1, nullptr);
+        zval *sb = zend_read_property(zvec_reranked_doc_ce, Z_OBJ_P(zb), "combinedScore", sizeof("combinedScore") - 1, 1, nullptr);
+        double da = Z_DVAL_P(sa);
+        double db = Z_DVAL_P(sb);
+        if (db > da) return 1;
+        if (db < da) return -1;
+        return 0;
+    }, 1);
+
+    array_init(return_value);
+    zend_long count = 0;
+    zval *item;
+    ZEND_HASH_FOREACH_VAL(result_ht, item) {
+        if (count >= topn) break;
+        Z_ADDREF_P(item);
+        add_next_index_zval(return_value, item);
+        count++;
+    } ZEND_HASH_FOREACH_END();
+
+    zval_ptr_dtor(&reranked);
+}
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_zvec_rrf___construct, 0, 0, 0)
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, topn, IS_LONG, 0, "10")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, rankConstant, IS_LONG, 0, "60")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zvec_rrf_rerank, 0, 1, IS_ARRAY, 0)
+    ZEND_ARG_TYPE_INFO(0, queryResults, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+static const zend_function_entry zvec_rrf_reranker_methods[] = {
+    PHP_ME(ZVecRrfReRanker, __construct, arginfo_zvec_rrf___construct, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecRrfReRanker, rerank, arginfo_zvec_rrf_rerank, ZEND_ACC_PUBLIC)
+    PHP_FE_END
+};
+
+void zvec_register_rrf_reranker(INIT_FUNC_ARGS) {
+    zend_class_entry ce;
+    INIT_CLASS_ENTRY(ce, "ZVecRrfReRanker", zvec_rrf_reranker_methods);
+    zvec_rrf_reranker_ce = zend_register_internal_class(&ce);
+    zend_class_implements(zvec_rrf_reranker_ce, 1, zvec_reranker_ce);
+
+    zend_declare_property_long(zvec_rrf_reranker_ce, "topn", sizeof("topn") - 1, 10, ZEND_ACC_PUBLIC);
+    zend_declare_property_long(zvec_rrf_reranker_ce, "rankConstant", sizeof("rankConstant") - 1, 60, ZEND_ACC_PUBLIC);
+}

--- a/php-ext/zvec_rrf_reranker.h
+++ b/php-ext/zvec_rrf_reranker.h
@@ -1,0 +1,6 @@
+#ifndef ZVEC_RRF_RERANKER_H
+#define ZVEC_RRF_RERANKER_H
+
+#include "php_zvec.h"
+
+#endif

--- a/php-ext/zvec_schema.cc
+++ b/php-ext/zvec_schema.cc
@@ -1,0 +1,344 @@
+#include "zvec_schema.h"
+#include "zvec_exception.h"
+#include <zvec/db/schema.h>
+#include <zvec/db/index_params.h>
+#include <string>
+
+using namespace zvec;
+
+zend_class_entry *zvec_schema_ce = nullptr;
+static zend_object_handlers zvec_schema_handlers;
+
+static zend_object *zvec_schema_create_object_handler(zend_class_entry *ce) {
+    auto *intern = static_cast<zvec_schema_object *>(
+        ecalloc(1, sizeof(zvec_schema_object) + zend_object_properties_size(ce)));
+    intern->schema = nullptr;
+    zend_object_std_init(&intern->std, ce);
+    object_properties_init(&intern->std, ce);
+    intern->std.handlers = &zvec_schema_handlers;
+    return &intern->std;
+}
+
+static void zvec_schema_free_object(zend_object *obj) {
+    auto *intern = zvec_schema_from_obj(obj);
+    if (intern->schema) {
+        delete intern->schema;
+    }
+    intern->schema = nullptr;
+    zend_object_std_dtor(obj);
+}
+
+CollectionSchema *zvec_schema_get_native(zval *zv) {
+    return Z_ZVEC_SCHEMA_P(zv)->schema;
+}
+
+static MetricType to_metric_type(uint32_t v) {
+    switch (v) {
+        case 1: return MetricType::L2;
+        case 2: return MetricType::IP;
+        case 3: return MetricType::COSINE;
+        default: return MetricType::IP;
+    }
+}
+
+PHP_METHOD(ZVecSchema, __construct) {
+    char *name; size_t name_len;
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_STRING(name, name_len)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_SCHEMA_P(ZEND_THIS);
+    intern->schema = new CollectionSchema(std::string(name, name_len));
+}
+
+PHP_METHOD(ZVecSchema, setMaxDocCountPerSegment) {
+    zend_long count;
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_LONG(count)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_SCHEMA_P(ZEND_THIS);
+    intern->schema->set_max_doc_count_per_segment(static_cast<uint64_t>(count));
+    RETURN_ZVAL(ZEND_THIS, 1, 0);
+}
+
+PHP_METHOD(ZVecSchema, addInt64) {
+    char *name; size_t name_len;
+    zend_bool nullable = 0, with_invert_index = 0;
+    ZEND_PARSE_PARAMETERS_START(1, 3)
+        Z_PARAM_STRING(name, name_len)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_BOOL(nullable)
+        Z_PARAM_BOOL(with_invert_index)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_SCHEMA_P(ZEND_THIS);
+    if (with_invert_index) {
+        intern->schema->add_field(std::make_shared<FieldSchema>(
+            std::string(name, name_len), DataType::INT64, (bool)nullable,
+            std::make_shared<InvertIndexParams>(true)));
+    } else {
+        intern->schema->add_field(std::make_shared<FieldSchema>(
+            std::string(name, name_len), DataType::INT64, (bool)nullable));
+    }
+    RETURN_ZVAL(ZEND_THIS, 1, 0);
+}
+
+PHP_METHOD(ZVecSchema, addString) {
+    char *name; size_t name_len;
+    zend_bool nullable = 0, with_invert_index = 0;
+    ZEND_PARSE_PARAMETERS_START(1, 3)
+        Z_PARAM_STRING(name, name_len)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_BOOL(nullable)
+        Z_PARAM_BOOL(with_invert_index)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_SCHEMA_P(ZEND_THIS);
+    if (with_invert_index) {
+        intern->schema->add_field(std::make_shared<FieldSchema>(
+            std::string(name, name_len), DataType::STRING, (bool)nullable,
+            std::make_shared<InvertIndexParams>(false)));
+    } else {
+        intern->schema->add_field(std::make_shared<FieldSchema>(
+            std::string(name, name_len), DataType::STRING, (bool)nullable));
+    }
+    RETURN_ZVAL(ZEND_THIS, 1, 0);
+}
+
+PHP_METHOD(ZVecSchema, addFloat) {
+    char *name; size_t name_len;
+    zend_bool nullable = 1;
+    ZEND_PARSE_PARAMETERS_START(1, 2)
+        Z_PARAM_STRING(name, name_len)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_BOOL(nullable)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_SCHEMA_P(ZEND_THIS);
+    intern->schema->add_field(std::make_shared<FieldSchema>(
+        std::string(name, name_len), DataType::FLOAT, (bool)nullable));
+    RETURN_ZVAL(ZEND_THIS, 1, 0);
+}
+
+PHP_METHOD(ZVecSchema, addDouble) {
+    char *name; size_t name_len;
+    zend_bool nullable = 1;
+    ZEND_PARSE_PARAMETERS_START(1, 2)
+        Z_PARAM_STRING(name, name_len)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_BOOL(nullable)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_SCHEMA_P(ZEND_THIS);
+    intern->schema->add_field(std::make_shared<FieldSchema>(
+        std::string(name, name_len), DataType::DOUBLE, (bool)nullable));
+    RETURN_ZVAL(ZEND_THIS, 1, 0);
+}
+
+PHP_METHOD(ZVecSchema, addBool) {
+    char *name; size_t name_len;
+    zend_bool nullable = 0, with_invert_index = 0;
+    ZEND_PARSE_PARAMETERS_START(1, 3)
+        Z_PARAM_STRING(name, name_len)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_BOOL(nullable)
+        Z_PARAM_BOOL(with_invert_index)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_SCHEMA_P(ZEND_THIS);
+    if (with_invert_index) {
+        intern->schema->add_field(std::make_shared<FieldSchema>(
+            std::string(name, name_len), DataType::BOOL, (bool)nullable,
+            std::make_shared<InvertIndexParams>(true)));
+    } else {
+        intern->schema->add_field(std::make_shared<FieldSchema>(
+            std::string(name, name_len), DataType::BOOL, (bool)nullable));
+    }
+    RETURN_ZVAL(ZEND_THIS, 1, 0);
+}
+
+PHP_METHOD(ZVecSchema, addInt32) {
+    char *name; size_t name_len;
+    zend_bool nullable = 0, with_invert_index = 0;
+    ZEND_PARSE_PARAMETERS_START(1, 3)
+        Z_PARAM_STRING(name, name_len)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_BOOL(nullable)
+        Z_PARAM_BOOL(with_invert_index)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_SCHEMA_P(ZEND_THIS);
+    if (with_invert_index) {
+        intern->schema->add_field(std::make_shared<FieldSchema>(
+            std::string(name, name_len), DataType::INT32, (bool)nullable,
+            std::make_shared<InvertIndexParams>(true)));
+    } else {
+        intern->schema->add_field(std::make_shared<FieldSchema>(
+            std::string(name, name_len), DataType::INT32, (bool)nullable));
+    }
+    RETURN_ZVAL(ZEND_THIS, 1, 0);
+}
+
+PHP_METHOD(ZVecSchema, addUint32) {
+    char *name; size_t name_len;
+    zend_bool nullable = 0, with_invert_index = 0;
+    ZEND_PARSE_PARAMETERS_START(1, 3)
+        Z_PARAM_STRING(name, name_len)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_BOOL(nullable)
+        Z_PARAM_BOOL(with_invert_index)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_SCHEMA_P(ZEND_THIS);
+    if (with_invert_index) {
+        intern->schema->add_field(std::make_shared<FieldSchema>(
+            std::string(name, name_len), DataType::UINT32, (bool)nullable,
+            std::make_shared<InvertIndexParams>(true)));
+    } else {
+        intern->schema->add_field(std::make_shared<FieldSchema>(
+            std::string(name, name_len), DataType::UINT32, (bool)nullable));
+    }
+    RETURN_ZVAL(ZEND_THIS, 1, 0);
+}
+
+PHP_METHOD(ZVecSchema, addUint64) {
+    char *name; size_t name_len;
+    zend_bool nullable = 0, with_invert_index = 0;
+    ZEND_PARSE_PARAMETERS_START(1, 3)
+        Z_PARAM_STRING(name, name_len)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_BOOL(nullable)
+        Z_PARAM_BOOL(with_invert_index)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_SCHEMA_P(ZEND_THIS);
+    if (with_invert_index) {
+        intern->schema->add_field(std::make_shared<FieldSchema>(
+            std::string(name, name_len), DataType::UINT64, (bool)nullable,
+            std::make_shared<InvertIndexParams>(true)));
+    } else {
+        intern->schema->add_field(std::make_shared<FieldSchema>(
+            std::string(name, name_len), DataType::UINT64, (bool)nullable));
+    }
+    RETURN_ZVAL(ZEND_THIS, 1, 0);
+}
+
+PHP_METHOD(ZVecSchema, addVectorFp32) {
+    char *name; size_t name_len;
+    zend_long dimension, metric_type = 2;
+    ZEND_PARSE_PARAMETERS_START(2, 3)
+        Z_PARAM_STRING(name, name_len)
+        Z_PARAM_LONG(dimension)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_LONG(metric_type)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_SCHEMA_P(ZEND_THIS);
+    intern->schema->add_field(std::make_shared<FieldSchema>(
+        std::string(name, name_len), DataType::VECTOR_FP32,
+        static_cast<uint32_t>(dimension), false,
+        std::make_shared<HnswIndexParams>(to_metric_type(static_cast<uint32_t>(metric_type)))));
+    RETURN_ZVAL(ZEND_THIS, 1, 0);
+}
+
+PHP_METHOD(ZVecSchema, addVectorInt8) {
+    char *name; size_t name_len;
+    zend_long dimension, metric_type = 2;
+    ZEND_PARSE_PARAMETERS_START(2, 3)
+        Z_PARAM_STRING(name, name_len)
+        Z_PARAM_LONG(dimension)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_LONG(metric_type)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_SCHEMA_P(ZEND_THIS);
+    intern->schema->add_field(std::make_shared<FieldSchema>(
+        std::string(name, name_len), DataType::VECTOR_INT8,
+        static_cast<uint32_t>(dimension), false,
+        std::make_shared<HnswIndexParams>(to_metric_type(static_cast<uint32_t>(metric_type)))));
+    RETURN_ZVAL(ZEND_THIS, 1, 0);
+}
+
+PHP_METHOD(ZVecSchema, addVectorFp16) {
+    char *name; size_t name_len;
+    zend_long dimension, metric_type = 2;
+    ZEND_PARSE_PARAMETERS_START(2, 3)
+        Z_PARAM_STRING(name, name_len)
+        Z_PARAM_LONG(dimension)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_LONG(metric_type)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_SCHEMA_P(ZEND_THIS);
+    intern->schema->add_field(std::make_shared<FieldSchema>(
+        std::string(name, name_len), DataType::VECTOR_FP16,
+        static_cast<uint32_t>(dimension), false,
+        std::make_shared<HnswIndexParams>(to_metric_type(static_cast<uint32_t>(metric_type)))));
+    RETURN_ZVAL(ZEND_THIS, 1, 0);
+}
+
+PHP_METHOD(ZVecSchema, addSparseVectorFp32) {
+    char *name; size_t name_len;
+    zend_long metric_type = 2;
+    ZEND_PARSE_PARAMETERS_START(1, 2)
+        Z_PARAM_STRING(name, name_len)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_LONG(metric_type)
+    ZEND_PARSE_PARAMETERS_END();
+    auto *intern = Z_ZVEC_SCHEMA_P(ZEND_THIS);
+    intern->schema->add_field(std::make_shared<FieldSchema>(
+        std::string(name, name_len), DataType::SPARSE_VECTOR_FP32, 0, false,
+        std::make_shared<HnswIndexParams>(to_metric_type(static_cast<uint32_t>(metric_type)))));
+    RETURN_ZVAL(ZEND_THIS, 1, 0);
+}
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_zvec_schema___construct, 0, 0, 1)
+    ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_zvec_schema_fluent, 0, 1, ZVecSchema, 0)
+    ZEND_ARG_INFO(0, value)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_zvec_schema_add_field, 0, 1, ZVecSchema, 0)
+    ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, nullable, _IS_BOOL, 0, "false")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, withInvertIndex, _IS_BOOL, 0, "false")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_zvec_schema_add_float, 0, 1, ZVecSchema, 0)
+    ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, nullable, _IS_BOOL, 0, "true")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_zvec_schema_add_vector, 0, 2, ZVecSchema, 0)
+    ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+    ZEND_ARG_TYPE_INFO(0, dimension, IS_LONG, 0)
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, metricType, IS_LONG, 0, "2")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_zvec_schema_add_sparse, 0, 1, ZVecSchema, 0)
+    ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, metricType, IS_LONG, 0, "2")
+ZEND_END_ARG_INFO()
+
+static const zend_function_entry zvec_schema_methods[] = {
+    PHP_ME(ZVecSchema, __construct, arginfo_zvec_schema___construct, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecSchema, setMaxDocCountPerSegment, arginfo_zvec_schema_fluent, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecSchema, addInt64, arginfo_zvec_schema_add_field, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecSchema, addString, arginfo_zvec_schema_add_field, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecSchema, addFloat, arginfo_zvec_schema_add_float, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecSchema, addDouble, arginfo_zvec_schema_add_float, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecSchema, addBool, arginfo_zvec_schema_add_field, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecSchema, addInt32, arginfo_zvec_schema_add_field, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecSchema, addUint32, arginfo_zvec_schema_add_field, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecSchema, addUint64, arginfo_zvec_schema_add_field, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecSchema, addVectorFp32, arginfo_zvec_schema_add_vector, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecSchema, addVectorInt8, arginfo_zvec_schema_add_vector, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecSchema, addVectorFp16, arginfo_zvec_schema_add_vector, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecSchema, addSparseVectorFp32, arginfo_zvec_schema_add_sparse, ZEND_ACC_PUBLIC)
+    PHP_FE_END
+};
+
+void zvec_register_schema(INIT_FUNC_ARGS) {
+    zend_class_entry ce;
+    INIT_CLASS_ENTRY(ce, "ZVecSchema", zvec_schema_methods);
+    zvec_schema_ce = zend_register_internal_class(&ce);
+    zvec_schema_ce->create_object = zvec_schema_create_object_handler;
+
+    memcpy(&zvec_schema_handlers, &std_object_handlers, sizeof(zend_object_handlers));
+    zvec_schema_handlers.offset = XtOffsetOf(zvec_schema_object, std);
+    zvec_schema_handlers.free_obj = zvec_schema_free_object;
+
+    zend_declare_class_constant_long(zvec_schema_ce, "METRIC_L2", sizeof("METRIC_L2") - 1, 1);
+    zend_declare_class_constant_long(zvec_schema_ce, "METRIC_IP", sizeof("METRIC_IP") - 1, 2);
+    zend_declare_class_constant_long(zvec_schema_ce, "METRIC_COSINE", sizeof("METRIC_COSINE") - 1, 3);
+}

--- a/php-ext/zvec_schema.h
+++ b/php-ext/zvec_schema.h
@@ -1,0 +1,25 @@
+#ifndef ZVEC_SCHEMA_H
+#define ZVEC_SCHEMA_H
+
+#include "php_zvec.h"
+
+#pragma push_macro("IS_NULL")
+#undef IS_NULL
+#include <zvec/db/schema.h>
+#pragma pop_macro("IS_NULL")
+
+struct zvec_schema_object {
+    zvec::CollectionSchema *schema;
+    zend_object std;
+};
+
+static inline zvec_schema_object *zvec_schema_from_obj(zend_object *obj) {
+    return reinterpret_cast<zvec_schema_object *>(
+        reinterpret_cast<char *>(obj) - XtOffsetOf(zvec_schema_object, std));
+}
+
+#define Z_ZVEC_SCHEMA_P(zv) zvec_schema_from_obj(Z_OBJ_P(zv))
+
+zvec::CollectionSchema *zvec_schema_get_native(zval *zv);
+
+#endif

--- a/php-ext/zvec_vector_query.cc
+++ b/php-ext/zvec_vector_query.cc
@@ -1,0 +1,160 @@
+#include "zvec_vector_query.h"
+
+zend_class_entry *zvec_vector_query_ce = nullptr;
+
+PHP_METHOD(ZVecVectorQuery, __construct) {
+    char *field; size_t field_len;
+    zval *vector;
+    ZEND_PARSE_PARAMETERS_START(2, 2)
+        Z_PARAM_STRING(field, field_len)
+        Z_PARAM_ARRAY(vector)
+    ZEND_PARSE_PARAMETERS_END();
+
+    zend_update_property_stringl(zvec_vector_query_ce, Z_OBJ_P(ZEND_THIS), "fieldName", sizeof("fieldName") - 1, field, field_len);
+    zend_update_property(zvec_vector_query_ce, Z_OBJ_P(ZEND_THIS), "vector", sizeof("vector") - 1, vector);
+    zend_update_property_null(zvec_vector_query_ce, Z_OBJ_P(ZEND_THIS), "docId", sizeof("docId") - 1);
+    zend_update_property_long(zvec_vector_query_ce, Z_OBJ_P(ZEND_THIS), "queryParamType", sizeof("queryParamType") - 1, 0);
+    zend_update_property_long(zvec_vector_query_ce, Z_OBJ_P(ZEND_THIS), "hnswEf", sizeof("hnswEf") - 1, 200);
+    zend_update_property_long(zvec_vector_query_ce, Z_OBJ_P(ZEND_THIS), "ivfNprobe", sizeof("ivfNprobe") - 1, 10);
+    zend_update_property_double(zvec_vector_query_ce, Z_OBJ_P(ZEND_THIS), "radius", sizeof("radius") - 1, 0.0);
+    zend_update_property_bool(zvec_vector_query_ce, Z_OBJ_P(ZEND_THIS), "isLinear", sizeof("isLinear") - 1, 0);
+    zend_update_property_bool(zvec_vector_query_ce, Z_OBJ_P(ZEND_THIS), "isUsingRefiner", sizeof("isUsingRefiner") - 1, 0);
+}
+
+PHP_METHOD(ZVecVectorQuery, fromId) {
+    char *field; size_t field_len;
+    char *doc_id; size_t doc_id_len;
+    ZEND_PARSE_PARAMETERS_START(2, 2)
+        Z_PARAM_STRING(field, field_len)
+        Z_PARAM_STRING(doc_id, doc_id_len)
+    ZEND_PARSE_PARAMETERS_END();
+
+    object_init_ex(return_value, zvec_vector_query_ce);
+
+    zval empty_arr;
+    array_init(&empty_arr);
+    zend_update_property_stringl(zvec_vector_query_ce, Z_OBJ_P(return_value), "fieldName", sizeof("fieldName") - 1, field, field_len);
+    zend_update_property(zvec_vector_query_ce, Z_OBJ_P(return_value), "vector", sizeof("vector") - 1, &empty_arr);
+    zval_ptr_dtor(&empty_arr);
+    zend_update_property_stringl(zvec_vector_query_ce, Z_OBJ_P(return_value), "docId", sizeof("docId") - 1, doc_id, doc_id_len);
+    zend_update_property_long(zvec_vector_query_ce, Z_OBJ_P(return_value), "queryParamType", sizeof("queryParamType") - 1, 0);
+    zend_update_property_long(zvec_vector_query_ce, Z_OBJ_P(return_value), "hnswEf", sizeof("hnswEf") - 1, 200);
+    zend_update_property_long(zvec_vector_query_ce, Z_OBJ_P(return_value), "ivfNprobe", sizeof("ivfNprobe") - 1, 10);
+    zend_update_property_double(zvec_vector_query_ce, Z_OBJ_P(return_value), "radius", sizeof("radius") - 1, 0.0);
+    zend_update_property_bool(zvec_vector_query_ce, Z_OBJ_P(return_value), "isLinear", sizeof("isLinear") - 1, 0);
+    zend_update_property_bool(zvec_vector_query_ce, Z_OBJ_P(return_value), "isUsingRefiner", sizeof("isUsingRefiner") - 1, 0);
+}
+
+PHP_METHOD(ZVecVectorQuery, setHnswParams) {
+    zend_long ef;
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_LONG(ef)
+    ZEND_PARSE_PARAMETERS_END();
+    zend_update_property_long(zvec_vector_query_ce, Z_OBJ_P(ZEND_THIS), "queryParamType", sizeof("queryParamType") - 1, 1);
+    zend_update_property_long(zvec_vector_query_ce, Z_OBJ_P(ZEND_THIS), "hnswEf", sizeof("hnswEf") - 1, ef);
+    RETURN_ZVAL(ZEND_THIS, 1, 0);
+}
+
+PHP_METHOD(ZVecVectorQuery, setIvfParams) {
+    zend_long nprobe;
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_LONG(nprobe)
+    ZEND_PARSE_PARAMETERS_END();
+    zend_update_property_long(zvec_vector_query_ce, Z_OBJ_P(ZEND_THIS), "queryParamType", sizeof("queryParamType") - 1, 2);
+    zend_update_property_long(zvec_vector_query_ce, Z_OBJ_P(ZEND_THIS), "ivfNprobe", sizeof("ivfNprobe") - 1, nprobe);
+    RETURN_ZVAL(ZEND_THIS, 1, 0);
+}
+
+PHP_METHOD(ZVecVectorQuery, setFlatParams) {
+    ZEND_PARSE_PARAMETERS_NONE();
+    zend_update_property_long(zvec_vector_query_ce, Z_OBJ_P(ZEND_THIS), "queryParamType", sizeof("queryParamType") - 1, 3);
+    RETURN_ZVAL(ZEND_THIS, 1, 0);
+}
+
+PHP_METHOD(ZVecVectorQuery, setRadius) {
+    double radius;
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_DOUBLE(radius)
+    ZEND_PARSE_PARAMETERS_END();
+    zend_update_property_double(zvec_vector_query_ce, Z_OBJ_P(ZEND_THIS), "radius", sizeof("radius") - 1, radius);
+    RETURN_ZVAL(ZEND_THIS, 1, 0);
+}
+
+PHP_METHOD(ZVecVectorQuery, setLinear) {
+    zend_bool linear;
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_BOOL(linear)
+    ZEND_PARSE_PARAMETERS_END();
+    zend_update_property_bool(zvec_vector_query_ce, Z_OBJ_P(ZEND_THIS), "isLinear", sizeof("isLinear") - 1, linear);
+    RETURN_ZVAL(ZEND_THIS, 1, 0);
+}
+
+PHP_METHOD(ZVecVectorQuery, setUsingRefiner) {
+    zend_bool refiner;
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_BOOL(refiner)
+    ZEND_PARSE_PARAMETERS_END();
+    zend_update_property_bool(zvec_vector_query_ce, Z_OBJ_P(ZEND_THIS), "isUsingRefiner", sizeof("isUsingRefiner") - 1, refiner);
+    RETURN_ZVAL(ZEND_THIS, 1, 0);
+}
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_zvec_vq___construct, 0, 0, 2)
+    ZEND_ARG_TYPE_INFO(0, fieldName, IS_STRING, 0)
+    ZEND_ARG_TYPE_INFO(0, vector, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_zvec_vq_from_id, 0, 2, ZVecVectorQuery, 0)
+    ZEND_ARG_TYPE_INFO(0, fieldName, IS_STRING, 0)
+    ZEND_ARG_TYPE_INFO(0, docId, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_zvec_vq_set_hnsw, 0, 1, ZVecVectorQuery, 0)
+    ZEND_ARG_TYPE_INFO(0, ef, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_zvec_vq_set_ivf, 0, 1, ZVecVectorQuery, 0)
+    ZEND_ARG_TYPE_INFO(0, nprobe, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_zvec_vq_set_none, 0, 0, ZVecVectorQuery, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_zvec_vq_set_radius, 0, 1, ZVecVectorQuery, 0)
+    ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_zvec_vq_set_linear, 0, 1, ZVecVectorQuery, 0)
+    ZEND_ARG_TYPE_INFO(0, linear, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_zvec_vq_set_refiner, 0, 1, ZVecVectorQuery, 0)
+    ZEND_ARG_TYPE_INFO(0, refiner, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+static const zend_function_entry zvec_vector_query_methods[] = {
+    PHP_ME(ZVecVectorQuery, __construct, arginfo_zvec_vq___construct, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecVectorQuery, fromId, arginfo_zvec_vq_from_id, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+    PHP_ME(ZVecVectorQuery, setHnswParams, arginfo_zvec_vq_set_hnsw, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecVectorQuery, setIvfParams, arginfo_zvec_vq_set_ivf, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecVectorQuery, setFlatParams, arginfo_zvec_vq_set_none, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecVectorQuery, setRadius, arginfo_zvec_vq_set_radius, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecVectorQuery, setLinear, arginfo_zvec_vq_set_linear, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecVectorQuery, setUsingRefiner, arginfo_zvec_vq_set_refiner, ZEND_ACC_PUBLIC)
+    PHP_FE_END
+};
+
+void zvec_register_vector_query(INIT_FUNC_ARGS) {
+    zend_class_entry ce;
+    INIT_CLASS_ENTRY(ce, "ZVecVectorQuery", zvec_vector_query_methods);
+    zvec_vector_query_ce = zend_register_internal_class(&ce);
+
+    zend_declare_property_null(zvec_vector_query_ce, "fieldName", sizeof("fieldName") - 1, ZEND_ACC_PUBLIC);
+    zend_declare_property_null(zvec_vector_query_ce, "vector", sizeof("vector") - 1, ZEND_ACC_PUBLIC);
+    zend_declare_property_null(zvec_vector_query_ce, "docId", sizeof("docId") - 1, ZEND_ACC_PUBLIC);
+    zend_declare_property_long(zvec_vector_query_ce, "queryParamType", sizeof("queryParamType") - 1, 0, ZEND_ACC_PUBLIC);
+    zend_declare_property_long(zvec_vector_query_ce, "hnswEf", sizeof("hnswEf") - 1, 200, ZEND_ACC_PUBLIC);
+    zend_declare_property_long(zvec_vector_query_ce, "ivfNprobe", sizeof("ivfNprobe") - 1, 10, ZEND_ACC_PUBLIC);
+    zend_declare_property_double(zvec_vector_query_ce, "radius", sizeof("radius") - 1, 0.0, ZEND_ACC_PUBLIC);
+    zend_declare_property_bool(zvec_vector_query_ce, "isLinear", sizeof("isLinear") - 1, 0, ZEND_ACC_PUBLIC);
+    zend_declare_property_bool(zvec_vector_query_ce, "isUsingRefiner", sizeof("isUsingRefiner") - 1, 0, ZEND_ACC_PUBLIC);
+}

--- a/php-ext/zvec_vector_query.h
+++ b/php-ext/zvec_vector_query.h
@@ -1,0 +1,6 @@
+#ifndef ZVEC_VECTOR_QUERY_H
+#define ZVEC_VECTOR_QUERY_H
+
+#include "php_zvec.h"
+
+#endif

--- a/php-ext/zvec_weighted_reranker.cc
+++ b/php-ext/zvec_weighted_reranker.cc
@@ -1,0 +1,270 @@
+#include "zvec_weighted_reranker.h"
+#include <cfloat>
+
+zend_class_entry *zvec_weighted_reranker_ce = nullptr;
+
+PHP_METHOD(ZVecWeightedReRanker, __construct) {
+    zend_long topn = 10;
+    zend_long metric_type = 2;
+    zval *weights = nullptr;
+    ZEND_PARSE_PARAMETERS_START(0, 3)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_LONG(topn)
+        Z_PARAM_LONG(metric_type)
+        Z_PARAM_ARRAY(weights)
+    ZEND_PARSE_PARAMETERS_END();
+
+    zend_update_property_long(zvec_weighted_reranker_ce, Z_OBJ_P(ZEND_THIS), "topn", sizeof("topn") - 1, topn);
+    zend_update_property_long(zvec_weighted_reranker_ce, Z_OBJ_P(ZEND_THIS), "metricType", sizeof("metricType") - 1, metric_type);
+
+    if (weights) {
+        zend_update_property(zvec_weighted_reranker_ce, Z_OBJ_P(ZEND_THIS), "weights", sizeof("weights") - 1, weights);
+    } else {
+        zval empty;
+        array_init(&empty);
+        zend_update_property(zvec_weighted_reranker_ce, Z_OBJ_P(ZEND_THIS), "weights", sizeof("weights") - 1, &empty);
+        zval_ptr_dtor(&empty);
+    }
+}
+
+PHP_METHOD(ZVecWeightedReRanker, rerank) {
+    zval *query_results;
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_ARRAY(query_results)
+    ZEND_PARSE_PARAMETERS_END();
+
+    HashTable *ht = Z_ARRVAL_P(query_results);
+    if (zend_hash_num_elements(ht) == 0) {
+        array_init(return_value);
+        return;
+    }
+
+    zval *topn_zv = zend_read_property(zvec_weighted_reranker_ce, Z_OBJ_P(ZEND_THIS), "topn", sizeof("topn") - 1, 1, nullptr);
+    zval *mt_zv = zend_read_property(zvec_weighted_reranker_ce, Z_OBJ_P(ZEND_THIS), "metricType", sizeof("metricType") - 1, 1, nullptr);
+    zval *weights_zv = zend_read_property(zvec_weighted_reranker_ce, Z_OBJ_P(ZEND_THIS), "weights", sizeof("weights") - 1, 1, nullptr);
+    zend_long topn = Z_LVAL_P(topn_zv);
+    zend_long metric_type = Z_LVAL_P(mt_zv);
+
+    HashTable field_stats;
+    zend_hash_init(&field_stats, 8, nullptr, ZVAL_PTR_DTOR, 0);
+
+    HashTable all_docs;
+    zend_hash_init(&all_docs, 8, nullptr, ZVAL_PTR_DTOR, 0);
+
+    zend_string *field_name;
+    zval *docs_arr;
+    ZEND_HASH_FOREACH_STR_KEY_VAL(ht, field_name, docs_arr) {
+        if (Z_TYPE_P(docs_arr) != IS_ARRAY || !field_name) continue;
+
+        zval stats;
+        array_init(&stats);
+        zval min_val, max_val;
+        ZVAL_DOUBLE(&min_val, DBL_MAX);
+        ZVAL_DOUBLE(&max_val, -DBL_MAX);
+        zend_hash_str_update(Z_ARRVAL(stats), "min", sizeof("min") - 1, &min_val);
+        zend_hash_str_update(Z_ARRVAL(stats), "max", sizeof("max") - 1, &max_val);
+
+        zval field_docs;
+        array_init(&field_docs);
+
+        HashTable *docs_ht = Z_ARRVAL_P(docs_arr);
+        zend_long rank_idx = 0;
+        zval *doc_zv;
+        ZEND_HASH_FOREACH_VAL(docs_ht, doc_zv) {
+            if (Z_TYPE_P(doc_zv) != IS_OBJECT || !instanceof_function(Z_OBJCE_P(doc_zv), zvec_doc_ce)) {
+                rank_idx++;
+                continue;
+            }
+
+            zval pk_zv;
+            zend_call_method_with_0_params(Z_OBJ_P(doc_zv), Z_OBJCE_P(doc_zv), nullptr, "getpk", &pk_zv);
+            if (Z_TYPE(pk_zv) != IS_STRING) {
+                zval_ptr_dtor(&pk_zv);
+                rank_idx++;
+                continue;
+            }
+
+            zval score_zv;
+            zend_call_method_with_0_params(Z_OBJ_P(doc_zv), Z_OBJCE_P(doc_zv), nullptr, "getscore", &score_zv);
+            double score = (Z_TYPE(score_zv) == IS_DOUBLE) ? Z_DVAL(score_zv) : 0.0;
+            zval_ptr_dtor(&score_zv);
+
+            zval doc_entry;
+            array_init(&doc_entry);
+            Z_ADDREF_P(doc_zv);
+            zend_hash_str_update(Z_ARRVAL(doc_entry), "doc", sizeof("doc") - 1, doc_zv);
+            zval s;
+            ZVAL_DOUBLE(&s, score);
+            zend_hash_str_update(Z_ARRVAL(doc_entry), "score", sizeof("score") - 1, &s);
+            zval r;
+            ZVAL_LONG(&r, rank_idx + 1);
+            zend_hash_str_update(Z_ARRVAL(doc_entry), "rank", sizeof("rank") - 1, &r);
+
+            zend_hash_update(Z_ARRVAL(field_docs), Z_STR(pk_zv), &doc_entry);
+
+            zval *cur_min = zend_hash_str_find(Z_ARRVAL(stats), "min", sizeof("min") - 1);
+            zval *cur_max = zend_hash_str_find(Z_ARRVAL(stats), "max", sizeof("max") - 1);
+            if (score < Z_DVAL_P(cur_min)) ZVAL_DOUBLE(cur_min, score);
+            if (score > Z_DVAL_P(cur_max)) ZVAL_DOUBLE(cur_max, score);
+
+            zval_ptr_dtor(&pk_zv);
+            rank_idx++;
+        } ZEND_HASH_FOREACH_END();
+
+        zend_hash_update(&field_stats, field_name, &stats);
+        zend_hash_update(&all_docs, field_name, &field_docs);
+    } ZEND_HASH_FOREACH_END();
+
+    HashTable combined;
+    zend_hash_init(&combined, 32, nullptr, ZVAL_PTR_DTOR, 0);
+
+    ZEND_HASH_FOREACH_STR_KEY_VAL(&all_docs, field_name, docs_arr) {
+        if (!field_name) continue;
+
+        double weight = 0.0;
+        if (Z_TYPE_P(weights_zv) == IS_ARRAY) {
+            zval *w = zend_hash_find(Z_ARRVAL_P(weights_zv), field_name);
+            if (w) {
+                weight = (Z_TYPE_P(w) == IS_DOUBLE) ? Z_DVAL_P(w) : (double)Z_LVAL_P(w);
+            }
+        }
+        if (weight == 0.0) continue;
+
+        zval *stats = zend_hash_find(&field_stats, field_name);
+        double min_s = Z_DVAL_P(zend_hash_str_find(Z_ARRVAL_P(stats), "min", sizeof("min") - 1));
+        double max_s = Z_DVAL_P(zend_hash_str_find(Z_ARRVAL_P(stats), "max", sizeof("max") - 1));
+        double range = max_s - min_s;
+        if (range == 0.0) range = 1.0;
+
+        zend_string *pk;
+        zval *doc_entry;
+        ZEND_HASH_FOREACH_STR_KEY_VAL(Z_ARRVAL_P(docs_arr), pk, doc_entry) {
+            if (!pk) continue;
+            double score = Z_DVAL_P(zend_hash_str_find(Z_ARRVAL_P(doc_entry), "score", sizeof("score") - 1));
+            zval *doc_zv = zend_hash_str_find(Z_ARRVAL_P(doc_entry), "doc", sizeof("doc") - 1);
+            zend_long rank = Z_LVAL_P(zend_hash_str_find(Z_ARRVAL_P(doc_entry), "rank", sizeof("rank") - 1));
+
+            double normalized;
+            if (metric_type == 1) {
+                normalized = (max_s - score) / range;
+            } else {
+                normalized = (score - min_s) / range;
+            }
+
+            zval *existing = zend_hash_find(&combined, pk);
+            if (existing) {
+                zval *c = zend_hash_str_find(Z_ARRVAL_P(existing), "combined", sizeof("combined") - 1);
+                ZVAL_DOUBLE(c, Z_DVAL_P(c) + weight * normalized);
+                zval *ranks = zend_hash_str_find(Z_ARRVAL_P(existing), "ranks", sizeof("ranks") - 1);
+                zval rv;
+                ZVAL_LONG(&rv, rank);
+                zend_hash_update(Z_ARRVAL_P(ranks), field_name, &rv);
+                zval *scores = zend_hash_str_find(Z_ARRVAL_P(existing), "scores", sizeof("scores") - 1);
+                zval sv;
+                ZVAL_DOUBLE(&sv, score);
+                zend_hash_update(Z_ARRVAL_P(scores), field_name, &sv);
+            } else {
+                zval entry;
+                array_init(&entry);
+
+                zval c;
+                ZVAL_DOUBLE(&c, weight * normalized);
+                zend_hash_str_update(Z_ARRVAL(entry), "combined", sizeof("combined") - 1, &c);
+
+                zval ranks;
+                array_init(&ranks);
+                zval rv;
+                ZVAL_LONG(&rv, rank);
+                zend_hash_update(Z_ARRVAL(ranks), field_name, &rv);
+                zend_hash_str_update(Z_ARRVAL(entry), "ranks", sizeof("ranks") - 1, &ranks);
+
+                zval scores;
+                array_init(&scores);
+                zval sv;
+                ZVAL_DOUBLE(&sv, score);
+                zend_hash_update(Z_ARRVAL(scores), field_name, &sv);
+                zend_hash_str_update(Z_ARRVAL(entry), "scores", sizeof("scores") - 1, &scores);
+
+                Z_ADDREF_P(doc_zv);
+                zend_hash_str_update(Z_ARRVAL(entry), "doc", sizeof("doc") - 1, doc_zv);
+
+                zend_hash_update(&combined, pk, &entry);
+            }
+        } ZEND_HASH_FOREACH_END();
+    } ZEND_HASH_FOREACH_END();
+
+    zval reranked;
+    array_init(&reranked);
+
+    zval *entry;
+    ZEND_HASH_FOREACH_VAL(&combined, entry) {
+        zval *doc_zv = zend_hash_str_find(Z_ARRVAL_P(entry), "doc", sizeof("doc") - 1);
+        zval *c = zend_hash_str_find(Z_ARRVAL_P(entry), "combined", sizeof("combined") - 1);
+        zval *ranks = zend_hash_str_find(Z_ARRVAL_P(entry), "ranks", sizeof("ranks") - 1);
+        zval *scores = zend_hash_str_find(Z_ARRVAL_P(entry), "scores", sizeof("scores") - 1);
+
+        zval rd_obj;
+        object_init_ex(&rd_obj, zvec_reranked_doc_ce);
+        zend_update_property(zvec_reranked_doc_ce, Z_OBJ(rd_obj), "doc", sizeof("doc") - 1, doc_zv);
+        zend_update_property_double(zvec_reranked_doc_ce, Z_OBJ(rd_obj), "combinedScore", sizeof("combinedScore") - 1, Z_DVAL_P(c));
+        zend_update_property(zvec_reranked_doc_ce, Z_OBJ(rd_obj), "sourceRanks", sizeof("sourceRanks") - 1, ranks);
+        zend_update_property(zvec_reranked_doc_ce, Z_OBJ(rd_obj), "sourceScores", sizeof("sourceScores") - 1, scores);
+        add_next_index_zval(&reranked, &rd_obj);
+    } ZEND_HASH_FOREACH_END();
+
+    zend_hash_destroy(&field_stats);
+    zend_hash_destroy(&all_docs);
+    zend_hash_destroy(&combined);
+
+    HashTable *result_ht = Z_ARRVAL(reranked);
+    zend_hash_sort(result_ht, [](Bucket *a, Bucket *b) -> int {
+        zval *za = &a->val;
+        zval *zb = &b->val;
+        zval *sa = zend_read_property(zvec_reranked_doc_ce, Z_OBJ_P(za), "combinedScore", sizeof("combinedScore") - 1, 1, nullptr);
+        zval *sb = zend_read_property(zvec_reranked_doc_ce, Z_OBJ_P(zb), "combinedScore", sizeof("combinedScore") - 1, 1, nullptr);
+        double da = Z_DVAL_P(sa);
+        double db = Z_DVAL_P(sb);
+        if (db > da) return 1;
+        if (db < da) return -1;
+        return 0;
+    }, 1);
+
+    array_init(return_value);
+    zend_long count = 0;
+    zval *item;
+    ZEND_HASH_FOREACH_VAL(result_ht, item) {
+        if (count >= topn) break;
+        Z_ADDREF_P(item);
+        add_next_index_zval(return_value, item);
+        count++;
+    } ZEND_HASH_FOREACH_END();
+
+    zval_ptr_dtor(&reranked);
+}
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_zvec_wr___construct, 0, 0, 0)
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, topn, IS_LONG, 0, "10")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, metricType, IS_LONG, 0, "2")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, weights, IS_ARRAY, 0, "[]")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zvec_wr_rerank, 0, 1, IS_ARRAY, 0)
+    ZEND_ARG_TYPE_INFO(0, queryResults, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+static const zend_function_entry zvec_weighted_reranker_methods[] = {
+    PHP_ME(ZVecWeightedReRanker, __construct, arginfo_zvec_wr___construct, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecWeightedReRanker, rerank, arginfo_zvec_wr_rerank, ZEND_ACC_PUBLIC)
+    PHP_FE_END
+};
+
+void zvec_register_weighted_reranker(INIT_FUNC_ARGS) {
+    zend_class_entry ce;
+    INIT_CLASS_ENTRY(ce, "ZVecWeightedReRanker", zvec_weighted_reranker_methods);
+    zvec_weighted_reranker_ce = zend_register_internal_class(&ce);
+    zend_class_implements(zvec_weighted_reranker_ce, 1, zvec_reranker_ce);
+
+    zend_declare_property_long(zvec_weighted_reranker_ce, "topn", sizeof("topn") - 1, 10, ZEND_ACC_PUBLIC);
+    zend_declare_property_long(zvec_weighted_reranker_ce, "metricType", sizeof("metricType") - 1, 2, ZEND_ACC_PUBLIC);
+    zend_declare_property_null(zvec_weighted_reranker_ce, "weights", sizeof("weights") - 1, ZEND_ACC_PUBLIC);
+}

--- a/php-ext/zvec_weighted_reranker.h
+++ b/php-ext/zvec_weighted_reranker.h
@@ -1,0 +1,6 @@
+#ifndef ZVEC_WEIGHTED_RERANKER_H
+#define ZVEC_WEIGHTED_RERANKER_H
+
+#include "php_zvec.h"
+
+#endif

--- a/php/ZVec.php
+++ b/php/ZVec.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+if (extension_loaded('zvec')) return;
+
 class ZVecException extends RuntimeException {}
 
 class ZVec

--- a/php/ZVecReRanker.php
+++ b/php/ZVecReRanker.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+if (extension_loaded('zvec')) return;
+
 /**
  * Interface for rerankers that post-process vector search results.
  * 

--- a/php/ZVecRerankedDoc.php
+++ b/php/ZVecRerankedDoc.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+if (extension_loaded('zvec')) return;
+
 /**
  * Reranked document result containing the original document and combined score.
  * 

--- a/php/ZVecRrfReRanker.php
+++ b/php/ZVecRrfReRanker.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+if (extension_loaded('zvec')) return;
+
 require_once __DIR__ . '/ZVecReRanker.php';
 require_once __DIR__ . '/ZVecRerankedDoc.php';
 

--- a/php/ZVecWeightedReRanker.php
+++ b/php/ZVecWeightedReRanker.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+if (extension_loaded('zvec')) return;
+
 require_once __DIR__ . '/ZVecReRanker.php';
 require_once __DIR__ . '/ZVecRerankedDoc.php';
 

--- a/php/embeddings.php
+++ b/php/embeddings.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+if (extension_loaded('zvec')) return;
+
 /**
  * ZVec PHP Embeddings
  *

--- a/php/embeddings/EmbeddingInterfaces.php
+++ b/php/embeddings/EmbeddingInterfaces.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+if (extension_loaded('zvec')) return;
+
 /**
  * Interface for dense embedding functions.
  * Converts text input into dense vector representations.

--- a/php/embeddings/OpenAIDenseEmbedding.php
+++ b/php/embeddings/OpenAIDenseEmbedding.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+if (extension_loaded('zvec')) return;
+
 require_once __DIR__ . '/EmbeddingInterfaces.php';
 
 /**

--- a/php/embeddings/QwenDenseEmbedding.php
+++ b/php/embeddings/QwenDenseEmbedding.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+if (extension_loaded('zvec')) return;
+
 require_once __DIR__ . '/EmbeddingInterfaces.php';
 
 /**


### PR DESCRIPTION
- Add php_zvec.h with module entry, class entries, and registration declarations
- Implement zvec.cc module init/shutdown/info with class registration
- Add zvec_collection.cc with complete Collection wrapper: create, open, close, destroy
- Support CRUD operations: insert, upsert, update, delete, fetch
- Support batch operations: insertBatch, upsertBatch, updateBatch with per-doc status
- Implement vector query with HNSW/IVF/Flat params, filters, output fields, rerankers
- Add column DDL: addColumn{Int64,Float,Double,String,Bool,Int32,Uint32,Uint64}, dropColumn, renameColumn, alterColumn
- Add index DDL: createInvertIndex, createHnswIndex, createFlatIndex, createIvfIndex, dropIndex
- Include schema, path, options, stats, flush, optimize methods
- Add zvec_exception.h and zvec_vector_query.h headers