### PR TITLE
chore: upgrade zvec to v0.4.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,15 +31,26 @@ jobs:
             autoconf automake libtool \
             curl binutils
 
-      - name: Download prebuilt zvec
+      - name: Setup zvec ${{ env.ZVEC_VERSION }}
         run: |
           URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${ZVEC_BUILD_RELEASE}/zvec-${ZVEC_VERSION}-ubuntu24-x86_64.tar.gz"
-          echo "Downloading: $URL"
-          curl -fL "$URL" -o /tmp/zvec.tar.gz
-
-          rm -rf zvec
-          tar -xzf /tmp/zvec.tar.gz
-
+          echo "Trying prebuilt: $URL"
+          if curl -fL --connect-timeout 10 "$URL" -o /tmp/zvec.tar.gz 2>/dev/null; then
+            echo "Prebuilt zvec ${ZVEC_VERSION} downloaded"
+            rm -rf zvec
+            tar -xzf /tmp/zvec.tar.gz
+            rm /tmp/zvec.tar.gz
+          else
+            echo "Prebuilt not found. Building zvec ${ZVEC_VERSION} from source..."
+            if [ ! -d zvec ]; then
+              git clone --recurse-submodules --branch "$ZVEC_VERSION" \
+                https://github.com/alibaba/zvec.git zvec
+            fi
+            cmake -S zvec -B zvec/build \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+            cmake --build zvec/build -j$(nproc)
+          fi
           test -f zvec/build/lib/libzvec_db.a
           test -d zvec/src/include
           test -d zvec/thirdparty/sparsehash/sparsehash-2.0.4/src
@@ -67,18 +78,8 @@ jobs:
             -Wl,--whole-archive \
               $ZVEC_LIB/libzvec_db.a \
               $ZVEC_LIB/libzvec_ailego.a \
-              $ZVEC_LIB/libcore_metric.a \
-              $ZVEC_LIB/libcore_knn_hnsw.a \
-              $ZVEC_LIB/libcore_knn_hnsw_sparse.a \
-              $ZVEC_LIB/libcore_knn_flat.a \
-              $ZVEC_LIB/libcore_knn_flat_sparse.a \
-              $ZVEC_LIB/libcore_knn_ivf.a \
-              $ZVEC_LIB/libcore_knn_cluster.a \
-              $ZVEC_LIB/libcore_quantizer.a \
-              $ZVEC_LIB/libcore_utility.a \
-              $ZVEC_LIB/libcore_mix_reducer.a \
-              $ZVEC_LIB/libcore_framework.a \
-              $ZVEC_LIB/libcore_interface.a \
+              $ZVEC_LIB/libzvec_core.a \
+              $ZVEC_LIB/libzvec_turbo.a \
               $ZVEC_EXT_LIB/*.a \
             -Wl,--no-whole-archive \
             -lssl -lcrypto -lstdc++ -lz -lpthread -ldl \
@@ -123,15 +124,26 @@ jobs:
             libssl-dev libz-dev \
             curl
 
-      - name: Download prebuilt zvec
+      - name: Setup zvec ${{ env.ZVEC_VERSION }}
         run: |
           URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${ZVEC_BUILD_RELEASE}/zvec-${ZVEC_VERSION}-ubuntu24-x86_64.tar.gz"
-          echo "Downloading: $URL"
-          curl -fL "$URL" -o /tmp/zvec.tar.gz
-
-          rm -rf zvec
-          tar -xzf /tmp/zvec.tar.gz
-
+          echo "Trying prebuilt: $URL"
+          if curl -fL --connect-timeout 10 "$URL" -o /tmp/zvec.tar.gz 2>/dev/null; then
+            echo "Prebuilt zvec ${ZVEC_VERSION} downloaded"
+            rm -rf zvec
+            tar -xzf /tmp/zvec.tar.gz
+            rm /tmp/zvec.tar.gz
+          else
+            echo "Prebuilt not found. Building zvec ${ZVEC_VERSION} from source..."
+            if [ ! -d zvec ]; then
+              git clone --recurse-submodules --branch "$ZVEC_VERSION" \
+                https://github.com/alibaba/zvec.git zvec
+            fi
+            cmake -S zvec -B zvec/build \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+            cmake --build zvec/build -j$(nproc)
+          fi
           test -f zvec/build/lib/libzvec_db.a
           test -d zvec/src/include
           test -d zvec/thirdparty/sparsehash/sparsehash-2.0.4/src

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,8 @@ on:
     branches: [main]
 
 env:
-  ZVEC_VERSION: v0.2.0
-  ZVEC_BUILD_RELEASE: zvec-build-v0.2.0
+  ZVEC_VERSION: v0.4.0
+  ZVEC_BUILD_RELEASE: zvec-build-v0.4.0
 
 jobs:
   build-ext:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,58 +9,7 @@ env:
   ZVEC_BUILD_RELEASE: zvec-build-v0.4.0
 
 jobs:
-  setup-zvec:
-    runs-on: ubuntu-24.04
-    name: setup zvec ${{ env.ZVEC_VERSION }}
-
-    steps:
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            build-essential cmake g++ \
-            libssl-dev libz-dev \
-            curl git
-
-      - name: Setup zvec
-        run: |
-          URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${ZVEC_BUILD_RELEASE}/zvec-${ZVEC_VERSION}-ubuntu24-x86_64.tar.gz"
-          echo "Trying prebuilt: $URL"
-          if curl -fL --connect-timeout 10 "$URL" -o /tmp/zvec.tar.gz 2>/dev/null; then
-            echo "Prebuilt zvec ${ZVEC_VERSION} downloaded"
-            mkdir -p zvec
-            tar -xzf /tmp/zvec.tar.gz
-            rm /tmp/zvec.tar.gz
-          else
-            echo "Prebuilt not found. Building zvec ${ZVEC_VERSION} from source..."
-            git clone --recurse-submodules --branch "$ZVEC_VERSION" \
-              https://github.com/alibaba/zvec.git zvec
-            cmake -S zvec -B zvec/build \
-              -DCMAKE_BUILD_TYPE=Release \
-              -DCMAKE_POLICY_VERSION_MINIMUM=3.5
-            cmake --build zvec/build -j$(nproc)
-          fi
-          test -f zvec/build/lib/libzvec_db.a
-          test -d zvec/src/include
-          test -d zvec/thirdparty/sparsehash/sparsehash-2.0.4/src
-
-      - name: Package zvec artifact
-        run: |
-          tar -czf zvec-built.tar.gz \
-            zvec/build/lib \
-            zvec/build/external/usr/local/lib \
-            zvec/src/include \
-            zvec/thirdparty/sparsehash
-          echo "zvec packaged: $(du -h zvec-built.tar.gz | cut -f1)"
-
-      - name: Upload zvec artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: zvec-built
-          path: zvec-built.tar.gz
-
   build-ext:
-    needs: setup-zvec
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-24.04
     strategy:
@@ -82,16 +31,29 @@ jobs:
             autoconf automake libtool \
             curl binutils
 
-      - name: Download zvec artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: zvec-built
-
-      - name: Extract zvec
+      - name: Setup zvec ${{ env.ZVEC_VERSION }}
         run: |
-          tar -xzf zvec-built.tar.gz
+          URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${ZVEC_BUILD_RELEASE}/zvec-${ZVEC_VERSION}-ubuntu24-x86_64.tar.gz"
+          echo "Trying prebuilt: $URL"
+          if curl -fL --connect-timeout 10 "$URL" -o /tmp/zvec.tar.gz 2>/dev/null; then
+            echo "Prebuilt zvec ${ZVEC_VERSION} downloaded"
+            rm -rf zvec
+            tar -xzf /tmp/zvec.tar.gz
+            rm /tmp/zvec.tar.gz
+          else
+            echo "Prebuilt not found. Building zvec ${ZVEC_VERSION} from source..."
+            if [ ! -d zvec ]; then
+              git clone --recurse-submodules --branch "$ZVEC_VERSION" \
+                https://github.com/alibaba/zvec.git zvec
+            fi
+            cmake -S zvec -B zvec/build \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+            cmake --build zvec/build -j$(nproc)
+          fi
           test -f zvec/build/lib/libzvec_db.a
           test -d zvec/src/include
+          test -d zvec/thirdparty/sparsehash/sparsehash-2.0.4/src
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -142,7 +104,6 @@ jobs:
           path: php-ext/modules/zvec.so
 
   build-ffi:
-    needs: setup-zvec
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-24.04
     strategy:
@@ -163,16 +124,29 @@ jobs:
             libssl-dev libz-dev \
             curl
 
-      - name: Download zvec artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: zvec-built
-
-      - name: Extract zvec
+      - name: Setup zvec ${{ env.ZVEC_VERSION }}
         run: |
-          tar -xzf zvec-built.tar.gz
+          URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${ZVEC_BUILD_RELEASE}/zvec-${ZVEC_VERSION}-ubuntu24-x86_64.tar.gz"
+          echo "Trying prebuilt: $URL"
+          if curl -fL --connect-timeout 10 "$URL" -o /tmp/zvec.tar.gz 2>/dev/null; then
+            echo "Prebuilt zvec ${ZVEC_VERSION} downloaded"
+            rm -rf zvec
+            tar -xzf /tmp/zvec.tar.gz
+            rm /tmp/zvec.tar.gz
+          else
+            echo "Prebuilt not found. Building zvec ${ZVEC_VERSION} from source..."
+            if [ ! -d zvec ]; then
+              git clone --recurse-submodules --branch "$ZVEC_VERSION" \
+                https://github.com/alibaba/zvec.git zvec
+            fi
+            cmake -S zvec -B zvec/build \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+            cmake --build zvec/build -j$(nproc)
+          fi
           test -f zvec/build/lib/libzvec_db.a
           test -d zvec/src/include
+          test -d zvec/thirdparty/sparsehash/sparsehash-2.0.4/src
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,6 @@ env:
 
 jobs:
   setup-zvec:
-    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-24.04
     name: setup zvec ${{ env.ZVEC_VERSION }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,9 +14,6 @@ jobs:
     runs-on: ubuntu-24.04
     name: setup zvec ${{ env.ZVEC_VERSION }}
 
-    permissions:
-      contents: write
-
     steps:
       - name: Install system dependencies
         run: |
@@ -24,10 +21,9 @@ jobs:
           sudo apt-get install -y \
             build-essential cmake g++ \
             libssl-dev libz-dev \
-            curl rsync git
+            curl git
 
       - name: Setup zvec
-        id: setup
         run: |
           URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${ZVEC_BUILD_RELEASE}/zvec-${ZVEC_VERSION}-ubuntu24-x86_64.tar.gz"
           echo "Trying prebuilt: $URL"
@@ -36,7 +32,6 @@ jobs:
             mkdir -p zvec
             tar -xzf /tmp/zvec.tar.gz
             rm /tmp/zvec.tar.gz
-            echo "built=false" >> "$GITHUB_OUTPUT"
           else
             echo "Prebuilt not found. Building zvec ${ZVEC_VERSION} from source..."
             git clone --recurse-submodules --branch "$ZVEC_VERSION" \
@@ -45,41 +40,19 @@ jobs:
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_POLICY_VERSION_MINIMUM=3.5
             cmake --build zvec/build -j$(nproc)
-            echo "built=true" >> "$GITHUB_OUTPUT"
           fi
           test -f zvec/build/lib/libzvec_db.a
           test -d zvec/src/include
           test -d zvec/thirdparty/sparsehash/sparsehash-2.0.4/src
 
-      - name: Upload built zvec for future builds
-        if: steps.setup.outputs.built == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Package zvec artifact
         run: |
-          echo "Packaging zvec ${ZVEC_VERSION} for reuse by future CI runs"
-          TARBALL="zvec-${ZVEC_VERSION}-ubuntu24-x86_64.tar.gz"
-          PKG=$(mktemp -d)
-          mkdir -p "$PKG/zvec/src"
-          mkdir -p "$PKG/zvec/thirdparty/sparsehash/sparsehash-2.0.4"
-          mkdir -p "$PKG/zvec/build/external/usr/local"
-          rsync -a zvec/src/include                                "$PKG/zvec/src/"
-          rsync -a zvec/thirdparty/sparsehash/sparsehash-2.0.4/src "$PKG/zvec/thirdparty/sparsehash/sparsehash-2.0.4/"
-          rsync -a zvec/build/lib                                   "$PKG/zvec/build/"
-          rsync -a zvec/build/external/usr/local/lib                "$PKG/zvec/build/external/usr/local/"
-          tar -czf "$TARBALL" -C "$PKG" zvec
-          rm -rf "$PKG"
-          gh release create "$ZVEC_BUILD_RELEASE" \
-            --repo "${{ github.repository }}" \
-            --title "zvec ${ZVEC_VERSION} build artifacts" \
-            --notes "Pre-built zvec ${ZVEC_VERSION} library for ubuntu-24.04." \
-            || echo "Release ${ZVEC_BUILD_RELEASE} already exists"
-          gh release upload "$ZVEC_BUILD_RELEASE" "$TARBALL" --clobber
-
-      - name: Package zvec for artifact
-        run: |
-          TARBALL="zvec-built.tar.gz"
-          tar -czf "$TARBALL" zvec/build/lib zvec/build/external/usr/local/lib zvec/src/include zvec/thirdparty/sparsehash
-          echo "zvec packaged: $(du -h $TARBALL | cut -f1)"
+          tar -czf zvec-built.tar.gz \
+            zvec/build/lib \
+            zvec/build/external/usr/local/lib \
+            zvec/src/include \
+            zvec/thirdparty/sparsehash
+          echo "zvec packaged: $(du -h zvec-built.tar.gz | cut -f1)"
 
       - name: Upload zvec artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,86 @@ env:
   ZVEC_BUILD_RELEASE: zvec-build-v0.4.0
 
 jobs:
+  setup-zvec:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-24.04
+    name: setup zvec ${{ env.ZVEC_VERSION }}
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential cmake g++ \
+            libssl-dev libz-dev \
+            curl rsync git
+
+      - name: Setup zvec
+        id: setup
+        run: |
+          URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${ZVEC_BUILD_RELEASE}/zvec-${ZVEC_VERSION}-ubuntu24-x86_64.tar.gz"
+          echo "Trying prebuilt: $URL"
+          if curl -fL --connect-timeout 10 "$URL" -o /tmp/zvec.tar.gz 2>/dev/null; then
+            echo "Prebuilt zvec ${ZVEC_VERSION} downloaded"
+            mkdir -p zvec
+            tar -xzf /tmp/zvec.tar.gz
+            rm /tmp/zvec.tar.gz
+            echo "built=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Prebuilt not found. Building zvec ${ZVEC_VERSION} from source..."
+            git clone --recurse-submodules --branch "$ZVEC_VERSION" \
+              https://github.com/alibaba/zvec.git zvec
+            cmake -S zvec -B zvec/build \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+            cmake --build zvec/build -j$(nproc)
+            echo "built=true" >> "$GITHUB_OUTPUT"
+          fi
+          test -f zvec/build/lib/libzvec_db.a
+          test -d zvec/src/include
+          test -d zvec/thirdparty/sparsehash/sparsehash-2.0.4/src
+
+      - name: Upload built zvec for future builds
+        if: steps.setup.outputs.built == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "Packaging zvec ${ZVEC_VERSION} for reuse by future CI runs"
+          TARBALL="zvec-${ZVEC_VERSION}-ubuntu24-x86_64.tar.gz"
+          PKG=$(mktemp -d)
+          mkdir -p "$PKG/zvec/src"
+          mkdir -p "$PKG/zvec/thirdparty/sparsehash/sparsehash-2.0.4"
+          mkdir -p "$PKG/zvec/build/external/usr/local"
+          rsync -a zvec/src/include                                "$PKG/zvec/src/"
+          rsync -a zvec/thirdparty/sparsehash/sparsehash-2.0.4/src "$PKG/zvec/thirdparty/sparsehash/sparsehash-2.0.4/"
+          rsync -a zvec/build/lib                                   "$PKG/zvec/build/"
+          rsync -a zvec/build/external/usr/local/lib                "$PKG/zvec/build/external/usr/local/"
+          tar -czf "$TARBALL" -C "$PKG" zvec
+          rm -rf "$PKG"
+          gh release create "$ZVEC_BUILD_RELEASE" \
+            --repo "${{ github.repository }}" \
+            --title "zvec ${ZVEC_VERSION} build artifacts" \
+            --notes "Pre-built zvec ${ZVEC_VERSION} library for ubuntu-24.04." \
+            || echo "Release ${ZVEC_BUILD_RELEASE} already exists"
+          gh release upload "$ZVEC_BUILD_RELEASE" "$TARBALL" --clobber
+
+      - name: Package zvec for artifact
+        run: |
+          TARBALL="zvec-built.tar.gz"
+          tar -czf "$TARBALL" zvec/build/lib zvec/build/external/usr/local/lib zvec/src/include zvec/thirdparty/sparsehash
+          echo "zvec packaged: $(du -h $TARBALL | cut -f1)"
+
+      - name: Upload zvec artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: zvec-built
+          path: zvec-built.tar.gz
+
   build-ext:
+    needs: setup-zvec
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-24.04
     strategy:
@@ -31,29 +110,16 @@ jobs:
             autoconf automake libtool \
             curl binutils
 
-      - name: Setup zvec ${{ env.ZVEC_VERSION }}
+      - name: Download zvec artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: zvec-built
+
+      - name: Extract zvec
         run: |
-          URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${ZVEC_BUILD_RELEASE}/zvec-${ZVEC_VERSION}-ubuntu24-x86_64.tar.gz"
-          echo "Trying prebuilt: $URL"
-          if curl -fL --connect-timeout 10 "$URL" -o /tmp/zvec.tar.gz 2>/dev/null; then
-            echo "Prebuilt zvec ${ZVEC_VERSION} downloaded"
-            rm -rf zvec
-            tar -xzf /tmp/zvec.tar.gz
-            rm /tmp/zvec.tar.gz
-          else
-            echo "Prebuilt not found. Building zvec ${ZVEC_VERSION} from source..."
-            if [ ! -d zvec ]; then
-              git clone --recurse-submodules --branch "$ZVEC_VERSION" \
-                https://github.com/alibaba/zvec.git zvec
-            fi
-            cmake -S zvec -B zvec/build \
-              -DCMAKE_BUILD_TYPE=Release \
-              -DCMAKE_POLICY_VERSION_MINIMUM=3.5
-            cmake --build zvec/build -j$(nproc)
-          fi
+          tar -xzf zvec-built.tar.gz
           test -f zvec/build/lib/libzvec_db.a
           test -d zvec/src/include
-          test -d zvec/thirdparty/sparsehash/sparsehash-2.0.4/src
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -104,6 +170,7 @@ jobs:
           path: php-ext/modules/zvec.so
 
   build-ffi:
+    needs: setup-zvec
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-24.04
     strategy:
@@ -124,29 +191,16 @@ jobs:
             libssl-dev libz-dev \
             curl
 
-      - name: Setup zvec ${{ env.ZVEC_VERSION }}
+      - name: Download zvec artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: zvec-built
+
+      - name: Extract zvec
         run: |
-          URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${ZVEC_BUILD_RELEASE}/zvec-${ZVEC_VERSION}-ubuntu24-x86_64.tar.gz"
-          echo "Trying prebuilt: $URL"
-          if curl -fL --connect-timeout 10 "$URL" -o /tmp/zvec.tar.gz 2>/dev/null; then
-            echo "Prebuilt zvec ${ZVEC_VERSION} downloaded"
-            rm -rf zvec
-            tar -xzf /tmp/zvec.tar.gz
-            rm /tmp/zvec.tar.gz
-          else
-            echo "Prebuilt not found. Building zvec ${ZVEC_VERSION} from source..."
-            if [ ! -d zvec ]; then
-              git clone --recurse-submodules --branch "$ZVEC_VERSION" \
-                https://github.com/alibaba/zvec.git zvec
-            fi
-            cmake -S zvec -B zvec/build \
-              -DCMAKE_BUILD_TYPE=Release \
-              -DCMAKE_POLICY_VERSION_MINIMUM=3.5
-            cmake --build zvec/build -j$(nproc)
-          fi
+          tar -xzf zvec-built.tar.gz
           test -f zvec/build/lib/libzvec_db.a
           test -d zvec/src/include
-          test -d zvec/thirdparty/sparsehash/sparsehash-2.0.4/src
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,86 @@ jobs:
             --generate-notes \
             || echo "Release already exists"
 
-  release-ffi:
+  setup-zvec:
     needs: create-release
+    runs-on: ubuntu-24.04
+    name: setup zvec ${{ env.ZVEC_VERSION }}
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential cmake g++ \
+            libssl-dev libz-dev \
+            curl rsync git
+
+      - name: Setup zvec
+        id: setup
+        run: |
+          URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${ZVEC_BUILD_RELEASE}/zvec-${ZVEC_VERSION}-ubuntu24-x86_64.tar.gz"
+          echo "Trying prebuilt: $URL"
+          if curl -fL --connect-timeout 10 "$URL" -o /tmp/zvec.tar.gz 2>/dev/null; then
+            echo "Prebuilt zvec ${ZVEC_VERSION} downloaded"
+            mkdir -p zvec
+            tar -xzf /tmp/zvec.tar.gz
+            rm /tmp/zvec.tar.gz
+            echo "built=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Prebuilt not found. Building zvec ${ZVEC_VERSION} from source..."
+            git clone --recurse-submodules --branch "$ZVEC_VERSION" \
+              https://github.com/alibaba/zvec.git zvec
+            cmake -S zvec -B zvec/build \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+            cmake --build zvec/build -j$(nproc)
+            echo "built=true" >> "$GITHUB_OUTPUT"
+          fi
+          test -f zvec/build/lib/libzvec_db.a
+          test -d zvec/src/include
+          test -d zvec/thirdparty/sparsehash/sparsehash-2.0.4/src
+
+      - name: Upload built zvec for future builds
+        if: steps.setup.outputs.built == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "Packaging zvec ${ZVEC_VERSION} for reuse by future CI runs"
+          TARBALL="zvec-${ZVEC_VERSION}-ubuntu24-x86_64.tar.gz"
+          PKG=$(mktemp -d)
+          mkdir -p "$PKG/zvec/src"
+          mkdir -p "$PKG/zvec/thirdparty/sparsehash/sparsehash-2.0.4"
+          mkdir -p "$PKG/zvec/build/external/usr/local"
+          rsync -a zvec/src/include                                "$PKG/zvec/src/"
+          rsync -a zvec/thirdparty/sparsehash/sparsehash-2.0.4/src "$PKG/zvec/thirdparty/sparsehash/sparsehash-2.0.4/"
+          rsync -a zvec/build/lib                                   "$PKG/zvec/build/"
+          rsync -a zvec/build/external/usr/local/lib                "$PKG/zvec/build/external/usr/local/"
+          tar -czf "$TARBALL" -C "$PKG" zvec
+          rm -rf "$PKG"
+          gh release create "$ZVEC_BUILD_RELEASE" \
+            --repo "${{ github.repository }}" \
+            --title "zvec ${ZVEC_VERSION} build artifacts" \
+            --notes "Pre-built zvec ${ZVEC_VERSION} library for ubuntu-24.04." \
+            || echo "Release ${ZVEC_BUILD_RELEASE} already exists"
+          gh release upload "$ZVEC_BUILD_RELEASE" "$TARBALL" --clobber
+
+      - name: Package zvec for artifact
+        run: |
+          TARBALL="zvec-built.tar.gz"
+          tar -czf "$TARBALL" zvec/build/lib zvec/build/external/usr/local/lib zvec/src/include zvec/thirdparty/sparsehash
+          echo "zvec packaged: $(du -h $TARBALL | cut -f1)"
+
+      - name: Upload zvec artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: zvec-built
+          path: zvec-built.tar.gz
+
+  release-ffi:
+    needs: [create-release, setup-zvec]
     runs-on: ubuntu-24.04
     name: Build & Release FFI Library
 
@@ -56,29 +134,16 @@ jobs:
             libssl-dev libz-dev \
             curl binutils
 
-      - name: Setup zvec ${{ env.ZVEC_VERSION }}
+      - name: Download zvec artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: zvec-built
+
+      - name: Extract zvec
         run: |
-          URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${ZVEC_BUILD_RELEASE}/zvec-${ZVEC_VERSION}-ubuntu24-x86_64.tar.gz"
-          echo "Trying prebuilt: $URL"
-          if curl -fL --connect-timeout 10 "$URL" -o /tmp/zvec.tar.gz 2>/dev/null; then
-            echo "Prebuilt zvec ${ZVEC_VERSION} downloaded"
-            rm -rf zvec
-            tar -xzf /tmp/zvec.tar.gz
-            rm /tmp/zvec.tar.gz
-          else
-            echo "Prebuilt not found. Building zvec ${ZVEC_VERSION} from source..."
-            if [ ! -d zvec ]; then
-              git clone --recurse-submodules --branch "$ZVEC_VERSION" \
-                https://github.com/alibaba/zvec.git zvec
-            fi
-            cmake -S zvec -B zvec/build \
-              -DCMAKE_BUILD_TYPE=Release \
-              -DCMAKE_POLICY_VERSION_MINIMUM=3.5
-            cmake --build zvec/build -j$(nproc)
-          fi
+          tar -xzf zvec-built.tar.gz
           test -f zvec/build/lib/libzvec_db.a
           test -d zvec/src/include
-          test -d zvec/thirdparty/sparsehash/sparsehash-2.0.4/src
 
       - name: Build FFI shared library
         working-directory: ffi
@@ -108,32 +173,8 @@ jobs:
         run: |
           gh release upload "${{ github.ref_name }}" "$ASSET_NAME" --clobber
 
-      - name: Upload prebuilt zvec for future builds
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          BUILD_RELEASE="zvec-build-${ZVEC_VERSION}"
-          TARBALL="zvec-${ZVEC_VERSION}-ubuntu24-x86_64.tar.gz"
-          echo "Packaging $TARBALL for release $BUILD_RELEASE"
-          PKG=$(mktemp -d)
-          mkdir -p "$PKG/zvec/src"
-          mkdir -p "$PKG/zvec/thirdparty/sparsehash/sparsehash-2.0.4"
-          mkdir -p "$PKG/zvec/build/external/usr/local"
-          rsync -a zvec/src/include                                "$PKG/zvec/src/"
-          rsync -a zvec/thirdparty/sparsehash/sparsehash-2.0.4/src "$PKG/zvec/thirdparty/sparsehash/sparsehash-2.0.4/"
-          rsync -a zvec/build/lib                                   "$PKG/zvec/build/"
-          rsync -a zvec/build/external/usr/local/lib                "$PKG/zvec/build/external/usr/local/"
-          tar -czf "$TARBALL" -C "$PKG" zvec
-          rm -rf "$PKG"
-          gh release create "$BUILD_RELEASE" \
-            --repo "${{ github.repository }}" \
-            --title "zvec ${ZVEC_VERSION} build artifacts" \
-            --notes "Pre-built zvec ${ZVEC_VERSION} library for ubuntu-24.04. Used by CI to avoid rebuilding zvec from source on every PR." \
-            || echo "Release ${BUILD_RELEASE} already exists"
-          gh release upload "$BUILD_RELEASE" "$TARBALL" --clobber
-
   release-ext:
-    needs: create-release
+    needs: [create-release, setup-zvec]
     runs-on: ubuntu-24.04
     strategy:
       matrix:
@@ -157,29 +198,16 @@ jobs:
             autoconf automake libtool \
             curl binutils
 
-      - name: Setup zvec ${{ env.ZVEC_VERSION }}
+      - name: Download zvec artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: zvec-built
+
+      - name: Extract zvec
         run: |
-          URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${ZVEC_BUILD_RELEASE}/zvec-${ZVEC_VERSION}-ubuntu24-x86_64.tar.gz"
-          echo "Trying prebuilt: $URL"
-          if curl -fL --connect-timeout 10 "$URL" -o /tmp/zvec.tar.gz 2>/dev/null; then
-            echo "Prebuilt zvec ${ZVEC_VERSION} downloaded"
-            rm -rf zvec
-            tar -xzf /tmp/zvec.tar.gz
-            rm /tmp/zvec.tar.gz
-          else
-            echo "Prebuilt not found. Building zvec ${ZVEC_VERSION} from source..."
-            if [ ! -d zvec ]; then
-              git clone --recurse-submodules --branch "$ZVEC_VERSION" \
-                https://github.com/alibaba/zvec.git zvec
-            fi
-            cmake -S zvec -B zvec/build \
-              -DCMAKE_BUILD_TYPE=Release \
-              -DCMAKE_POLICY_VERSION_MINIMUM=3.5
-            cmake --build zvec/build -j$(nproc)
-          fi
+          tar -xzf zvec-built.tar.gz
           test -f zvec/build/lib/libzvec_db.a
           test -d zvec/src/include
-          test -d zvec/thirdparty/sparsehash/sparsehash-2.0.4/src
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,86 +36,8 @@ jobs:
             --generate-notes \
             || echo "Release already exists"
 
-  setup-zvec:
-    needs: create-release
-    runs-on: ubuntu-24.04
-    name: setup zvec ${{ env.ZVEC_VERSION }}
-
-    permissions:
-      contents: write
-
-    steps:
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            build-essential cmake g++ \
-            libssl-dev libz-dev \
-            curl rsync git
-
-      - name: Setup zvec
-        id: setup
-        run: |
-          URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${ZVEC_BUILD_RELEASE}/zvec-${ZVEC_VERSION}-ubuntu24-x86_64.tar.gz"
-          echo "Trying prebuilt: $URL"
-          if curl -fL --connect-timeout 10 "$URL" -o /tmp/zvec.tar.gz 2>/dev/null; then
-            echo "Prebuilt zvec ${ZVEC_VERSION} downloaded"
-            mkdir -p zvec
-            tar -xzf /tmp/zvec.tar.gz
-            rm /tmp/zvec.tar.gz
-            echo "built=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "Prebuilt not found. Building zvec ${ZVEC_VERSION} from source..."
-            git clone --recurse-submodules --branch "$ZVEC_VERSION" \
-              https://github.com/alibaba/zvec.git zvec
-            cmake -S zvec -B zvec/build \
-              -DCMAKE_BUILD_TYPE=Release \
-              -DCMAKE_POLICY_VERSION_MINIMUM=3.5
-            cmake --build zvec/build -j$(nproc)
-            echo "built=true" >> "$GITHUB_OUTPUT"
-          fi
-          test -f zvec/build/lib/libzvec_db.a
-          test -d zvec/src/include
-          test -d zvec/thirdparty/sparsehash/sparsehash-2.0.4/src
-
-      - name: Upload built zvec for future builds
-        if: steps.setup.outputs.built == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          echo "Packaging zvec ${ZVEC_VERSION} for reuse by future CI runs"
-          TARBALL="zvec-${ZVEC_VERSION}-ubuntu24-x86_64.tar.gz"
-          PKG=$(mktemp -d)
-          mkdir -p "$PKG/zvec/src"
-          mkdir -p "$PKG/zvec/thirdparty/sparsehash/sparsehash-2.0.4"
-          mkdir -p "$PKG/zvec/build/external/usr/local"
-          rsync -a zvec/src/include                                "$PKG/zvec/src/"
-          rsync -a zvec/thirdparty/sparsehash/sparsehash-2.0.4/src "$PKG/zvec/thirdparty/sparsehash/sparsehash-2.0.4/"
-          rsync -a zvec/build/lib                                   "$PKG/zvec/build/"
-          rsync -a zvec/build/external/usr/local/lib                "$PKG/zvec/build/external/usr/local/"
-          tar -czf "$TARBALL" -C "$PKG" zvec
-          rm -rf "$PKG"
-          gh release create "$ZVEC_BUILD_RELEASE" \
-            --repo "${{ github.repository }}" \
-            --title "zvec ${ZVEC_VERSION} build artifacts" \
-            --notes "Pre-built zvec ${ZVEC_VERSION} library for ubuntu-24.04." \
-            || echo "Release ${ZVEC_BUILD_RELEASE} already exists"
-          gh release upload "$ZVEC_BUILD_RELEASE" "$TARBALL" --clobber
-
-      - name: Package zvec for artifact
-        run: |
-          TARBALL="zvec-built.tar.gz"
-          tar -czf "$TARBALL" zvec/build/lib zvec/build/external/usr/local/lib zvec/src/include zvec/thirdparty/sparsehash
-          echo "zvec packaged: $(du -h $TARBALL | cut -f1)"
-
-      - name: Upload zvec artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: zvec-built
-          path: zvec-built.tar.gz
-
   release-ffi:
-    needs: [create-release, setup-zvec]
+    needs: create-release
     runs-on: ubuntu-24.04
     name: Build & Release FFI Library
 
@@ -134,16 +56,29 @@ jobs:
             libssl-dev libz-dev \
             curl binutils
 
-      - name: Download zvec artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: zvec-built
-
-      - name: Extract zvec
+      - name: Setup zvec ${{ env.ZVEC_VERSION }}
         run: |
-          tar -xzf zvec-built.tar.gz
+          URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${ZVEC_BUILD_RELEASE}/zvec-${ZVEC_VERSION}-ubuntu24-x86_64.tar.gz"
+          echo "Trying prebuilt: $URL"
+          if curl -fL --connect-timeout 10 "$URL" -o /tmp/zvec.tar.gz 2>/dev/null; then
+            echo "Prebuilt zvec ${ZVEC_VERSION} downloaded"
+            rm -rf zvec
+            tar -xzf /tmp/zvec.tar.gz
+            rm /tmp/zvec.tar.gz
+          else
+            echo "Prebuilt not found. Building zvec ${ZVEC_VERSION} from source..."
+            if [ ! -d zvec ]; then
+              git clone --recurse-submodules --branch "$ZVEC_VERSION" \
+                https://github.com/alibaba/zvec.git zvec
+            fi
+            cmake -S zvec -B zvec/build \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+            cmake --build zvec/build -j$(nproc)
+          fi
           test -f zvec/build/lib/libzvec_db.a
           test -d zvec/src/include
+          test -d zvec/thirdparty/sparsehash/sparsehash-2.0.4/src
 
       - name: Build FFI shared library
         working-directory: ffi
@@ -173,8 +108,32 @@ jobs:
         run: |
           gh release upload "${{ github.ref_name }}" "$ASSET_NAME" --clobber
 
+      - name: Upload prebuilt zvec for future builds
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          BUILD_RELEASE="zvec-build-${ZVEC_VERSION}"
+          TARBALL="zvec-${ZVEC_VERSION}-ubuntu24-x86_64.tar.gz"
+          echo "Packaging $TARBALL for release $BUILD_RELEASE"
+          PKG=$(mktemp -d)
+          mkdir -p "$PKG/zvec/src"
+          mkdir -p "$PKG/zvec/thirdparty/sparsehash/sparsehash-2.0.4"
+          mkdir -p "$PKG/zvec/build/external/usr/local"
+          rsync -a zvec/src/include                                "$PKG/zvec/src/"
+          rsync -a zvec/thirdparty/sparsehash/sparsehash-2.0.4/src "$PKG/zvec/thirdparty/sparsehash/sparsehash-2.0.4/"
+          rsync -a zvec/build/lib                                   "$PKG/zvec/build/"
+          rsync -a zvec/build/external/usr/local/lib                "$PKG/zvec/build/external/usr/local/"
+          tar -czf "$TARBALL" -C "$PKG" zvec
+          rm -rf "$PKG"
+          gh release create "$BUILD_RELEASE" \
+            --repo "${{ github.repository }}" \
+            --title "zvec ${ZVEC_VERSION} build artifacts" \
+            --notes "Pre-built zvec ${ZVEC_VERSION} library for ubuntu-24.04. Used by CI to avoid rebuilding zvec from source on every PR." \
+            || echo "Release ${BUILD_RELEASE} already exists"
+          gh release upload "$BUILD_RELEASE" "$TARBALL" --clobber
+
   release-ext:
-    needs: [create-release, setup-zvec]
+    needs: create-release
     runs-on: ubuntu-24.04
     strategy:
       matrix:
@@ -198,16 +157,29 @@ jobs:
             autoconf automake libtool \
             curl binutils
 
-      - name: Download zvec artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: zvec-built
-
-      - name: Extract zvec
+      - name: Setup zvec ${{ env.ZVEC_VERSION }}
         run: |
-          tar -xzf zvec-built.tar.gz
+          URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${ZVEC_BUILD_RELEASE}/zvec-${ZVEC_VERSION}-ubuntu24-x86_64.tar.gz"
+          echo "Trying prebuilt: $URL"
+          if curl -fL --connect-timeout 10 "$URL" -o /tmp/zvec.tar.gz 2>/dev/null; then
+            echo "Prebuilt zvec ${ZVEC_VERSION} downloaded"
+            rm -rf zvec
+            tar -xzf /tmp/zvec.tar.gz
+            rm /tmp/zvec.tar.gz
+          else
+            echo "Prebuilt not found. Building zvec ${ZVEC_VERSION} from source..."
+            if [ ! -d zvec ]; then
+              git clone --recurse-submodules --branch "$ZVEC_VERSION" \
+                https://github.com/alibaba/zvec.git zvec
+            fi
+            cmake -S zvec -B zvec/build \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+            cmake --build zvec/build -j$(nproc)
+          fi
           test -f zvec/build/lib/libzvec_db.a
           test -d zvec/src/include
+          test -d zvec/thirdparty/sparsehash/sparsehash-2.0.4/src
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,15 +56,26 @@ jobs:
             libssl-dev libz-dev \
             curl binutils
 
-      - name: Download prebuilt zvec
+      - name: Setup zvec ${{ env.ZVEC_VERSION }}
         run: |
           URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${ZVEC_BUILD_RELEASE}/zvec-${ZVEC_VERSION}-ubuntu24-x86_64.tar.gz"
-          echo "Downloading: $URL"
-          curl -fL "$URL" -o /tmp/zvec.tar.gz
-
-          rm -rf zvec
-          tar -xzf /tmp/zvec.tar.gz
-
+          echo "Trying prebuilt: $URL"
+          if curl -fL --connect-timeout 10 "$URL" -o /tmp/zvec.tar.gz 2>/dev/null; then
+            echo "Prebuilt zvec ${ZVEC_VERSION} downloaded"
+            rm -rf zvec
+            tar -xzf /tmp/zvec.tar.gz
+            rm /tmp/zvec.tar.gz
+          else
+            echo "Prebuilt not found. Building zvec ${ZVEC_VERSION} from source..."
+            if [ ! -d zvec ]; then
+              git clone --recurse-submodules --branch "$ZVEC_VERSION" \
+                https://github.com/alibaba/zvec.git zvec
+            fi
+            cmake -S zvec -B zvec/build \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+            cmake --build zvec/build -j$(nproc)
+          fi
           test -f zvec/build/lib/libzvec_db.a
           test -d zvec/src/include
           test -d zvec/thirdparty/sparsehash/sparsehash-2.0.4/src
@@ -91,11 +102,35 @@ jobs:
           tar -czf "$ASSET_NAME" -C ffi/build libzvec_ffi.so
           echo "ASSET_NAME=$ASSET_NAME" >> "$GITHUB_ENV"
 
-      - name: Upload release asset
+      - name: Upload FFI release asset
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release upload "${{ github.ref_name }}" "$ASSET_NAME" --clobber
+
+      - name: Upload prebuilt zvec for future builds
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          BUILD_RELEASE="zvec-build-${ZVEC_VERSION}"
+          TARBALL="zvec-${ZVEC_VERSION}-ubuntu24-x86_64.tar.gz"
+          echo "Packaging $TARBALL for release $BUILD_RELEASE"
+          PKG=$(mktemp -d)
+          mkdir -p "$PKG/zvec/src"
+          mkdir -p "$PKG/zvec/thirdparty/sparsehash/sparsehash-2.0.4"
+          mkdir -p "$PKG/zvec/build/external/usr/local"
+          rsync -a zvec/src/include                                "$PKG/zvec/src/"
+          rsync -a zvec/thirdparty/sparsehash/sparsehash-2.0.4/src "$PKG/zvec/thirdparty/sparsehash/sparsehash-2.0.4/"
+          rsync -a zvec/build/lib                                   "$PKG/zvec/build/"
+          rsync -a zvec/build/external/usr/local/lib                "$PKG/zvec/build/external/usr/local/"
+          tar -czf "$TARBALL" -C "$PKG" zvec
+          rm -rf "$PKG"
+          gh release create "$BUILD_RELEASE" \
+            --repo "${{ github.repository }}" \
+            --title "zvec ${ZVEC_VERSION} build artifacts" \
+            --notes "Pre-built zvec ${ZVEC_VERSION} library for ubuntu-24.04. Used by CI to avoid rebuilding zvec from source on every PR." \
+            || echo "Release ${BUILD_RELEASE} already exists"
+          gh release upload "$BUILD_RELEASE" "$TARBALL" --clobber
 
   release-ext:
     needs: create-release
@@ -122,15 +157,26 @@ jobs:
             autoconf automake libtool \
             curl binutils
 
-      - name: Download prebuilt zvec
+      - name: Setup zvec ${{ env.ZVEC_VERSION }}
         run: |
           URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${ZVEC_BUILD_RELEASE}/zvec-${ZVEC_VERSION}-ubuntu24-x86_64.tar.gz"
-          echo "Downloading: $URL"
-          curl -fL "$URL" -o /tmp/zvec.tar.gz
-
-          rm -rf zvec
-          tar -xzf /tmp/zvec.tar.gz
-
+          echo "Trying prebuilt: $URL"
+          if curl -fL --connect-timeout 10 "$URL" -o /tmp/zvec.tar.gz 2>/dev/null; then
+            echo "Prebuilt zvec ${ZVEC_VERSION} downloaded"
+            rm -rf zvec
+            tar -xzf /tmp/zvec.tar.gz
+            rm /tmp/zvec.tar.gz
+          else
+            echo "Prebuilt not found. Building zvec ${ZVEC_VERSION} from source..."
+            if [ ! -d zvec ]; then
+              git clone --recurse-submodules --branch "$ZVEC_VERSION" \
+                https://github.com/alibaba/zvec.git zvec
+            fi
+            cmake -S zvec -B zvec/build \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+            cmake --build zvec/build -j$(nproc)
+          fi
           test -f zvec/build/lib/libzvec_db.a
           test -d zvec/src/include
           test -d zvec/thirdparty/sparsehash/sparsehash-2.0.4/src
@@ -158,18 +204,8 @@ jobs:
             -Wl,--whole-archive \
               $ZVEC_LIB/libzvec_db.a \
               $ZVEC_LIB/libzvec_ailego.a \
-              $ZVEC_LIB/libcore_metric.a \
-              $ZVEC_LIB/libcore_knn_hnsw.a \
-              $ZVEC_LIB/libcore_knn_hnsw_sparse.a \
-              $ZVEC_LIB/libcore_knn_flat.a \
-              $ZVEC_LIB/libcore_knn_flat_sparse.a \
-              $ZVEC_LIB/libcore_knn_ivf.a \
-              $ZVEC_LIB/libcore_knn_cluster.a \
-              $ZVEC_LIB/libcore_quantizer.a \
-              $ZVEC_LIB/libcore_utility.a \
-              $ZVEC_LIB/libcore_mix_reducer.a \
-              $ZVEC_LIB/libcore_framework.a \
-              $ZVEC_LIB/libcore_interface.a \
+              $ZVEC_LIB/libzvec_core.a \
+              $ZVEC_LIB/libzvec_turbo.a \
               $ZVEC_EXT_LIB/*.a \
             -Wl,--no-whole-archive \
             -lssl -lcrypto -lstdc++ -lz -lpthread -ldl \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,8 @@ on:
       - 'v*'
 
 env:
-  ZVEC_VERSION: v0.2.0
-  ZVEC_BUILD_RELEASE: zvec-build-v0.2.0
+  ZVEC_VERSION: v0.4.0
+  ZVEC_BUILD_RELEASE: zvec-build-v0.4.0
 
 jobs:
   create-release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.9] - 2026-05-10
+
+### Changed
+
+- **Upgrade zvec to v0.4.0** (#8)
+  - Bumped upstream `alibaba/zvec` library from v0.2.0 to v0.4.0 (released 2026-05-09)
+  - All build scripts, Docker workflows, and CI pinned to `v0.4.0` tag
+  - Updated FFI link list: v0.4.0 merged 12 individual `libcore_*.a` libraries into aggregate `libzvec_core.a` and `libzvec_db.a` — linker now uses 4 libs instead of 14
+  - Cross-platform `build_zvec.sh`: auto-detects macOS/Linux, CPU count, and GCC version
+  - GCC 15 workaround: `-include stdint.h` for RocksDB 8.1.1 `uint64_t` compatibility
+  - CI now builds zvec from source when pre-built tarball not available
+  - All 54 tests pass (53 PASS + 1 XFAIL), all example scripts verified
+
 ## [0.4.8] - 2026-03-15
 
 ### Added
@@ -696,7 +709,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-[Unreleased]: https://github.com/alibaba/zvec-php/compare/v0.3.22...HEAD
+[Unreleased]: https://github.com/alibaba/zvec-php/compare/v0.4.9...HEAD
+[0.4.9]: https://github.com/alibaba/zvec-php/compare/v0.4.8...v0.4.9
+[0.4.8]: https://github.com/alibaba/zvec-php/compare/v0.4.7...v0.4.8
 [0.3.22]: https://github.com/alibaba/zvec-php/releases/tag/v0.3.22
 [0.3.21]: https://github.com/alibaba/zvec-php/releases/tag/v0.3.21
 [0.3.20]: https://github.com/alibaba/zvec-php/releases/tag/v0.3.20

--- a/build_zvec.sh
+++ b/build_zvec.sh
@@ -6,7 +6,7 @@ cd "$SCRIPT_DIR"
 
 # Pobierz repozytorium zvec
 if [ ! -d "zvec" ]; then
-    git clone --recurse-submodules https://github.com/alibaba/zvec.git zvec
+    git clone --recurse-submodules --branch v0.4.0 https://github.com/alibaba/zvec.git zvec
 else
     cd zvec
     git submodule update --init --recursive

--- a/build_zvec.sh
+++ b/build_zvec.sh
@@ -4,50 +4,89 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR"
 
-# Pobierz repozytorium zvec
+OS="$(uname -s)"
+
+# --- CPU count ---
+if [ "$OS" = "Darwin" ]; then
+    CPUS=$(sysctl -n hw.ncpu)
+elif [ "$OS" = "Linux" ]; then
+    CPUS=$(nproc)
+else
+    echo "Unsupported OS: $OS"
+    exit 1
+fi
+
+# --- CMake ---
+if [ "$OS" = "Darwin" ]; then
+    CMAKE_VERSION="3.28.3"
+    CMAKE_DIR="cmake-${CMAKE_VERSION}-macos-universal"
+    CMAKE_TAR="${CMAKE_DIR}.tar.gz"
+
+    if [ ! -d "${CMAKE_DIR}" ]; then
+        echo "Downloading CMake ${CMAKE_VERSION}..."
+        curl -L -O "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/${CMAKE_TAR}"
+        tar -xzf "${CMAKE_TAR}"
+        rm "${CMAKE_TAR}"
+    fi
+
+    CMAKE="${SCRIPT_DIR}/${CMAKE_DIR}/CMake.app/Contents/bin/cmake"
+else
+    CMAKE="cmake"
+fi
+
+echo "Using CMake: $(${CMAKE} --version | head -1)"
+echo "CPUs: ${CPUS}"
+
+# --- Clone zvec ---
+ZVEC_VERSION="v0.4.0"
 if [ ! -d "zvec" ]; then
-    git clone --recurse-submodules --branch v0.4.0 https://github.com/alibaba/zvec.git zvec
+    echo "Cloning zvec ${ZVEC_VERSION}..."
+    git clone --recurse-submodules --branch "$ZVEC_VERSION" https://github.com/alibaba/zvec.git zvec
 else
     cd zvec
     git submodule update --init --recursive
     cd "$SCRIPT_DIR"
 fi
 
-# Pobierz i zainstaluj CMake 3.28 lokalnie
-CMAKE_VERSION="3.28.3"
-CMAKE_DIR="cmake-${CMAKE_VERSION}-macos-universal"
-CMAKE_TAR="${CMAKE_DIR}.tar.gz"
-
-if [ ! -d "${CMAKE_DIR}" ]; then
-    echo "Pobieranie CMake ${CMAKE_VERSION}..."
-    curl -L -O "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/${CMAKE_TAR}"
-    tar -xzf "${CMAKE_TAR}"
-    rm "${CMAKE_TAR}"
+# --- GCC 15 workaround (Linux) ---
+# GCC 15 moves uint64_t from global to std:: namespace.
+# RocksDB 8.1.1 headers use bare uint64_t, so pre-include <stdint.h>.
+if [ "$OS" = "Linux" ]; then
+    GXX_VER=$(${CXX:-c++} -dumpversion 2>/dev/null | cut -d. -f1)
+    if [ "$GXX_VER" -ge 15 ] 2>/dev/null; then
+        echo "Detected GCC ${GXX_VER}, creating g++ wrapper for -include stdint.h"
+        GXX_WRAPPER="/tmp/zvec-g++-wrapper.sh"
+        cat > "$GXX_WRAPPER" << 'WRAPPER_EOF'
+#!/bin/bash
+exec /usr/bin/c++ -include stdint.h "$@"
+WRAPPER_EOF
+        chmod +x "$GXX_WRAPPER"
+        ZVEC_CXX_COMPILER="-DCMAKE_CXX_COMPILER=$GXX_WRAPPER"
+    fi
 fi
 
-export CMAKE="${SCRIPT_DIR}/${CMAKE_DIR}/CMake.app/Contents/bin/cmake"
-export PATH="${SCRIPT_DIR}/${CMAKE_DIR}/CMake.app/Contents/bin:$PATH"
+# --- Build zvec ---
+echo "Building zvec..."
+ZVEC_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Release -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ${ZVEC_CXX_COMPILER:-}"
+mkdir -p zvec/build
+${CMAKE} -S zvec -B zvec/build $ZVEC_CMAKE_FLAGS
+${CMAKE} --build zvec/build -j${CPUS}
 
-echo "Używam CMake: $(which cmake)"
-cmake --version
+echo "zvec built in zvec/build"
 
-# Buduj zvec
-cd zvec
-mkdir -p build
-cd build
-cmake ..
-make -j$(sysctl -n hw.ncpu)
+# --- Build FFI wrapper ---
+echo "Building FFI wrapper..."
+FFI_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Release ${ZVEC_CXX_COMPILER:-}"
+mkdir -p ffi/build
+${CMAKE} -S ffi -B ffi/build $FFI_CMAKE_FLAGS
+${CMAKE} --build ffi/build -j${CPUS}
 
-echo "zvec zbudowany w katalogu zvec/build"
-
-# Buduj FFI wrapper
-cd "$SCRIPT_DIR"
-echo "Buduję FFI wrapper..."
-cd ffi
-mkdir -p build
-cd build
-cmake ..
-make -j$(sysctl -n hw.ncpu)
-
-echo "Gotowe! Biblioteka FFI: ffi/build/libzvec_ffi.dylib"
-echo "Uruchom przykład: php php/example.php"
+# --- Done ---
+if [ "$OS" = "Darwin" ]; then
+    LIB_EXT="dylib"
+else
+    LIB_EXT="so"
+fi
+echo ""
+echo "Done! FFI library: ffi/build/libzvec_ffi.${LIB_EXT}"
+echo "Run tests: php run-tests.php tests/"

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,4 +1,4 @@
-ZVEC_VERSION ?= v0.2.0
+ZVEC_VERSION ?= v0.4.0
 MARCH        ?= nehalem
 IMAGE        := zvec-builder
 

--- a/docker/build-zvec.sh
+++ b/docker/build-zvec.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-ZVEC_VERSION="${ZVEC_VERSION:-v0.2.0}"
+ZVEC_VERSION="${ZVEC_VERSION:-v0.4.0}"
 MARCH="${MARCH:-nehalem}"
 JOBS="${JOBS:-$(nproc)}"
 PLATFORM="${PLATFORM:-ubuntu24-x86_64}"

--- a/ffi/CMakeLists.txt
+++ b/ffi/CMakeLists.txt
@@ -20,18 +20,8 @@ target_include_directories(zvec_ffi PRIVATE
 set(ZVEC_STATIC_LIBS
     ${ZVEC_LIB}/libzvec_db.a
     ${ZVEC_LIB}/libzvec_ailego.a
-    ${ZVEC_LIB}/libcore_metric.a
-    ${ZVEC_LIB}/libcore_knn_hnsw.a
-    ${ZVEC_LIB}/libcore_knn_hnsw_sparse.a
-    ${ZVEC_LIB}/libcore_knn_flat.a
-    ${ZVEC_LIB}/libcore_knn_flat_sparse.a
-    ${ZVEC_LIB}/libcore_knn_ivf.a
-    ${ZVEC_LIB}/libcore_knn_cluster.a
-    ${ZVEC_LIB}/libcore_quantizer.a
-    ${ZVEC_LIB}/libcore_utility.a
-    ${ZVEC_LIB}/libcore_mix_reducer.a
-    ${ZVEC_LIB}/libcore_framework.a
-    ${ZVEC_LIB}/libcore_interface.a
+    ${ZVEC_LIB}/libzvec_core.a
+    ${ZVEC_LIB}/libzvec_turbo.a
 )
 
 set(ZVEC_EXTERNAL_LIBS


### PR DESCRIPTION
## Summary

Upgrade upstream `alibaba/zvec` from v0.2.0 → v0.4.0 (released 2026-05-09).

### Changes

1. **Pin zvec v0.4.0** — update `build_zvec.sh`, `docker/build-zvec.sh`, CI workflows, Makefile to clone tag `v0.4.0`
2. **Fix FFI link list** — v0.4.0 restructured the build: `libzvec_core.a` now absorbs all `libcore_*.a` libs, and `libzvec_db.a` absorbs `libzvec_{common,index,sqlengine,proto}.a`. Reduced linker list from 14 → 4 static libs.
3. **Cross-platform build script** — `build_zvec.sh` now auto-detects OS (Linux/macOS), CPU count, and GCC version. Adds `-include stdint.h` workaround for GCC ≥ 15 (RocksDB 8.1.1 compatibility).

### Testing

- **53/54 phpt tests passed** (1 XFAIL: GroupByQuery "Coming Soon")
- **7/7 example scripts passed**
- Tested on: Linux (GCC 15.2), Ubuntu 24.04