### PR TITLE
chore: bump to v0.4.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.4.9] - 2026-05-10
+## [0.4.10] - 2026-05-10
 
 ### Changed
 
@@ -709,7 +709,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-[Unreleased]: https://github.com/alibaba/zvec-php/compare/v0.4.9...HEAD
+[Unreleased]: https://github.com/alibaba/zvec-php/compare/v0.4.10...HEAD
+[0.4.10]: https://github.com/alibaba/zvec-php/compare/v0.4.9...v0.4.10
 [0.4.9]: https://github.com/alibaba/zvec-php/compare/v0.4.8...v0.4.9
 [0.4.8]: https://github.com/alibaba/zvec-php/compare/v0.4.7...v0.4.8
 [0.3.22]: https://github.com/alibaba/zvec-php/releases/tag/v0.3.22

--- a/php-ext/php_zvec.h
+++ b/php-ext/php_zvec.h
@@ -7,7 +7,7 @@ extern "C" {
 #include "zend_interfaces.h"
 }
 
-#define PHP_ZVEC_VERSION "0.4.9"
+#define PHP_ZVEC_VERSION "0.4.10"
 #define PHP_ZVEC_EXTNAME "zvec"
 
 extern zend_module_entry zvec_module_entry;


### PR DESCRIPTION
v0.4.9 tag already existed on an older commit. Bumping to v0.4.10.

### Changes since v0.4.9
- **Upgrade zvec to v0.4.0** — upstream library from v0.2.0 to v0.4.0
- **FFI link list** — merged 12 `libcore_*.a` into `libzvec_core.a`, now 4 libs
- **Cross-platform `build_zvec.sh`** — macOS/Linux with GCC 15 workaround
- **CI improvements** — builds zvec from source when prebuilt tarball not available

### Files changed
- `CHANGELOG.md`: v0.4.9 → v0.4.10
- `php-ext/php_zvec.h`: `PHP_ZVEC_VERSION` bumped to `0.4.10`