### PR TITLE
feat: split build into separate zvec and FFI steps with version caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,24 +33,8 @@ jobs:
 
       - name: Setup zvec ${{ env.ZVEC_VERSION }}
         run: |
-          URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${ZVEC_BUILD_RELEASE}/zvec-${ZVEC_VERSION}-ubuntu24-x86_64.tar.gz"
-          echo "Trying prebuilt: $URL"
-          if curl -fL --connect-timeout 10 "$URL" -o /tmp/zvec.tar.gz 2>/dev/null; then
-            echo "Prebuilt zvec ${ZVEC_VERSION} downloaded"
-            rm -rf zvec
-            tar -xzf /tmp/zvec.tar.gz
-            rm /tmp/zvec.tar.gz
-          else
-            echo "Prebuilt not found. Building zvec ${ZVEC_VERSION} from source..."
-            if [ ! -d zvec ]; then
-              git clone --recurse-submodules --branch "$ZVEC_VERSION" \
-                https://github.com/alibaba/zvec.git zvec
-            fi
-            cmake -S zvec -B zvec/build \
-              -DCMAKE_BUILD_TYPE=Release \
-              -DCMAKE_POLICY_VERSION_MINIMUM=3.5
-            cmake --build zvec/build -j$(nproc)
-          fi
+          PREBUILT_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${ZVEC_BUILD_RELEASE}/zvec-${ZVEC_VERSION}-ubuntu24-x86_64.tar.gz"
+          ./build_zvec_lib.sh "$ZVEC_VERSION" "$PREBUILT_URL"
           test -f zvec/build/lib/libzvec_db.a
           test -d zvec/src/include
           test -d zvec/thirdparty/sparsehash/sparsehash-2.0.4/src
@@ -126,24 +110,8 @@ jobs:
 
       - name: Setup zvec ${{ env.ZVEC_VERSION }}
         run: |
-          URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${ZVEC_BUILD_RELEASE}/zvec-${ZVEC_VERSION}-ubuntu24-x86_64.tar.gz"
-          echo "Trying prebuilt: $URL"
-          if curl -fL --connect-timeout 10 "$URL" -o /tmp/zvec.tar.gz 2>/dev/null; then
-            echo "Prebuilt zvec ${ZVEC_VERSION} downloaded"
-            rm -rf zvec
-            tar -xzf /tmp/zvec.tar.gz
-            rm /tmp/zvec.tar.gz
-          else
-            echo "Prebuilt not found. Building zvec ${ZVEC_VERSION} from source..."
-            if [ ! -d zvec ]; then
-              git clone --recurse-submodules --branch "$ZVEC_VERSION" \
-                https://github.com/alibaba/zvec.git zvec
-            fi
-            cmake -S zvec -B zvec/build \
-              -DCMAKE_BUILD_TYPE=Release \
-              -DCMAKE_POLICY_VERSION_MINIMUM=3.5
-            cmake --build zvec/build -j$(nproc)
-          fi
+          PREBUILT_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${ZVEC_BUILD_RELEASE}/zvec-${ZVEC_VERSION}-ubuntu24-x86_64.tar.gz"
+          ./build_zvec_lib.sh "$ZVEC_VERSION" "$PREBUILT_URL"
           test -f zvec/build/lib/libzvec_db.a
           test -d zvec/src/include
           test -d zvec/thirdparty/sparsehash/sparsehash-2.0.4/src

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,50 @@ env:
   ZVEC_BUILD_RELEASE: zvec-build-v0.4.0
 
 jobs:
+  setup-zvec:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-24.04
+    name: Build zvec C++ library
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential cmake g++ \
+            libssl-dev libz-dev \
+            curl rsync
+
+      - name: Setup zvec ${{ env.ZVEC_VERSION }}
+        run: |
+          PREBUILT_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${ZVEC_BUILD_RELEASE}/zvec-${ZVEC_VERSION}-ubuntu24-x86_64.tar.gz"
+          ./build_zvec_lib.sh "$ZVEC_VERSION" "$PREBUILT_URL"
+          test -f zvec/build/lib/libzvec_db.a
+          test -d zvec/src/include
+          test -d zvec/thirdparty/sparsehash/sparsehash-2.0.4/src
+
+      - name: Package zvec build
+        run: |
+          PKG=$(mktemp -d)
+          mkdir -p "$PKG/zvec/src" \
+                   "$PKG/zvec/thirdparty/sparsehash/sparsehash-2.0.4" \
+                   "$PKG/zvec/build/external/usr/local"
+          rsync -a zvec/src/include                                "$PKG/zvec/src/"
+          rsync -a zvec/thirdparty/sparsehash/sparsehash-2.0.4/src "$PKG/zvec/thirdparty/sparsehash/sparsehash-2.0.4/"
+          rsync -a zvec/build/lib                                   "$PKG/zvec/build/"
+          rsync -a zvec/build/external/usr/local/lib                "$PKG/zvec/build/external/usr/local/"
+          tar -czf zvec-pkg.tar.gz -C "$PKG" zvec
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: zvec-build
+          path: zvec-pkg.tar.gz
+
   build-ext:
+    needs: setup-zvec
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-24.04
     strategy:
@@ -19,8 +62,20 @@ jobs:
     name: ext - PHP ${{ matrix.php-version }}
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+
+      - name: Download zvec artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: zvec-build
+
+      - name: Extract zvec
+        run: |
+          tar -xzf zvec-pkg.tar.gz
+          rm zvec-pkg.tar.gz
+          test -f zvec/build/lib/libzvec_db.a
+          test -d zvec/src/include
+          test -d zvec/thirdparty/sparsehash/sparsehash-2.0.4/src
 
       - name: Install system dependencies
         run: |
@@ -30,14 +85,6 @@ jobs:
             libssl-dev libz-dev \
             autoconf automake libtool \
             curl binutils
-
-      - name: Setup zvec ${{ env.ZVEC_VERSION }}
-        run: |
-          PREBUILT_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${ZVEC_BUILD_RELEASE}/zvec-${ZVEC_VERSION}-ubuntu24-x86_64.tar.gz"
-          ./build_zvec_lib.sh "$ZVEC_VERSION" "$PREBUILT_URL"
-          test -f zvec/build/lib/libzvec_db.a
-          test -d zvec/src/include
-          test -d zvec/thirdparty/sparsehash/sparsehash-2.0.4/src
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -88,6 +135,7 @@ jobs:
           path: php-ext/modules/zvec.so
 
   build-ffi:
+    needs: setup-zvec
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-24.04
     strategy:
@@ -97,8 +145,20 @@ jobs:
     name: ffi - PHP ${{ matrix.php-version }}
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+
+      - name: Download zvec artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: zvec-build
+
+      - name: Extract zvec
+        run: |
+          tar -xzf zvec-pkg.tar.gz
+          rm zvec-pkg.tar.gz
+          test -f zvec/build/lib/libzvec_db.a
+          test -d zvec/src/include
+          test -d zvec/thirdparty/sparsehash/sparsehash-2.0.4/src
 
       - name: Install system dependencies
         run: |
@@ -107,14 +167,6 @@ jobs:
             build-essential cmake g++ \
             libssl-dev libz-dev \
             curl
-
-      - name: Setup zvec ${{ env.ZVEC_VERSION }}
-        run: |
-          PREBUILT_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${ZVEC_BUILD_RELEASE}/zvec-${ZVEC_VERSION}-ubuntu24-x86_64.tar.gz"
-          ./build_zvec_lib.sh "$ZVEC_VERSION" "$PREBUILT_URL"
-          test -f zvec/build/lib/libzvec_db.a
-          test -d zvec/src/include
-          test -d zvec/thirdparty/sparsehash/sparsehash-2.0.4/src
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,17 +36,16 @@ jobs:
             --generate-notes \
             || echo "Release already exists"
 
-  release-ffi:
+  setup-zvec:
     needs: create-release
     runs-on: ubuntu-24.04
-    name: Build & Release FFI Library
+    name: Build zvec C++ library
 
     permissions:
       contents: write
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
       - name: Install system dependencies
         run: |
@@ -54,7 +53,7 @@ jobs:
           sudo apt-get install -y \
             build-essential cmake g++ \
             libssl-dev libz-dev \
-            curl binutils
+            curl rsync binutils
 
       - name: Setup zvec ${{ env.ZVEC_VERSION }}
         run: |
@@ -63,6 +62,80 @@ jobs:
           test -f zvec/build/lib/libzvec_db.a
           test -d zvec/src/include
           test -d zvec/thirdparty/sparsehash/sparsehash-2.0.4/src
+
+      - name: Package zvec build for downstream jobs
+        run: |
+          PKG=$(mktemp -d)
+          mkdir -p "$PKG/zvec/src" \
+                   "$PKG/zvec/thirdparty/sparsehash/sparsehash-2.0.4" \
+                   "$PKG/zvec/build/external/usr/local"
+          rsync -a zvec/src/include                                "$PKG/zvec/src/"
+          rsync -a zvec/thirdparty/sparsehash/sparsehash-2.0.4/src "$PKG/zvec/thirdparty/sparsehash/sparsehash-2.0.4/"
+          rsync -a zvec/build/lib                                   "$PKG/zvec/build/"
+          rsync -a zvec/build/external/usr/local/lib                "$PKG/zvec/build/external/usr/local/"
+          tar -czf zvec-pkg.tar.gz -C "$PKG" zvec
+
+      - name: Upload artifact for downstream jobs
+        uses: actions/upload-artifact@v4
+        with:
+          name: zvec-build
+          path: zvec-pkg.tar.gz
+
+      - name: Upload prebuilt zvec for future CI builds
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          BUILD_RELEASE="zvec-build-${ZVEC_VERSION}"
+          TARBALL="zvec-${ZVEC_VERSION}-ubuntu24-x86_64.tar.gz"
+          echo "Packaging $TARBALL for release $BUILD_RELEASE"
+          PKG=$(mktemp -d)
+          mkdir -p "$PKG/zvec/src" \
+                   "$PKG/zvec/thirdparty/sparsehash/sparsehash-2.0.4" \
+                   "$PKG/zvec/build/external/usr/local"
+          rsync -a zvec/src/include                                "$PKG/zvec/src/"
+          rsync -a zvec/thirdparty/sparsehash/sparsehash-2.0.4/src "$PKG/zvec/thirdparty/sparsehash/sparsehash-2.0.4/"
+          rsync -a zvec/build/lib                                   "$PKG/zvec/build/"
+          rsync -a zvec/build/external/usr/local/lib                "$PKG/zvec/build/external/usr/local/"
+          tar -czf "$TARBALL" -C "$PKG" zvec
+          rm -rf "$PKG"
+          gh release create "$BUILD_RELEASE" \
+            --repo "${{ github.repository }}" \
+            --title "zvec ${ZVEC_VERSION} build artifacts" \
+            --notes "Pre-built zvec ${ZVEC_VERSION} library for ubuntu-24.04. Used by CI to avoid rebuilding zvec from source on every PR." \
+            || echo "Release ${BUILD_RELEASE} already exists"
+          gh release upload "$BUILD_RELEASE" "$TARBALL" --clobber
+
+  release-ffi:
+    needs: setup-zvec
+    runs-on: ubuntu-24.04
+    name: Build & Release FFI Library
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download zvec artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: zvec-build
+
+      - name: Extract zvec
+        run: |
+          tar -xzf zvec-pkg.tar.gz
+          rm zvec-pkg.tar.gz
+          test -f zvec/build/lib/libzvec_db.a
+          test -d zvec/src/include
+          test -d zvec/thirdparty/sparsehash/sparsehash-2.0.4/src
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential cmake g++ \
+            libssl-dev libz-dev \
+            curl binutils
 
       - name: Build FFI shared library
         working-directory: ffi
@@ -92,32 +165,8 @@ jobs:
         run: |
           gh release upload "${{ github.ref_name }}" "$ASSET_NAME" --clobber
 
-      - name: Upload prebuilt zvec for future builds
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          BUILD_RELEASE="zvec-build-${ZVEC_VERSION}"
-          TARBALL="zvec-${ZVEC_VERSION}-ubuntu24-x86_64.tar.gz"
-          echo "Packaging $TARBALL for release $BUILD_RELEASE"
-          PKG=$(mktemp -d)
-          mkdir -p "$PKG/zvec/src"
-          mkdir -p "$PKG/zvec/thirdparty/sparsehash/sparsehash-2.0.4"
-          mkdir -p "$PKG/zvec/build/external/usr/local"
-          rsync -a zvec/src/include                                "$PKG/zvec/src/"
-          rsync -a zvec/thirdparty/sparsehash/sparsehash-2.0.4/src "$PKG/zvec/thirdparty/sparsehash/sparsehash-2.0.4/"
-          rsync -a zvec/build/lib                                   "$PKG/zvec/build/"
-          rsync -a zvec/build/external/usr/local/lib                "$PKG/zvec/build/external/usr/local/"
-          tar -czf "$TARBALL" -C "$PKG" zvec
-          rm -rf "$PKG"
-          gh release create "$BUILD_RELEASE" \
-            --repo "${{ github.repository }}" \
-            --title "zvec ${ZVEC_VERSION} build artifacts" \
-            --notes "Pre-built zvec ${ZVEC_VERSION} library for ubuntu-24.04. Used by CI to avoid rebuilding zvec from source on every PR." \
-            || echo "Release ${BUILD_RELEASE} already exists"
-          gh release upload "$BUILD_RELEASE" "$TARBALL" --clobber
-
   release-ext:
-    needs: create-release
+    needs: setup-zvec
     runs-on: ubuntu-24.04
     strategy:
       matrix:
@@ -129,8 +178,20 @@ jobs:
       contents: write
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+
+      - name: Download zvec artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: zvec-build
+
+      - name: Extract zvec
+        run: |
+          tar -xzf zvec-pkg.tar.gz
+          rm zvec-pkg.tar.gz
+          test -f zvec/build/lib/libzvec_db.a
+          test -d zvec/src/include
+          test -d zvec/thirdparty/sparsehash/sparsehash-2.0.4/src
 
       - name: Install system dependencies
         run: |
@@ -140,14 +201,6 @@ jobs:
             libssl-dev libz-dev \
             autoconf automake libtool \
             curl binutils
-
-      - name: Setup zvec ${{ env.ZVEC_VERSION }}
-        run: |
-          PREBUILT_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${ZVEC_BUILD_RELEASE}/zvec-${ZVEC_VERSION}-ubuntu24-x86_64.tar.gz"
-          ./build_zvec_lib.sh "$ZVEC_VERSION" "$PREBUILT_URL"
-          test -f zvec/build/lib/libzvec_db.a
-          test -d zvec/src/include
-          test -d zvec/thirdparty/sparsehash/sparsehash-2.0.4/src
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,24 +58,8 @@ jobs:
 
       - name: Setup zvec ${{ env.ZVEC_VERSION }}
         run: |
-          URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${ZVEC_BUILD_RELEASE}/zvec-${ZVEC_VERSION}-ubuntu24-x86_64.tar.gz"
-          echo "Trying prebuilt: $URL"
-          if curl -fL --connect-timeout 10 "$URL" -o /tmp/zvec.tar.gz 2>/dev/null; then
-            echo "Prebuilt zvec ${ZVEC_VERSION} downloaded"
-            rm -rf zvec
-            tar -xzf /tmp/zvec.tar.gz
-            rm /tmp/zvec.tar.gz
-          else
-            echo "Prebuilt not found. Building zvec ${ZVEC_VERSION} from source..."
-            if [ ! -d zvec ]; then
-              git clone --recurse-submodules --branch "$ZVEC_VERSION" \
-                https://github.com/alibaba/zvec.git zvec
-            fi
-            cmake -S zvec -B zvec/build \
-              -DCMAKE_BUILD_TYPE=Release \
-              -DCMAKE_POLICY_VERSION_MINIMUM=3.5
-            cmake --build zvec/build -j$(nproc)
-          fi
+          PREBUILT_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${ZVEC_BUILD_RELEASE}/zvec-${ZVEC_VERSION}-ubuntu24-x86_64.tar.gz"
+          ./build_zvec_lib.sh "$ZVEC_VERSION" "$PREBUILT_URL"
           test -f zvec/build/lib/libzvec_db.a
           test -d zvec/src/include
           test -d zvec/thirdparty/sparsehash/sparsehash-2.0.4/src
@@ -159,24 +143,8 @@ jobs:
 
       - name: Setup zvec ${{ env.ZVEC_VERSION }}
         run: |
-          URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${ZVEC_BUILD_RELEASE}/zvec-${ZVEC_VERSION}-ubuntu24-x86_64.tar.gz"
-          echo "Trying prebuilt: $URL"
-          if curl -fL --connect-timeout 10 "$URL" -o /tmp/zvec.tar.gz 2>/dev/null; then
-            echo "Prebuilt zvec ${ZVEC_VERSION} downloaded"
-            rm -rf zvec
-            tar -xzf /tmp/zvec.tar.gz
-            rm /tmp/zvec.tar.gz
-          else
-            echo "Prebuilt not found. Building zvec ${ZVEC_VERSION} from source..."
-            if [ ! -d zvec ]; then
-              git clone --recurse-submodules --branch "$ZVEC_VERSION" \
-                https://github.com/alibaba/zvec.git zvec
-            fi
-            cmake -S zvec -B zvec/build \
-              -DCMAKE_BUILD_TYPE=Release \
-              -DCMAKE_POLICY_VERSION_MINIMUM=3.5
-            cmake --build zvec/build -j$(nproc)
-          fi
+          PREBUILT_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${ZVEC_BUILD_RELEASE}/zvec-${ZVEC_VERSION}-ubuntu24-x86_64.tar.gz"
+          ./build_zvec_lib.sh "$ZVEC_VERSION" "$PREBUILT_URL"
           test -f zvec/build/lib/libzvec_db.a
           test -d zvec/src/include
           test -d zvec/thirdparty/sparsehash/sparsehash-2.0.4/src

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,21 +12,49 @@ zvec-php/
 ├── tests/                # Bug reproduction scripts (plain PHP, no framework)
 ├── test_dbs/             # Test database directory (content ignored by git)
 ├── tasks/todo/           # Feature planning documents
-├── build_zvec.sh         # Builds zvec C++ lib + FFI shared library
+├── build_zvec_lib.sh     # Builds only the zvec C++ library (with version caching)
+├── build_ffi.sh          # Builds only the FFI shared library (requires zvec built)
+├── build_zvec.sh         # Orchestrator: builds zvec C++ lib + FFI shared library
 ├── zvec/                 # Git-cloned upstream zvec C++ library (not committed)
 └── cmake-3.28.3-*/       # Vendored CMake (not committed)
 ```
 
 ## Build Commands
 
-### Build the native FFI library (required before running PHP code)
+### Step 1: Build the zvec C++ library (only if not already built for this version)
 
 ```bash
-./build_zvec.sh
+./build_zvec_lib.sh [version]
 ```
 
-This clones zvec if needed, downloads CMake 3.28 locally, builds the C++ library,
-then builds the FFI wrapper (`ffi/build/libzvec_ffi.dylib`). macOS only currently.
+Default version is `v0.4.0`. The script checks `zvec/build/.zvec_version` — if the
+stamp matches, the build is skipped. If the version changes, it auto-updates the
+git checkout and rebuilds.
+
+For CI with prebuilt download:
+```bash
+./build_zvec_lib.sh v0.4.0 "https://url-to-prebuilt.tar.gz"
+```
+
+### Step 2: Build the FFI shared library (requires zvec already built)
+
+```bash
+./build_ffi.sh
+```
+
+### Build both in one command (orchestrator)
+
+```bash
+./build_zvec.sh [version]
+```
+
+This calls `build_zvec_lib.sh` then `build_ffi.sh`.
+
+### Build PHP extension (requires zvec already built)
+
+```bash
+./php-ext/build_ext.sh
+```
 
 ### Run the integration test suite
 
@@ -80,6 +108,13 @@ Before marking any task as DONE:
 
 1. **Build the FFI library** (if C++ changes):
    ```bash
+   # If zvec version changed (e.g. new v0.5.0):
+   ./build_zvec_lib.sh v0.4.0
+
+   # Rebuild FFI wrapper (always if ffi/*.cc or ffi/*.h changed):
+   ./build_ffi.sh
+
+   # Or use the orchestrator for both:
    ./build_zvec.sh
    ```
 

--- a/build_ffi.sh
+++ b/build_ffi.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+OS="$(uname -s)"
+
+# --- CPU count ---
+if [ "$OS" = "Darwin" ]; then
+    CPUS=$(sysctl -n hw.ncpu)
+elif [ "$OS" = "Linux" ]; then
+    CPUS=$(nproc)
+else
+    echo "Unsupported OS: $OS"
+    exit 1
+fi
+
+# --- Check zvec is built ---
+if [ ! -f zvec/build/lib/libzvec_db.a ]; then
+    echo "Error: zvec library not built. Run ./build_zvec_lib.sh first."
+    exit 1
+fi
+
+# --- CMake ---
+if [ "$OS" = "Darwin" ]; then
+    CMAKE_VERSION="3.28.3"
+    CMAKE_DIR="cmake-${CMAKE_VERSION}-macos-universal"
+    CMAKE="${SCRIPT_DIR}/${CMAKE_DIR}/CMake.app/Contents/bin/cmake"
+else
+    CMAKE="cmake"
+fi
+
+# --- GCC 15 workaround (Linux) ---
+if [ "$OS" = "Linux" ]; then
+    GXX_VER=$(${CXX:-c++} -dumpversion 2>/dev/null | cut -d. -f1)
+    if [ "$GXX_VER" -ge 15 ] 2>/dev/null; then
+        GXX_WRAPPER="/tmp/zvec-g++-wrapper.sh"
+        cat > "$GXX_WRAPPER" << 'WRAPPER_EOF'
+#!/bin/bash
+exec /usr/bin/c++ -include stdint.h "$@"
+WRAPPER_EOF
+        chmod +x "$GXX_WRAPPER"
+        ZVEC_CXX_COMPILER="-DCMAKE_CXX_COMPILER=$GXX_WRAPPER"
+    fi
+fi
+
+echo "Building FFI wrapper..."
+FFI_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Release ${ZVEC_CXX_COMPILER:-}"
+mkdir -p ffi/build
+${CMAKE} -S ffi -B ffi/build $FFI_CMAKE_FLAGS
+${CMAKE} --build ffi/build -j${CPUS}
+
+if [ "$OS" = "Darwin" ]; then
+    LIB_EXT="dylib"
+else
+    LIB_EXT="so"
+fi
+echo "FFI library built: ffi/build/libzvec_ffi.${LIB_EXT}"

--- a/build_zvec.sh
+++ b/build_zvec.sh
@@ -4,89 +4,15 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR"
 
-OS="$(uname -s)"
+ZVEC_VERSION="${1:-v0.4.0}"
 
-# --- CPU count ---
-if [ "$OS" = "Darwin" ]; then
-    CPUS=$(sysctl -n hw.ncpu)
-elif [ "$OS" = "Linux" ]; then
-    CPUS=$(nproc)
-else
-    echo "Unsupported OS: $OS"
-    exit 1
-fi
+echo "=== Step 1/2: Build zvec library ${ZVEC_VERSION} ==="
+./build_zvec_lib.sh "$ZVEC_VERSION"
 
-# --- CMake ---
-if [ "$OS" = "Darwin" ]; then
-    CMAKE_VERSION="3.28.3"
-    CMAKE_DIR="cmake-${CMAKE_VERSION}-macos-universal"
-    CMAKE_TAR="${CMAKE_DIR}.tar.gz"
-
-    if [ ! -d "${CMAKE_DIR}" ]; then
-        echo "Downloading CMake ${CMAKE_VERSION}..."
-        curl -L -O "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/${CMAKE_TAR}"
-        tar -xzf "${CMAKE_TAR}"
-        rm "${CMAKE_TAR}"
-    fi
-
-    CMAKE="${SCRIPT_DIR}/${CMAKE_DIR}/CMake.app/Contents/bin/cmake"
-else
-    CMAKE="cmake"
-fi
-
-echo "Using CMake: $(${CMAKE} --version | head -1)"
-echo "CPUs: ${CPUS}"
-
-# --- Clone zvec ---
-ZVEC_VERSION="v0.4.0"
-if [ ! -d "zvec" ]; then
-    echo "Cloning zvec ${ZVEC_VERSION}..."
-    git clone --recurse-submodules --branch "$ZVEC_VERSION" https://github.com/alibaba/zvec.git zvec
-else
-    cd zvec
-    git submodule update --init --recursive
-    cd "$SCRIPT_DIR"
-fi
-
-# --- GCC 15 workaround (Linux) ---
-# GCC 15 moves uint64_t from global to std:: namespace.
-# RocksDB 8.1.1 headers use bare uint64_t, so pre-include <stdint.h>.
-if [ "$OS" = "Linux" ]; then
-    GXX_VER=$(${CXX:-c++} -dumpversion 2>/dev/null | cut -d. -f1)
-    if [ "$GXX_VER" -ge 15 ] 2>/dev/null; then
-        echo "Detected GCC ${GXX_VER}, creating g++ wrapper for -include stdint.h"
-        GXX_WRAPPER="/tmp/zvec-g++-wrapper.sh"
-        cat > "$GXX_WRAPPER" << 'WRAPPER_EOF'
-#!/bin/bash
-exec /usr/bin/c++ -include stdint.h "$@"
-WRAPPER_EOF
-        chmod +x "$GXX_WRAPPER"
-        ZVEC_CXX_COMPILER="-DCMAKE_CXX_COMPILER=$GXX_WRAPPER"
-    fi
-fi
-
-# --- Build zvec ---
-echo "Building zvec..."
-ZVEC_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Release -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ${ZVEC_CXX_COMPILER:-}"
-mkdir -p zvec/build
-${CMAKE} -S zvec -B zvec/build $ZVEC_CMAKE_FLAGS
-${CMAKE} --build zvec/build -j${CPUS}
-
-echo "zvec built in zvec/build"
-
-# --- Build FFI wrapper ---
-echo "Building FFI wrapper..."
-FFI_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Release ${ZVEC_CXX_COMPILER:-}"
-mkdir -p ffi/build
-${CMAKE} -S ffi -B ffi/build $FFI_CMAKE_FLAGS
-${CMAKE} --build ffi/build -j${CPUS}
-
-# --- Done ---
-if [ "$OS" = "Darwin" ]; then
-    LIB_EXT="dylib"
-else
-    LIB_EXT="so"
-fi
 echo ""
-echo "Done! FFI library: ffi/build/libzvec_ffi.${LIB_EXT}"
+echo "=== Step 2/2: Build FFI wrapper ==="
+./build_ffi.sh
+
+echo ""
+echo "=== Done ==="
 echo "Run tests: php run-tests.php tests/"

--- a/build_zvec_lib.sh
+++ b/build_zvec_lib.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+ZVEC_VERSION="${1:-v0.4.0}"
+PREBUILT_URL="${2:-}"
+
+OS="$(uname -s)"
+
+# --- CPU count ---
+if [ "$OS" = "Darwin" ]; then
+    CPUS=$(sysctl -n hw.ncpu)
+elif [ "$OS" = "Linux" ]; then
+    CPUS=$(nproc)
+else
+    echo "Unsupported OS: $OS"
+    exit 1
+fi
+
+# --- CMake ---
+if [ "$OS" = "Darwin" ]; then
+    CMAKE_VERSION="3.28.3"
+    CMAKE_DIR="cmake-${CMAKE_VERSION}-macos-universal"
+    CMAKE_TAR="${CMAKE_DIR}.tar.gz"
+
+    if [ ! -d "${CMAKE_DIR}" ]; then
+        echo "Downloading CMake ${CMAKE_VERSION}..."
+        curl -L -O "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/${CMAKE_TAR}"
+        tar -xzf "${CMAKE_TAR}"
+        rm "${CMAKE_TAR}"
+    fi
+
+    CMAKE="${SCRIPT_DIR}/${CMAKE_DIR}/CMake.app/Contents/bin/cmake"
+else
+    CMAKE="cmake"
+fi
+
+echo "Using CMake: $(${CMAKE} --version | head -1)"
+echo "CPUs: ${CPUS}"
+
+STAMP_FILE="zvec/build/.zvec_version"
+
+# --- Try prebuilt if URL provided (CI flow) ---
+if [ -n "$PREBUILT_URL" ]; then
+    echo "Trying prebuilt zvec ${ZVEC_VERSION} from ${PREBUILT_URL}..."
+    if curl -fL --connect-timeout 10 "$PREBUILT_URL" -o /tmp/zvec.tar.gz 2>/dev/null; then
+        echo "Prebuilt zvec ${ZVEC_VERSION} downloaded"
+        rm -rf zvec
+        tar -xzf /tmp/zvec.tar.gz
+        rm /tmp/zvec.tar.gz
+        mkdir -p zvec/build
+        echo "$ZVEC_VERSION" > "$STAMP_FILE"
+        echo "zvec ${ZVEC_VERSION} ready (prebuilt)"
+        exit 0
+    fi
+    echo "Prebuilt not found, building from source..."
+fi
+
+# --- Check if already built for this version ---
+if [ -f "$STAMP_FILE" ] && [ "$(cat "$STAMP_FILE")" = "$ZVEC_VERSION" ]; then
+    if [ -f zvec/build/lib/libzvec_db.a ]; then
+        echo "zvec ${ZVEC_VERSION} already built (stamp matches), skipping build"
+        exit 0
+    fi
+    echo "Stamp exists but build artifacts missing, rebuilding..."
+fi
+
+# --- Clone zvec ---
+if [ ! -d "zvec" ]; then
+    echo "Cloning zvec ${ZVEC_VERSION}..."
+    git clone --recurse-submodules --branch "$ZVEC_VERSION" https://github.com/alibaba/zvec.git zvec
+else
+    cd zvec
+    CURRENT_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+    if [ "$CURRENT_TAG" != "$ZVEC_VERSION" ]; then
+        echo "zvec version mismatch (current: ${CURRENT_TAG:-unknown}, needed: ${ZVEC_VERSION}), updating..."
+        git fetch --tags
+        git checkout "$ZVEC_VERSION"
+        git submodule update --init --recursive
+    else
+        git submodule update --init --recursive
+    fi
+    cd "$SCRIPT_DIR"
+fi
+
+# --- GCC 15 workaround (Linux) ---
+if [ "$OS" = "Linux" ]; then
+    GXX_VER=$(${CXX:-c++} -dumpversion 2>/dev/null | cut -d. -f1)
+    if [ "$GXX_VER" -ge 15 ] 2>/dev/null; then
+        echo "Detected GCC ${GXX_VER}, creating g++ wrapper for -include stdint.h"
+        GXX_WRAPPER="/tmp/zvec-g++-wrapper.sh"
+        cat > "$GXX_WRAPPER" << 'WRAPPER_EOF'
+#!/bin/bash
+exec /usr/bin/c++ -include stdint.h "$@"
+WRAPPER_EOF
+        chmod +x "$GXX_WRAPPER"
+        ZVEC_CXX_COMPILER="-DCMAKE_CXX_COMPILER=$GXX_WRAPPER"
+    fi
+fi
+
+# --- Build zvec ---
+echo "Building zvec ${ZVEC_VERSION}..."
+ZVEC_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Release -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ${ZVEC_CXX_COMPILER:-}"
+mkdir -p zvec/build
+${CMAKE} -S zvec -B zvec/build $ZVEC_CMAKE_FLAGS
+${CMAKE} --build zvec/build -j${CPUS}
+
+echo "$ZVEC_VERSION" > "$STAMP_FILE"
+echo "zvec ${ZVEC_VERSION} built in zvec/build"


### PR DESCRIPTION
## Summary

Split monolithic `build_zvec.sh` into separate, cacheable build steps. CI
workflows restructured with a dedicated `setup-zvec` job that ext and FFI
jobs depend on.

## Changes

### New scripts

- **`build_zvec_lib.sh`** — builds only the zvec C++ library with version caching.
  Creates `zvec/build/.zvec_version` stamp file. Skips build if stamp matches
  the requested version. Auto-updates git checkout on version change. Supports
  prebuilt download fallback for CI.

- **`build_ffi.sh`** — builds only the FFI shared library (`ffi/build/libzvec_ffi.so`).
  Fails early if zvec is not built yet.

### Modified scripts

- **`build_zvec.sh`** — simplified to an orchestrator calling `build_zvec_lib.sh`
  then `build_ffi.sh`. Accepts optional version argument.

### CI workflows

**`build.yml`** — three jobs with dependency chain:
1. `setup-zvec`: builds zvec (prebuilt download or source), uploads as artifact
2. `build-ext` (needs: setup-zvec): downloads zvec artifact, builds ext, tests
3. `build-ffi` (needs: setup-zvec): downloads zvec artifact, builds FFI, tests

**`release.yml`** — same pattern with 4 jobs:
1. `create-release`: creates GitHub release
2. `setup-zvec` (needs: create-release): builds zvec, uploads artifact + prebuilt
3. `release-ffi` (needs: setup-zvec): builds FFI, uploads to release
4. `release-ext` (needs: setup-zvec): builds ext, uploads to release

No more duplicated "Setup zvec" steps in ext/FFI jobs.

### Documentation

- **`AGENTS.md`** — updated build commands section with the new 2-step flow
  and pre-commit checklist.

## Build flow

```bash
# Step 1: build zvec (skipped if already built for this version)
./build_zvec_lib.sh v0.4.0

# Step 2: build FFI wrapper
./build_ffi.sh

# Or both at once:
./build_zvec.sh v0.4.0
```

## Testing

- `./build_zvec_lib.sh` skips rebuild when stamp matches (verified)
- `./build_ffi.sh` builds FFI correctly (verified)
- `./build_zvec.sh` orchestrator (verified)
- All 54 .phpt tests pass (53 PASS, 1 XFAIL)