### PR TITLE
feat: add Composer package with FFI library auto-download

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,9 @@ zvec-php/
 ├── php/ZVec.php          # Main library (ZVec, ZVecSchema, ZVecDoc, ZVecException)
 ├── php/example.php       # Integration test / usage examples (21 scenarios)
 ├── ffi/                  # C++ FFI bridge (zvec_ffi.h, zvec_ffi.cc, CMakeLists.txt)
+├── src/Installer.php     # Composer CLI installer for FFI shared library
+├── bin/zvec-install      # CLI tool entry point for FFI library download
+├── composer.json         # Composer package definition
 ├── tests/                # Bug reproduction scripts (plain PHP, no framework)
 ├── test_dbs/             # Test database directory (content ignored by git)
 ├── tasks/todo/           # Feature planning documents
@@ -180,9 +183,9 @@ PHP 8.1+ required. Always use `declare(strict_types=1);` at the top of every fil
 
 ### Namespaces & Imports
 
-- No namespaces are used — all classes live in the global namespace.
-- No `use` import statements — reference all types by their global names.
-- Keep this convention until a composer autoloader is introduced.
+- Composer PSR-4 autoloading is configured for `CrazyGoat\ZVec\` namespace in `src/`.
+- Global classes (`ZVec`, `ZVecSchema`, `ZVecDoc`, `ZVecException`) are loaded via `autoload.files` — no `require_once` needed when using Composer.
+- No `use` import statements for global classes — reference them by their unqualified names.
 
 ### File Organization
 
@@ -322,9 +325,11 @@ require_once __DIR__ . '/../php/ZVec.php';
 
 ### Platform Notes
 
-- Currently macOS-only (builds `.dylib`, links CoreFoundation/Security).
-- The FFI shared library must be at the path expected by `ZVec.php`
-  (currently `__DIR__ . '/../ffi/build/libzvec_ffi.dylib'`).
+- Pre-built FFI library available for Linux x86_64 (glibc).
+- macOS and musl Linux builds not yet available as pre-built artifacts.
+- The FFI shared library is resolved from two locations (in order):
+  1. `__DIR__ . '/../lib/libzvec_ffi.so'` — Composer-installed (via `vendor/bin/zvec-install`)
+  2. `__DIR__ . '/../ffi/build/libzvec_ffi.so'` — locally built (via `./build_zvec.sh`)
 - `zvec/` directory is a git submodule - run `git submodule update --init` if missing.
 
 ### Memory Management

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.11] - 2026-05-10
+
+### Added
+
+- **Composer package with FFI library auto-download** (#4)
+  - Added `composer.json` with PSR-4 autoloading for `CrazyGoat\ZVec\` namespace
+  - `src/Installer.php` — standalone CLI installer for FFI shared library
+  - `bin/zvec-install` — `vendor/bin/zvec-install` entry point
+  - Platform detection: Linux x86_64 (glibc) supported; musl/Alpine, macOS rejected with clear message
+  - Version auto-detected from `vendor/composer/installed.json`; manual override via `vendor/bin/zvec-install v0.4.11`
+  - Pre-built FFI library (`libzvec_ffi-ubuntu24-x86_64.tar.gz`) uploaded to releases
+  - `ZVec.php` resolves FFI library from `lib/` (Composer) or `ffi/build/` (source build)
+
 ## [0.4.10] - 2026-05-10
 
 ### Changed
@@ -709,7 +722,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-[Unreleased]: https://github.com/alibaba/zvec-php/compare/v0.4.10...HEAD
+[Unreleased]: https://github.com/alibaba/zvec-php/compare/v0.4.11...HEAD
+[0.4.11]: https://github.com/crazy-goat/php-zvec/compare/v0.4.10...v0.4.11
 [0.4.10]: https://github.com/alibaba/zvec-php/compare/v0.4.9...v0.4.10
 [0.4.9]: https://github.com/alibaba/zvec-php/compare/v0.4.8...v0.4.9
 [0.4.8]: https://github.com/alibaba/zvec-php/compare/v0.4.7...v0.4.8

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ vendor/bin/zvec-install
 
 The `zvec-install` tool detects your OS and architecture, downloads the matching
 pre-built FFI shared library from GitHub Releases, and places it in `lib/`.
-The version is auto-detected from Composer's `installed.json` (matching your
-installed package version).
+The version is auto-detected from Composer's `installed.json`. If omitted,
+specify it explicitly: `vendor/bin/zvec-install v0.4.10`.
 
 Supported platforms:
 - **Linux x86_64 (glibc)** — pre-built (`libzvec_ffi-ubuntu24-x86_64.tar.gz`)

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ vendor/bin/zvec-install
 
 The `zvec-install` tool detects your OS and architecture, downloads the matching
 pre-built FFI shared library from GitHub Releases, and places it in `lib/`.
+The version is auto-detected from Composer's `installed.json` (matching your
+installed package version).
 
 Supported platforms:
 - **Linux x86_64 (glibc)** — pre-built (`libzvec_ffi-ubuntu24-x86_64.tar.gz`)

--- a/README.md
+++ b/README.md
@@ -24,10 +24,25 @@ zvec-php provides PHP bindings for the zvec vector database through FFI (Foreign
 ## Requirements
 
 - PHP 8.1+ (FFI mode) or PHP 8.5+ (native extension mode)
-- macOS (currently macOS only)
-- CMake 3.14+ (for building)
+- Linux x86_64 (for pre-built FFI library) or build tools for other platforms
+- CMake 3.14+ (if building from source)
 
 ## Installation
+
+### Quick start via Composer (FFI mode, Linux x86_64)
+
+```bash
+composer require crazy-goat/zvec
+vendor/bin/zvec-install
+```
+
+The `zvec-install` tool detects your OS and architecture, downloads the matching
+pre-built FFI shared library from GitHub Releases, and places it in `lib/`.
+
+Supported platforms:
+- **Linux x86_64 (glibc)** — pre-built (`libzvec_ffi-ubuntu24-x86_64.tar.gz`)
+
+### Manual build (all platforms)
 
 ### 1. Clone with submodules
 
@@ -46,7 +61,7 @@ This will:
 - Clone zvec repository (if not present)
 - Download CMake 3.28 locally
 - Build zvec C++ library
-- Build FFI wrapper (`ffi/build/libzvec_ffi.dylib`)
+- Build FFI wrapper (`ffi/build/libzvec_ffi.so`)
 
 ### 3. Verify installation (FFI mode)
 
@@ -269,7 +284,8 @@ See `tasks/done/` for detailed planning documents.
 ## Known Limitations
 
 - **GroupByQuery**: The C++ API has this method but it returns all documents in a single group with empty group value. This is a known issue in upstream zvec (marked as "Coming Soon" in zvec docs).
-- **Platform**: Currently macOS only (builds `.dylib` / `.so`)
+- **Platform**: Pre-built FFI library available for Linux x86_64 (glibc). macOS builds coming soon.
+- **musl Linux** (e.g., Alpine): musl-based Linux is not yet supported by the pre-built library. Build from source instead.
 
 ## License
 

--- a/bin/zvec-install
+++ b/bin/zvec-install
@@ -15,10 +15,9 @@ if ($argc > 1) {
         echo "Downloads and installs the zvec FFI shared library for your platform.\n\n";
         echo "Arguments:\n";
         echo "  version   Release version to download (e.g., v0.4.10).\n";
-        echo "            Default: detects version from Composer's installed.json,\n";
-        echo "            otherwise uses the hardcoded default (v0.4.10).\n\n";
+        echo "            Required when not running inside a Composer installation.\n\n";
         echo "Examples:\n";
-        echo "  zvec-install          Auto-detect version\n";
+        echo "  zvec-install          Detect version from installed.json\n";
         echo "  zvec-install v0.4.10  Install specific version\n";
         exit(0);
     }

--- a/bin/zvec-install
+++ b/bin/zvec-install
@@ -14,9 +14,11 @@ if ($argc > 1) {
         echo "Usage: zvec-install [version]\n\n";
         echo "Downloads and installs the zvec FFI shared library for your platform.\n\n";
         echo "Arguments:\n";
-        echo "  version   Release version to download (e.g., v0.4.10). Defaults to latest.\n\n";
+        echo "  version   Release version to download (e.g., v0.4.10).\n";
+        echo "            Default: detects version from Composer's installed.json,\n";
+        echo "            otherwise uses the hardcoded default (v0.4.10).\n\n";
         echo "Examples:\n";
-        echo "  zvec-install          Install latest version\n";
+        echo "  zvec-install          Auto-detect version\n";
         echo "  zvec-install v0.4.10  Install specific version\n";
         exit(0);
     }

--- a/bin/zvec-install
+++ b/bin/zvec-install
@@ -1,0 +1,26 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../src/Installer.php';
+
+use CrazyGoat\ZVec\Installer;
+
+$version = null;
+if ($argc > 1) {
+    $arg = $argv[1];
+    if ($arg === '--help' || $arg === '-h') {
+        echo "Usage: zvec-install [version]\n\n";
+        echo "Downloads and installs the zvec FFI shared library for your platform.\n\n";
+        echo "Arguments:\n";
+        echo "  version   Release version to download (e.g., v0.4.10). Defaults to latest.\n\n";
+        echo "Examples:\n";
+        echo "  zvec-install          Install latest version\n";
+        echo "  zvec-install v0.4.10  Install specific version\n";
+        exit(0);
+    }
+    $version = 'v' . ltrim($argv[1], 'v');
+}
+
+Installer::install($version);

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,27 @@
+{
+    "name": "crazy-goat/zvec",
+    "description": "PHP FFI bindings for zvec vector database",
+    "type": "library",
+    "license": "MIT",
+    "require": {
+        "php": ">=8.1",
+        "ext-ffi": "*"
+    },
+    "autoload": {
+        "psr-4": {
+            "CrazyGoat\\ZVec\\": "src/"
+        },
+        "files": [
+            "php/ZVec.php",
+            "php/ZVecRerankedDoc.php",
+            "php/ZVecReRanker.php",
+            "php/ZVecRrfReRanker.php",
+            "php/ZVecWeightedReRanker.php"
+        ]
+    },
+    "scripts": {
+        "post-install-cmd": "CrazyGoat\\ZVec\\Installer::install",
+        "post-update-cmd": "CrazyGoat\\ZVec\\Installer::install"
+    },
+    "minimum-stability": "stable"
+}

--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,8 @@
             "php/ZVecWeightedReRanker.php"
         ]
     },
-    "scripts": {
-        "post-install-cmd": "CrazyGoat\\ZVec\\Installer::install",
-        "post-update-cmd": "CrazyGoat\\ZVec\\Installer::install"
-    },
+    "bin": [
+        "bin/zvec-install"
+    ],
     "minimum-stability": "stable"
 }

--- a/php/ZVec.php
+++ b/php/ZVec.php
@@ -16,10 +16,21 @@ class ZVec
     {
         if (self::$ffi === null) {
             $ext = PHP_OS_FAMILY === 'Darwin' ? 'dylib' : 'so';
-            $libPath = __DIR__ . "/../ffi/build/libzvec_ffi.$ext";
+            $candidates = [
+                __DIR__ . "/../lib/libzvec_ffi.$ext",
+                __DIR__ . "/../ffi/build/libzvec_ffi.$ext",
+            ];
 
-            if (!file_exists($libPath)) {
-                throw new ZVecException("Library not found: $libPath. Run build_zvec.sh first.");
+            $libPath = null;
+            foreach ($candidates as $candidate) {
+                if (file_exists($candidate)) {
+                    $libPath = $candidate;
+                    break;
+                }
+            }
+
+            if ($libPath === null) {
+                throw new ZVecException("Library not found. Run 'composer install' or 'build_zvec.sh'.");
             }
 
             self::$ffi = FFI::cdef('

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\ZVec;
+
+use Composer\Script\Event;
+use RuntimeException;
+
+class Installer
+{
+    private const GITHUB_REPO = 'crazy-goat/php-zvec';
+    private const LIB_DIR = __DIR__ . '/../lib';
+
+    public static function install(Event $event): void
+    {
+        $io = $event->getIO();
+
+        $os = PHP_OS_FAMILY;
+        if ($os !== 'Linux') {
+            $io->writeError('<warning>zvec FFI library auto-download is only supported on Linux. Please build manually.</warning>');
+            return;
+        }
+
+        $arch = php_uname('m');
+        if ($arch !== 'x86_64') {
+            $io->writeError('<warning>zvec FFI library auto-download is only supported on x86_64. Please build manually.</warning>');
+            return;
+        }
+
+        $version = self::resolveVersion($event);
+        $assetName = 'libzvec_ffi-ubuntu24-x86_64.tar.gz';
+        $url = "https://github.com/" . self::GITHUB_REPO . "/releases/download/{$version}/{$assetName}";
+
+        $libDir = self::LIB_DIR;
+        if (!is_dir($libDir) && !mkdir($libDir, 0755, true)) {
+            throw new RuntimeException("Failed to create lib directory: {$libDir}");
+        }
+
+        $libPath = $libDir . '/libzvec_ffi.so';
+        if (file_exists($libPath)) {
+            $io->write("<info>zvec FFI library already installed at {$libPath}</info>");
+            return;
+        }
+
+        $io->write("<info>Downloading zvec FFI library {$version}...</info>");
+        $io->write("<info>URL: {$url}</info>");
+
+        $tmpFile = tempnam(sys_get_temp_dir(), 'zvec_ffi_') . '.tar.gz';
+
+        try {
+            self::download($url, $tmpFile);
+            self::extract($tmpFile, $libDir);
+        } finally {
+            if (file_exists($tmpFile)) {
+                unlink($tmpFile);
+            }
+        }
+
+        if (!file_exists($libPath)) {
+            throw new RuntimeException("Download succeeded but libzvec_ffi.so not found in archive.");
+        }
+
+        $io->write("<info>zvec FFI library installed at {$libPath}</info>");
+    }
+
+    private static function resolveVersion(Event $event): string
+    {
+        $package = $event->getComposer()->getPackage();
+        $version = $package->getPrettyVersion();
+
+        if (str_starts_with($version, 'dev-') || $version === 'No version set (parsed as 1.0.0)') {
+            return self::fetchLatestVersion();
+        }
+
+        return 'v' . ltrim($version, 'v');
+    }
+
+    private static function fetchLatestVersion(): string
+    {
+        $url = 'https://api.github.com/repos/' . self::GITHUB_REPO . '/releases/latest';
+        $ctx = stream_context_create(['http' => ['header' => "User-Agent: crazy-goat/zvec-installer\r\n"]]);
+        $json = @file_get_contents($url, false, $ctx);
+        if ($json === false) {
+            throw new RuntimeException("Failed to fetch latest release from GitHub API.");
+        }
+        $data = json_decode($json, true);
+        return $data['tag_name'] ?? throw new RuntimeException("Could not determine latest release version.");
+    }
+
+    private static function download(string $url, string $dest): void
+    {
+        $ctx = stream_context_create(['http' => ['header' => "User-Agent: crazy-goat/zvec-installer\r\n"]]);
+        $data = @file_get_contents($url, false, $ctx);
+        if ($data === false) {
+            throw new RuntimeException("Failed to download: {$url}");
+        }
+        file_put_contents($dest, $data);
+    }
+
+    private static function extract(string $tarGz, string $destDir): void
+    {
+        $cmd = sprintf('tar -xzf %s -C %s 2>&1', escapeshellarg($tarGz), escapeshellarg($destDir));
+        exec($cmd, $output, $code);
+        if ($code !== 0) {
+            throw new RuntimeException("Failed to extract archive: " . implode("\n", $output));
+        }
+    }
+}

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CrazyGoat\ZVec;
 
-use Composer\Script\Event;
 use RuntimeException;
 
 class Installer
@@ -12,24 +11,16 @@ class Installer
     private const GITHUB_REPO = 'crazy-goat/php-zvec';
     private const LIB_DIR = __DIR__ . '/../lib';
 
-    public static function install(Event $event): void
+    public static function install(?string $version = null): void
     {
-        $io = $event->getIO();
-
-        $os = PHP_OS_FAMILY;
-        if ($os !== 'Linux') {
-            $io->writeError('<warning>zvec FFI library auto-download is only supported on Linux. Please build manually.</warning>');
+        $assetName = self::resolveAssetName();
+        if ($assetName === null) {
+            echo "zvec FFI library auto-download is not supported on your platform (" . PHP_OS_FAMILY . " " . php_uname('m') . ").\n";
+            echo "See https://github.com/" . self::GITHUB_REPO . " for build instructions.\n";
             return;
         }
 
-        $arch = php_uname('m');
-        if ($arch !== 'x86_64') {
-            $io->writeError('<warning>zvec FFI library auto-download is only supported on x86_64. Please build manually.</warning>');
-            return;
-        }
-
-        $version = self::resolveVersion($event);
-        $assetName = 'libzvec_ffi-ubuntu24-x86_64.tar.gz';
+        $version = $version ?? self::detectVersion();
         $url = "https://github.com/" . self::GITHUB_REPO . "/releases/download/{$version}/{$assetName}";
 
         $libDir = self::LIB_DIR;
@@ -37,14 +28,14 @@ class Installer
             throw new RuntimeException("Failed to create lib directory: {$libDir}");
         }
 
-        $libPath = $libDir . '/libzvec_ffi.so';
+        $libName = self::libName();
+        $libPath = $libDir . '/' . $libName;
         if (file_exists($libPath)) {
-            $io->write("<info>zvec FFI library already installed at {$libPath}</info>");
+            echo "zvec FFI library already installed at {$libPath}\n";
             return;
         }
 
-        $io->write("<info>Downloading zvec FFI library {$version}...</info>");
-        $io->write("<info>URL: {$url}</info>");
+        echo "Downloading zvec FFI library {$version} for " . self::platformLabel() . "...\n";
 
         $tmpFile = tempnam(sys_get_temp_dir(), 'zvec_ffi_') . '.tar.gz';
 
@@ -58,22 +49,80 @@ class Installer
         }
 
         if (!file_exists($libPath)) {
-            throw new RuntimeException("Download succeeded but libzvec_ffi.so not found in archive.");
+            throw new RuntimeException("Download succeeded but {$libName} not found in archive.");
         }
 
-        $io->write("<info>zvec FFI library installed at {$libPath}</info>");
+        echo "zvec FFI library installed at {$libPath}\n";
     }
 
-    private static function resolveVersion(Event $event): string
+    public static function platformLabel(): string
     {
-        $package = $event->getComposer()->getPackage();
-        $version = $package->getPrettyVersion();
-
-        if (str_starts_with($version, 'dev-') || $version === 'No version set (parsed as 1.0.0)') {
-            return self::fetchLatestVersion();
+        if (PHP_OS_FAMILY === 'Darwin') {
+            return 'macOS ' . php_uname('m');
         }
+        if (PHP_OS_FAMILY === 'Linux') {
+            $libc = self::isMusl() ? 'musl' : 'glibc';
+            return 'Linux ' . php_uname('m') . ' (' . $libc . ')';
+        }
+        return PHP_OS_FAMILY . ' ' . php_uname('m');
+    }
 
-        return 'v' . ltrim($version, 'v');
+    private static function resolveAssetName(): ?string
+    {
+        if (PHP_OS_FAMILY !== 'Linux') {
+            return null;
+        }
+        if (php_uname('m') !== 'x86_64') {
+            return null;
+        }
+        if (self::isMusl()) {
+            return null;
+        }
+        return 'libzvec_ffi-ubuntu24-x86_64.tar.gz';
+    }
+
+    private static function isMusl(): bool
+    {
+        return file_exists('/lib/ld-musl-x86_64.so.1')
+            || file_exists('/lib/ld-musl-aarch64.so.1')
+            || file_exists('/lib/ld-musl-arm.so.1');
+    }
+
+    private static function libName(): string
+    {
+        return PHP_OS_FAMILY === 'Darwin' ? 'libzvec_ffi.dylib' : 'libzvec_ffi.so';
+    }
+
+    private static function detectVersion(): string
+    {
+        $version = self::versionFromInstalledJson();
+        if ($version !== null) {
+            return $version;
+        }
+        return self::fetchLatestVersion();
+    }
+
+    private static function versionFromInstalledJson(): ?string
+    {
+        $path = __DIR__ . '/../../../composer/installed.json';
+        if (!file_exists($path)) {
+            return null;
+        }
+        $data = json_decode(file_get_contents($path), true);
+        if (!is_array($data)) {
+            return null;
+        }
+        $packages = $data['packages'] ?? $data;
+        foreach ((array)$packages as $key => $pkg) {
+            $name = $pkg['name'] ?? (is_array($pkg) && isset($data['packages']) ? $key : null);
+            if ($name === 'crazy-goat/zvec' || ($name === null && isset($pkg['name']) && $pkg['name'] === 'crazy-goat/zvec')) {
+                $version = $pkg['version'] ?? null;
+                if ($version !== null && $version !== '*') {
+                    return 'v' . ltrim($version, 'v');
+                }
+            }
+        }
+        return null;
     }
 
     private static function fetchLatestVersion(): string

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -9,6 +9,7 @@ use RuntimeException;
 class Installer
 {
     private const GITHUB_REPO = 'crazy-goat/php-zvec';
+    private const DEFAULT_VERSION = 'v0.4.10';
     private const LIB_DIR = __DIR__ . '/../lib';
 
     public static function install(?string $version = null): void
@@ -99,7 +100,7 @@ class Installer
         if ($version !== null) {
             return $version;
         }
-        return self::fetchLatestVersion();
+        return self::DEFAULT_VERSION;
     }
 
     private static function versionFromInstalledJson(): ?string
@@ -123,18 +124,6 @@ class Installer
             }
         }
         return null;
-    }
-
-    private static function fetchLatestVersion(): string
-    {
-        $url = 'https://api.github.com/repos/' . self::GITHUB_REPO . '/releases/latest';
-        $ctx = stream_context_create(['http' => ['header' => "User-Agent: crazy-goat/zvec-installer\r\n"]]);
-        $json = @file_get_contents($url, false, $ctx);
-        if ($json === false) {
-            throw new RuntimeException("Failed to fetch latest release from GitHub API.");
-        }
-        $data = json_decode($json, true);
-        return $data['tag_name'] ?? throw new RuntimeException("Could not determine latest release version.");
     }
 
     private static function download(string $url, string $dest): void

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -9,7 +9,6 @@ use RuntimeException;
 class Installer
 {
     private const GITHUB_REPO = 'crazy-goat/php-zvec';
-    private const DEFAULT_VERSION = 'v0.4.10';
     private const LIB_DIR = __DIR__ . '/../lib';
 
     public static function install(?string $version = null): void
@@ -100,7 +99,10 @@ class Installer
         if ($version !== null) {
             return $version;
         }
-        return self::DEFAULT_VERSION;
+        throw new RuntimeException(
+            "Could not determine package version. " .
+            "Run 'composer install' first, or specify a version: vendor/bin/zvec-install v0.4.10"
+        );
     }
 
     private static function versionFromInstalledJson(): ?string


### PR DESCRIPTION
## Summary

Add a Composer package (crazy-goat/zvec) so users can install zvec-php FFI backend with a simple `composer require`.

### Changes

- **composer.json** — package definition with PSR-4 autoloading (CrazyGoat\ZVec\ namespace)
- **php/ZVec.php** — look for FFI library in lib/ (Composer) first, then ffi/build/ (dev)
- **src/Installer.php** — standalone class for platform detection and FFI library download
- **bin/zvec-install** — CLI entry point (vendor/bin/zvec-install)
- **README/AGENTS.md** — updated installation docs

### CLI Tool Features

- Platform detection: Linux x86_64 (glibc) supported; musl/Alpine and macOS detected and rejected
- Version matching: reads installed package version from vendor/composer/installed.json
- Manual override: vendor/bin/zvec-install v0.4.10 for specific version
- Fails with clear message when version can't be determined

### Usage

```bash
composer require crazy-goat/zvec
vendor/bin/zvec-install
```

Or specify a version explicitly:

```bash
vendor/bin/zvec-install v0.4.10
```

### Why CLI tool instead of post-install-cmd?

Composer post-install-cmd scripts defined in a dependency package are NOT executed — only root package scripts run. A bin entry (vendor/bin/zvec-install) works reliably.

### Follow-up

Multi-platform builds (Alpine musl, macOS) tracked in issue #23.