### PR TITLE
feat: unified IndexParams API — createIndex(IndexParams)

### DIFF
--- a/ffi/zvec_ffi.cc
+++ b/ffi/zvec_ffi.cc
@@ -454,6 +454,109 @@ zvec_status_t zvec_collection_drop_index(zvec_collection_t coll, const char* fie
     return make_status(c->DropIndex(field_name));
 }
 
+// --- Unified IndexParams API ---
+
+struct IndexParamsHolder {
+    IndexType type_;
+    MetricType metric_type_;
+    QuantizeType quantize_type_;
+    int hnsw_m_;
+    int hnsw_ef_construction_;
+    int ivf_n_list_;
+    int ivf_n_iters_;
+    bool ivf_use_soar_;
+    bool invert_enable_range_;
+    bool invert_enable_wildcard_;
+
+    IndexParamsHolder(IndexType type, MetricType metric_type)
+        : type_(type), metric_type_(metric_type), quantize_type_(QuantizeType::UNDEFINED),
+          hnsw_m_(50), hnsw_ef_construction_(500),
+          ivf_n_list_(1024), ivf_n_iters_(10), ivf_use_soar_(false),
+          invert_enable_range_(true), invert_enable_wildcard_(false) {}
+
+    IndexParams::Ptr build() const {
+        switch (type_) {
+            case IndexType::HNSW:
+                return std::make_shared<HnswIndexParams>(metric_type_, hnsw_m_, hnsw_ef_construction_, quantize_type_);
+            case IndexType::FLAT:
+                return std::make_shared<FlatIndexParams>(metric_type_, quantize_type_);
+            case IndexType::IVF:
+                return std::make_shared<IVFIndexParams>(metric_type_, ivf_n_list_, ivf_n_iters_, ivf_use_soar_, quantize_type_);
+            case IndexType::INVERT:
+                return std::make_shared<InvertIndexParams>(invert_enable_range_, invert_enable_wildcard_);
+            default:
+                return nullptr;
+        }
+    }
+};
+
+static IndexType to_index_type(int v) {
+    switch (v) {
+        case 1: return IndexType::HNSW;
+        case 2: return IndexType::IVF;
+        case 3: return IndexType::FLAT;
+        case 10: return IndexType::INVERT;
+        default: return IndexType::UNDEFINED;
+    }
+}
+
+zvec_index_params_t zvec_index_params_create(int index_type, int metric_type) {
+    auto* holder = new IndexParamsHolder(to_index_type(index_type), to_metric_type(metric_type));
+    return static_cast<zvec_index_params_t>(holder);
+}
+
+void zvec_index_params_free(zvec_index_params_t params) {
+    delete static_cast<IndexParamsHolder*>(params);
+}
+
+void zvec_index_params_set_hnsw(zvec_index_params_t params, int m, int ef_construction, int quantize_type) {
+    auto* h = static_cast<IndexParamsHolder*>(params);
+    h->hnsw_m_ = m;
+    h->hnsw_ef_construction_ = ef_construction;
+    h->quantize_type_ = to_quantize_type(quantize_type);
+}
+
+void zvec_index_params_set_flat(zvec_index_params_t params, int quantize_type) {
+    auto* h = static_cast<IndexParamsHolder*>(params);
+    h->quantize_type_ = to_quantize_type(quantize_type);
+}
+
+void zvec_index_params_set_ivf(zvec_index_params_t params, int n_list, int n_iters, int use_soar, int quantize_type) {
+    auto* h = static_cast<IndexParamsHolder*>(params);
+    h->ivf_n_list_ = n_list;
+    h->ivf_n_iters_ = n_iters;
+    h->ivf_use_soar_ = (bool)use_soar;
+    h->quantize_type_ = to_quantize_type(quantize_type);
+}
+
+void zvec_index_params_set_invert(zvec_index_params_t params, int enable_range, int enable_wildcard) {
+    auto* h = static_cast<IndexParamsHolder*>(params);
+    h->invert_enable_range_ = (bool)enable_range;
+    h->invert_enable_wildcard_ = (bool)enable_wildcard;
+}
+
+void zvec_index_params_set_quantize_type(zvec_index_params_t params, int quantize_type) {
+    auto* h = static_cast<IndexParamsHolder*>(params);
+    h->quantize_type_ = to_quantize_type(quantize_type);
+}
+
+void zvec_index_params_set_metric_type(zvec_index_params_t params, int metric_type) {
+    auto* h = static_cast<IndexParamsHolder*>(params);
+    h->metric_type_ = to_metric_type(metric_type);
+}
+
+zvec_status_t zvec_collection_create_index(zvec_collection_t coll, const char* field_name, zvec_index_params_t params, uint32_t concurrency) {
+    auto* c = static_cast<Collection*>(coll);
+    auto* h = static_cast<IndexParamsHolder*>(params);
+    auto index_params = h->build();
+    if (!index_params) {
+        return make_status(Status(StatusCode::INVALID_ARGUMENT, "Invalid or unsupported index type"));
+    }
+    CreateIndexOptions opts;
+    if (concurrency > 0) opts.concurrency_ = static_cast<int>(concurrency);
+    return make_status(c->CreateIndex(field_name, index_params, opts));
+}
+
 // --- Doc ---
 
 zvec_doc_t zvec_doc_create(const char* pk) {

--- a/ffi/zvec_ffi.h
+++ b/ffi/zvec_ffi.h
@@ -101,6 +101,19 @@ zvec_status_t zvec_collection_create_flat_index(zvec_collection_t coll, const ch
 zvec_status_t zvec_collection_create_ivf_index(zvec_collection_t coll, const char* field_name, uint32_t metric_type, int n_list, int n_iters, int use_soar, uint32_t quantize_type, uint32_t concurrency);
 zvec_status_t zvec_collection_drop_index(zvec_collection_t coll, const char* field_name);
 
+// Unified IndexParams API
+typedef void* zvec_index_params_t;
+
+zvec_index_params_t zvec_index_params_create(int index_type, int metric_type);
+void zvec_index_params_free(zvec_index_params_t params);
+void zvec_index_params_set_hnsw(zvec_index_params_t params, int m, int ef_construction, int quantize_type);
+void zvec_index_params_set_flat(zvec_index_params_t params, int quantize_type);
+void zvec_index_params_set_ivf(zvec_index_params_t params, int n_list, int n_iters, int use_soar, int quantize_type);
+void zvec_index_params_set_invert(zvec_index_params_t params, int enable_range, int enable_wildcard);
+void zvec_index_params_set_quantize_type(zvec_index_params_t params, int quantize_type);
+void zvec_index_params_set_metric_type(zvec_index_params_t params, int metric_type);
+zvec_status_t zvec_collection_create_index(zvec_collection_t coll, const char* field_name, zvec_index_params_t params, uint32_t concurrency);
+
 // Doc
 zvec_doc_t zvec_doc_create(const char* pk);
 void zvec_doc_free(zvec_doc_t doc);

--- a/src/ZVec.php
+++ b/src/ZVec.php
@@ -108,7 +108,19 @@ class ZVec
 zvec_status_t zvec_collection_create_hnsw_index(zvec_collection_t coll, const char* field_name, uint32_t metric_type, int m, int ef_construction, uint32_t quantize_type, uint32_t concurrency);
 zvec_status_t zvec_collection_create_flat_index(zvec_collection_t coll, const char* field_name, uint32_t metric_type, uint32_t quantize_type, uint32_t concurrency);
 zvec_status_t zvec_collection_create_ivf_index(zvec_collection_t coll, const char* field_name, uint32_t metric_type, int n_list, int n_iters, int use_soar, uint32_t quantize_type, uint32_t concurrency);
-zvec_status_t zvec_collection_drop_index(zvec_collection_t coll, const char* field_name);
+                zvec_status_t zvec_collection_drop_index(zvec_collection_t coll, const char* field_name);
+
+                typedef void* zvec_index_params_t;
+
+                zvec_index_params_t zvec_index_params_create(int index_type, int metric_type);
+                void zvec_index_params_free(zvec_index_params_t params);
+                void zvec_index_params_set_hnsw(zvec_index_params_t params, int m, int ef_construction, int quantize_type);
+                void zvec_index_params_set_flat(zvec_index_params_t params, int quantize_type);
+                void zvec_index_params_set_ivf(zvec_index_params_t params, int n_list, int n_iters, int use_soar, int quantize_type);
+                void zvec_index_params_set_invert(zvec_index_params_t params, int enable_range, int enable_wildcard);
+                void zvec_index_params_set_quantize_type(zvec_index_params_t params, int quantize_type);
+                void zvec_index_params_set_metric_type(zvec_index_params_t params, int metric_type);
+                zvec_status_t zvec_collection_create_index(zvec_collection_t coll, const char* field_name, zvec_index_params_t params, uint32_t concurrency);
 
                 zvec_doc_t zvec_doc_create(const char* pk);
                 void zvec_doc_free(zvec_doc_t doc);
@@ -421,34 +433,43 @@ zvec_status_t zvec_collection_drop_index(zvec_collection_t coll, const char* fie
         self::checkStatus(self::ffi()->zvec_collection_alter_column($this->handle, $columnName, $rename, $dataType, $isNullable, $concurrency));
     }
 
-    public function createInvertIndex(string $fieldName, bool $enableRange = true, bool $enableWildcard = false): void
-    {
-        $this->checkClosed();
-        self::checkStatus(self::ffi()->zvec_collection_create_invert_index($this->handle, $fieldName, $enableRange ? 1 : 0, $enableWildcard ? 1 : 0));
-    }
-
-    public function createHnswIndex(string $fieldName, int $metricType = ZVecSchema::METRIC_IP, int $m = 50, int $efConstruction = 500, int $quantizeType = 0, int $concurrency = 0): void
-    {
-        $this->checkClosed();
-        self::checkStatus(self::ffi()->zvec_collection_create_hnsw_index($this->handle, $fieldName, $metricType, $m, $efConstruction, $quantizeType, $concurrency));
-    }
-
-    public function createFlatIndex(string $fieldName, int $metricType = ZVecSchema::METRIC_IP, int $quantizeType = 0, int $concurrency = 0): void
-    {
-        $this->checkClosed();
-        self::checkStatus(self::ffi()->zvec_collection_create_flat_index($this->handle, $fieldName, $metricType, $quantizeType, $concurrency));
-    }
-
-    public function createIvfIndex(string $fieldName, int $metricType = ZVecSchema::METRIC_IP, int $nList = 1024, int $nIters = 10, bool $useSoar = false, int $quantizeType = 0, int $concurrency = 0): void
-    {
-        $this->checkClosed();
-        self::checkStatus(self::ffi()->zvec_collection_create_ivf_index($this->handle, $fieldName, $metricType, $nList, $nIters, $useSoar ? 1 : 0, $quantizeType, $concurrency));
-    }
-
     public function dropIndex(string $fieldName): void
     {
         $this->checkClosed();
         self::checkStatus(self::ffi()->zvec_collection_drop_index($this->handle, $fieldName));
+    }
+
+    /**
+     * Create an index using the unified IndexParams API.
+     */
+    public function createIndex(string $fieldName, ZVecIndexParams $params, int $concurrency = 0): void
+    {
+        $this->checkClosed();
+        self::checkStatus(self::ffi()->zvec_collection_create_index($this->handle, $fieldName, $params->getHandle(), $concurrency));
+    }
+
+    /** @deprecated Use createIndex() with ZVecIndexParams::forInvert() instead */
+    public function createInvertIndex(string $fieldName, bool $enableRange = true, bool $enableWildcard = false): void
+    {
+        $this->createIndex($fieldName, ZVecIndexParams::forInvert($enableRange, $enableWildcard));
+    }
+
+    /** @deprecated Use createIndex() with ZVecIndexParams::forHnsw() instead */
+    public function createHnswIndex(string $fieldName, int $metricType = ZVecSchema::METRIC_IP, int $m = 50, int $efConstruction = 500, int $quantizeType = 0, int $concurrency = 0): void
+    {
+        $this->createIndex($fieldName, ZVecIndexParams::forHnsw($metricType, $m, $efConstruction, $quantizeType), $concurrency);
+    }
+
+    /** @deprecated Use createIndex() with ZVecIndexParams::forFlat() instead */
+    public function createFlatIndex(string $fieldName, int $metricType = ZVecSchema::METRIC_IP, int $quantizeType = 0, int $concurrency = 0): void
+    {
+        $this->createIndex($fieldName, ZVecIndexParams::forFlat($metricType, $quantizeType), $concurrency);
+    }
+
+    /** @deprecated Use createIndex() with ZVecIndexParams::forIvf() instead */
+    public function createIvfIndex(string $fieldName, int $metricType = ZVecSchema::METRIC_IP, int $nList = 1024, int $nIters = 10, bool $useSoar = false, int $quantizeType = 0, int $concurrency = 0): void
+    {
+        $this->createIndex($fieldName, ZVecIndexParams::forIvf($metricType, $nList, $nIters, $useSoar, $quantizeType), $concurrency);
     }
 
     public function insert(ZVecDoc ...$docs): void
@@ -635,6 +656,12 @@ zvec_status_t zvec_collection_drop_index(zvec_collection_t coll, const char* fie
 
         return $docs;
     }
+
+    // Index types for unified IndexParams API
+    public const INDEX_TYPE_HNSW = 1;
+    public const INDEX_TYPE_IVF = 2;
+    public const INDEX_TYPE_FLAT = 3;
+    public const INDEX_TYPE_INVERT = 10;
 
     public const QUERY_PARAM_NONE = 0;
     public const QUERY_PARAM_HNSW = 1;
@@ -1219,6 +1246,63 @@ zvec_status_t zvec_collection_drop_index(zvec_collection_t coll, const char* fie
         $buf = $ffi->new('char[4096]');
         self::checkStatus($ffi->zvec_collection_stats($this->handle, $buf, 4096));
         return FFI::string($buf);
+    }
+}
+
+class ZVecIndexParams
+{
+    private FFI\CData $handle;
+
+    private function __construct(FFI\CData $handle)
+    {
+        $this->handle = $handle;
+    }
+
+    public function __destruct()
+    {
+        self::ffi()->zvec_index_params_free($this->handle);
+    }
+
+    public function getHandle(): FFI\CData
+    {
+        return $this->handle;
+    }
+
+    public static function forHnsw(int $metricType, int $m = 50, int $efConstruction = 500, int $quantizeType = ZVec::QUANTIZE_UNDEFINED): self
+    {
+        $ffi = self::ffi();
+        $handle = $ffi->zvec_index_params_create(ZVec::INDEX_TYPE_HNSW, $metricType);
+        $ffi->zvec_index_params_set_hnsw($handle, $m, $efConstruction, $quantizeType);
+        return new self($handle);
+    }
+
+    public static function forFlat(int $metricType, int $quantizeType = ZVec::QUANTIZE_UNDEFINED): self
+    {
+        $ffi = self::ffi();
+        $handle = $ffi->zvec_index_params_create(ZVec::INDEX_TYPE_FLAT, $metricType);
+        $ffi->zvec_index_params_set_flat($handle, $quantizeType);
+        return new self($handle);
+    }
+
+    public static function forIvf(int $metricType, int $nList = 1024, int $nIters = 10, bool $useSoar = false, int $quantizeType = ZVec::QUANTIZE_UNDEFINED): self
+    {
+        $ffi = self::ffi();
+        $handle = $ffi->zvec_index_params_create(ZVec::INDEX_TYPE_IVF, $metricType);
+        $ffi->zvec_index_params_set_ivf($handle, $nList, $nIters, $useSoar ? 1 : 0, $quantizeType);
+        return new self($handle);
+    }
+
+    public static function forInvert(bool $enableRange = true, bool $enableWildcard = false): self
+    {
+        $ffi = self::ffi();
+        $handle = $ffi->zvec_index_params_create(ZVec::INDEX_TYPE_INVERT, ZVecSchema::METRIC_IP);
+        $ffi->zvec_index_params_set_invert($handle, $enableRange ? 1 : 0, $enableWildcard ? 1 : 0);
+        return new self($handle);
+    }
+
+    private static function ffi(): FFI
+    {
+        return (new ReflectionClass(ZVec::class))->getMethod('ffi')->invoke(null);
     }
 }
 

--- a/tests/test_index_params.phpt
+++ b/tests/test_index_params.phpt
@@ -1,0 +1,77 @@
+--TEST--
+IndexParams: unified createIndex() with ZVecIndexParams (all 4 types)
+--SKIPIF--
+<?php if (!extension_loaded('ffi')) die('skip FFI extension not available'); ?>
+--FILE--
+<?php
+require_once __DIR__ . '/../src/ZVec.php';
+ZVec::init(logType: ZVec::LOG_CONSOLE, logLevel: ZVec::LOG_WARN);
+
+$path = __DIR__ . '/../test_dbs/idxparams_' . uniqid();
+try {
+    // Create schema
+    $schema = new ZVecSchema('test');
+    $schema->addInt64('id', nullable: false, withInvertIndex: true);
+    $schema->addVectorFp32('vec', 4, ZVecSchema::METRIC_COSINE);
+    $coll = ZVec::create($path, $schema);
+
+    // HNSW via unified API
+    $params = ZVecIndexParams::forHnsw(
+        metricType: ZVecSchema::METRIC_COSINE,
+        m: 16,
+        efConstruction: 200,
+        quantizeType: ZVec::QUANTIZE_INT8
+    );
+    $coll->createIndex('vec', $params);
+    echo "HNSW via unified API\n";
+
+    // Flat via unified API
+    $params2 = ZVecIndexParams::forFlat(metricType: ZVecSchema::METRIC_IP);
+    $coll->createIndex('vec', $params2);
+    echo "Flat via unified API\n";
+
+    // Invert via unified API
+    $params3 = ZVecIndexParams::forInvert(enableRange: true, enableWildcard: false);
+    $coll->createIndex('id', $params3);
+    echo "Invert via unified API\n";
+
+    // IVF via unified API
+    $params4 = ZVecIndexParams::forIvf(
+        metricType: ZVecSchema::METRIC_COSINE,
+        nList: 64,
+        nIters: 5,
+        useSoar: false,
+        quantizeType: ZVec::QUANTIZE_FP16
+    );
+    $coll->createIndex('vec', $params4);
+    echo "IVF via unified API\n";
+
+    // Deprecated wrappers still work
+    $coll->createHnswIndex('vec', metricType: ZVecSchema::METRIC_COSINE, m: 16, efConstruction: 200);
+    echo "HNSW via legacy API\n";
+
+    $coll->createFlatIndex('vec', metricType: ZVecSchema::METRIC_IP);
+    echo "Flat via legacy API\n";
+
+    $coll->createInvertIndex('id');
+    echo "Invert via legacy API\n";
+
+    $coll->createIvfIndex('vec', metricType: ZVecSchema::METRIC_COSINE, nList: 64, nIters: 5);
+    echo "IVF via legacy API\n";
+
+    $coll->close();
+    echo "OK\n";
+} finally {
+    exec("rm -rf " . escapeshellarg($path));
+}
+?>
+--EXPECT--
+HNSW via unified API
+Flat via unified API
+Invert via unified API
+IVF via unified API
+HNSW via legacy API
+Flat via legacy API
+Invert via legacy API
+IVF via legacy API
+OK


### PR DESCRIPTION
## Summary

Replace the 4 separate index creation methods (`createHnswIndex`, `createFlatIndex`, `createIvfIndex`, `createInvertIndex`) with a single `createIndex()` that accepts a `ZVecIndexParams` object, matching zvec v0.4.0's unified API and Node.js/Python SDK patterns.

## Changes

### FFI Layer (`ffi/zvec_ffi.h` / `ffi/zvec_ffi.cc`)
- Added `zvec_index_params_t` opaque type with type-specific setters
- Added `zvec_collection_create_index()` unified function
- Old FFI functions kept as-is (used by PHP FFI directly)

### PHP Layer (`src/ZVec.php`)
- New `ZVecIndexParams` class with 4 static factories:
  - `ZVecIndexParams::forHnsw(metricType, m, efConstruction, quantizeType)`
  - `ZVecIndexParams::forFlat(metricType, quantizeType)`
  - `ZVecIndexParams::forIvf(metricType, nList, nIters, useSoar, quantizeType)`
  - `ZVecIndexParams::forInvert(enableRange, enableWildcard)`
- New `ZVec::createIndex(string $fieldName, ZVecIndexParams $params, int $concurrency = 0)` method
- Old methods (`createHnswIndex`, `createFlatIndex`, `createIvfIndex`, `createInvertIndex`) kept as `@deprecated` wrappers that delegate to `createIndex()`
- Added `INDEX_TYPE_*` constants (HNSW=1, IVF=2, FLAT=3, INVERT=10)

### Tests (`tests/test_index_params.phpt`)
- Covers all 4 index types via new unified API and legacy wrappers

## Testing
All 56 tests pass (54 PASS + 2 XFAIL).

Closes #9