### PR TITLE
feat: add QUANTIZE_RABITQ and METRIC_MIPSL2 constants (#27)

### DIFF
--- a/php-ext/zvec_collection.cc
+++ b/php-ext/zvec_collection.cc
@@ -1634,4 +1634,5 @@ void zvec_register_collection(INIT_FUNC_ARGS) {
     zend_declare_class_constant_long(zvec_collection_ce, "QUANTIZE_FP16", sizeof("QUANTIZE_FP16") - 1, 1);
     zend_declare_class_constant_long(zvec_collection_ce, "QUANTIZE_INT8", sizeof("QUANTIZE_INT8") - 1, 2);
     zend_declare_class_constant_long(zvec_collection_ce, "QUANTIZE_INT4", sizeof("QUANTIZE_INT4") - 1, 3);
+    zend_declare_class_constant_long(zvec_collection_ce, "QUANTIZE_RABITQ", sizeof("QUANTIZE_RABITQ") - 1, 4);
 }

--- a/php-ext/zvec_schema.cc
+++ b/php-ext/zvec_schema.cc
@@ -359,4 +359,5 @@ void zvec_register_schema(INIT_FUNC_ARGS) {
     zend_declare_class_constant_long(zvec_schema_ce, "METRIC_L2", sizeof("METRIC_L2") - 1, 1);
     zend_declare_class_constant_long(zvec_schema_ce, "METRIC_IP", sizeof("METRIC_IP") - 1, 2);
     zend_declare_class_constant_long(zvec_schema_ce, "METRIC_COSINE", sizeof("METRIC_COSINE") - 1, 3);
+    zend_declare_class_constant_long(zvec_schema_ce, "METRIC_MIPSL2", sizeof("METRIC_MIPSL2") - 1, 4);
 }

--- a/src/ZVec.php
+++ b/src/ZVec.php
@@ -695,6 +695,7 @@ zvec_status_t zvec_collection_create_ivf_index(zvec_collection_t coll, const cha
     public const QUANTIZE_FP16 = 1;
     public const QUANTIZE_INT8 = 2;
     public const QUANTIZE_INT4 = 3;
+    public const QUANTIZE_RABITQ = 4;
 
     public static function init(
         int $logType = self::LOG_CONSOLE,
@@ -1474,6 +1475,7 @@ class ZVecSchema
     public const METRIC_L2 = 1;
     public const METRIC_IP = 2;
     public const METRIC_COSINE = 3;
+    public const METRIC_MIPSL2 = 4;
 
     public function addVectorFp32(string $name, int $dimension, int $metricType = self::METRIC_IP): self
     {

--- a/tests/test_quantize_rabitq_and_metric_mipsl2.phpt
+++ b/tests/test_quantize_rabitq_and_metric_mipsl2.phpt
@@ -1,0 +1,91 @@
+--TEST--
+QUANTIZE_RABITQ and METRIC_MIPSL2 constants
+--SKIPIF--
+<?php if (!extension_loaded('zvec') && !extension_loaded('ffi')) die('skip Neither zvec extension nor FFI available'); ?>
+--FILE--
+<?php
+require_once __DIR__ . '/../src/ZVec.php';
+ZVec::init(logType: ZVec::LOG_CONSOLE, logLevel: ZVec::LOG_WARN);
+
+// Verify constant values match C++ enum definitions
+assert(ZVec::QUANTIZE_RABITQ === 4, "QUANTIZE_RABITQ should be 4");
+echo "QUANTIZE_RABITQ = " . ZVec::QUANTIZE_RABITQ . "\n";
+
+assert(ZVecSchema::METRIC_MIPSL2 === 4, "METRIC_MIPSL2 should be 4");
+echo "METRIC_MIPSL2 = " . ZVecSchema::METRIC_MIPSL2 . "\n";
+
+$path = __DIR__ . '/../test_dbs/rabitq_mipsl2_' . uniqid();
+try {
+    $schema = new ZVecSchema('test');
+    $schema->addInt64('id', nullable: false, withInvertIndex: true)
+        ->addVectorFp32('vec', dimension: 8, metricType: ZVecSchema::METRIC_MIPSL2);
+
+    $collection = ZVec::create($path, $schema);
+
+    // Insert docs
+    for ($i = 1; $i <= 10; $i++) {
+        $vec = [];
+        for ($j = 0; $j < 8; $j++) {
+            $vec[] = 0.01 * $i + 0.001 * $j;
+        }
+        $doc = new ZVecDoc("doc$i");
+        $doc->setInt64('id', $i)->setVectorFp32('vec', $vec);
+        $collection->insert($doc);
+    }
+    $collection->optimize();
+
+    // Query with METRIC_MIPSL2 field
+    $queryVec = [];
+    for ($j = 0; $j < 8; $j++) {
+        $queryVec[] = 0.01 + 0.001 * $j;
+    }
+    $results = $collection->query('vec', $queryVec, topk: 5);
+    assert(count($results) === 5, "Expected 5 results with METRIC_MIPSL2");
+    echo "Query with METRIC_MIPSL2 field returns " . count($results) . " results\n";
+
+    // Create HNSW index with QUANTIZE_RABITQ
+    $collection->createHnswIndex(
+        'vec',
+        metricType: ZVecSchema::METRIC_MIPSL2,
+        m: 16,
+        efConstruction: 200,
+        quantizeType: ZVec::QUANTIZE_RABITQ
+    );
+    $collection->flush();
+    $collection->optimize();
+    echo "HNSW index with QUANTIZE_RABITQ created\n";
+
+    $rabitqResults = $collection->query('vec', $queryVec, topk: 5);
+    assert(count($rabitqResults) === 5, "Expected 5 results with QUANTIZE_RABITQ");
+    echo "Query with QUANTIZE_RABITQ HNSW returns " . count($rabitqResults) . " results\n";
+
+    // Create Flat index with QUANTIZE_RABITQ
+    $collection->dropIndex('vec');
+    $collection->flush();
+    $collection->createFlatIndex(
+        'vec',
+        metricType: ZVecSchema::METRIC_MIPSL2,
+        quantizeType: ZVec::QUANTIZE_RABITQ
+    );
+    $collection->flush();
+    $collection->optimize();
+    echo "Flat index with QUANTIZE_RABITQ created\n";
+
+    $flatResults = $collection->query('vec', $queryVec, topk: 5);
+    assert(count($flatResults) === 5, "Expected 5 results with QUANTIZE_RABITQ Flat");
+    echo "Query with QUANTIZE_RABITQ Flat returns " . count($flatResults) . " results\n";
+
+    echo "PASS: All constants and index operations work\n";
+} finally {
+    exec("rm -rf " . escapeshellarg($path));
+}
+?>
+--EXPECT--
+QUANTIZE_RABITQ = 4
+METRIC_MIPSL2 = 4
+Query with METRIC_MIPSL2 field returns 5 results
+HNSW index with QUANTIZE_RABITQ created
+Query with QUANTIZE_RABITQ HNSW returns 5 results
+Flat index with QUANTIZE_RABITQ created
+Query with QUANTIZE_RABITQ Flat returns 5 results
+PASS: All constants and index operations work


### PR DESCRIPTION
## Summary

Adds two missing enum constants from upstream zvec v0.4.0 C++ library and Python/Node.js SDKs:

- `QUANTIZE_RABITQ = 4` — quantization type for HNSW/Flat/Vamana indexes
- `METRIC_MIPSL2 = 4` — metric type for vector similarity search

**Changes:**
- `src/ZVec.php`: Added two constants matching C++ enum values from `zvec/src/include/zvec/db/type.h`
- `tests/test_quantize_rabitq_and_metric_mipsl2.phpt`: Functional test covering both constants — creates collections, inserts data, builds HNSW and Flat indexes with new constants, and runs queries

**Verification:**
- All 57 tests pass (55 pass + 2 pre-existing expected failures)
- Constant values verified against upstream C++ definitions