### PR TITLE
feat: add createHnswRabitqIndex() support (HNSW + RaBitQ quantization)

### DIFF
--- a/ffi/zvec_ffi.cc
+++ b/ffi/zvec_ffi.cc
@@ -433,6 +433,14 @@ zvec_status_t zvec_collection_create_hnsw_index(zvec_collection_t coll, const ch
     return make_status(c->CreateIndex(field_name, params, opts));
 }
 
+zvec_status_t zvec_collection_create_hnsw_rabitq_index(zvec_collection_t coll, const char* field_name, uint32_t metric_type, int total_bits, int num_clusters, int m, int ef_construction, int sample_count, uint32_t concurrency) {
+    auto* c = static_cast<Collection*>(coll);
+    auto params = std::make_shared<HnswRabitqIndexParams>(to_metric_type(metric_type), total_bits, num_clusters, m, ef_construction, sample_count);
+    CreateIndexOptions opts;
+    if (concurrency > 0) opts.concurrency_ = static_cast<int>(concurrency);
+    return make_status(c->CreateIndex(field_name, params, opts));
+}
+
 zvec_status_t zvec_collection_create_flat_index(zvec_collection_t coll, const char* field_name, uint32_t metric_type, uint32_t quantize_type, uint32_t concurrency) {
     auto* c = static_cast<Collection*>(coll);
     auto params = std::make_shared<FlatIndexParams>(to_metric_type(metric_type), to_quantize_type(quantize_type));
@@ -467,17 +475,23 @@ struct IndexParamsHolder {
     bool ivf_use_soar_;
     bool invert_enable_range_;
     bool invert_enable_wildcard_;
+    int rabitq_total_bits_;
+    int rabitq_num_clusters_;
+    int rabitq_sample_count_;
 
     IndexParamsHolder(IndexType type, MetricType metric_type)
         : type_(type), metric_type_(metric_type), quantize_type_(QuantizeType::UNDEFINED),
           hnsw_m_(50), hnsw_ef_construction_(500),
           ivf_n_list_(1024), ivf_n_iters_(10), ivf_use_soar_(false),
-          invert_enable_range_(true), invert_enable_wildcard_(false) {}
+          invert_enable_range_(true), invert_enable_wildcard_(false),
+          rabitq_total_bits_(7), rabitq_num_clusters_(16), rabitq_sample_count_(0) {}
 
     IndexParams::Ptr build() const {
         switch (type_) {
             case IndexType::HNSW:
                 return std::make_shared<HnswIndexParams>(metric_type_, hnsw_m_, hnsw_ef_construction_, quantize_type_);
+            case IndexType::HNSW_RABITQ:
+                return std::make_shared<HnswRabitqIndexParams>(metric_type_, rabitq_total_bits_, rabitq_num_clusters_, hnsw_m_, hnsw_ef_construction_, rabitq_sample_count_);
             case IndexType::FLAT:
                 return std::make_shared<FlatIndexParams>(metric_type_, quantize_type_);
             case IndexType::IVF:
@@ -495,6 +509,7 @@ static IndexType to_index_type(int v) {
         case 1: return IndexType::HNSW;
         case 2: return IndexType::IVF;
         case 3: return IndexType::FLAT;
+        case 4: return IndexType::HNSW_RABITQ;
         case 10: return IndexType::INVERT;
         default: return IndexType::UNDEFINED;
     }
@@ -527,6 +542,15 @@ void zvec_index_params_set_ivf(zvec_index_params_t params, int n_list, int n_ite
     h->ivf_n_iters_ = n_iters;
     h->ivf_use_soar_ = (bool)use_soar;
     h->quantize_type_ = to_quantize_type(quantize_type);
+}
+
+void zvec_index_params_set_hnsw_rabitq(zvec_index_params_t params, int total_bits, int num_clusters, int m, int ef_construction, int sample_count) {
+    auto* h = static_cast<IndexParamsHolder*>(params);
+    h->rabitq_total_bits_ = total_bits;
+    h->rabitq_num_clusters_ = num_clusters;
+    h->hnsw_m_ = m;
+    h->hnsw_ef_construction_ = ef_construction;
+    h->rabitq_sample_count_ = sample_count;
 }
 
 void zvec_index_params_set_invert(zvec_index_params_t params, int enable_range, int enable_wildcard) {
@@ -1261,6 +1285,7 @@ static zvec_status_t validate_query_param_type(Collection* c, const char* field_
         case 1: expected_index_type = IndexType::HNSW; break;
         case 2: expected_index_type = IndexType::IVF; break;
         case 3: expected_index_type = IndexType::FLAT; break;
+        case 4: expected_index_type = IndexType::HNSW_RABITQ; break;
     }
     
     if (expected_index_type != IndexType::UNDEFINED && 
@@ -1293,6 +1318,9 @@ static void apply_query_params(VectorQuery& query, int type, int hnsw_ef, int iv
         params->set_radius(radius);
         params->set_is_linear((bool)is_linear);
         query.query_params_ = params;
+    } else if (type == 4) {
+        query.query_params_ = std::make_shared<HnswRabitqQueryParams>(
+            hnsw_ef, radius, (bool)is_linear, (bool)is_using_refiner);
     }
 }
 

--- a/ffi/zvec_ffi.h
+++ b/ffi/zvec_ffi.h
@@ -97,6 +97,7 @@ zvec_status_t zvec_collection_alter_column(zvec_collection_t coll, const char* c
 // Schema evolution - Index DDL
 zvec_status_t zvec_collection_create_invert_index(zvec_collection_t coll, const char* field_name, int enable_range, int enable_wildcard);
 zvec_status_t zvec_collection_create_hnsw_index(zvec_collection_t coll, const char* field_name, uint32_t metric_type, int m, int ef_construction, uint32_t quantize_type, uint32_t concurrency);
+zvec_status_t zvec_collection_create_hnsw_rabitq_index(zvec_collection_t coll, const char* field_name, uint32_t metric_type, int total_bits, int num_clusters, int m, int ef_construction, int sample_count, uint32_t concurrency);
 zvec_status_t zvec_collection_create_flat_index(zvec_collection_t coll, const char* field_name, uint32_t metric_type, uint32_t quantize_type, uint32_t concurrency);
 zvec_status_t zvec_collection_create_ivf_index(zvec_collection_t coll, const char* field_name, uint32_t metric_type, int n_list, int n_iters, int use_soar, uint32_t quantize_type, uint32_t concurrency);
 zvec_status_t zvec_collection_drop_index(zvec_collection_t coll, const char* field_name);
@@ -107,6 +108,7 @@ typedef void* zvec_index_params_t;
 zvec_index_params_t zvec_index_params_create(int index_type, int metric_type);
 void zvec_index_params_free(zvec_index_params_t params);
 void zvec_index_params_set_hnsw(zvec_index_params_t params, int m, int ef_construction, int quantize_type);
+void zvec_index_params_set_hnsw_rabitq(zvec_index_params_t params, int total_bits, int num_clusters, int m, int ef_construction, int sample_count);
 void zvec_index_params_set_flat(zvec_index_params_t params, int quantize_type);
 void zvec_index_params_set_ivf(zvec_index_params_t params, int n_list, int n_iters, int use_soar, int quantize_type);
 void zvec_index_params_set_invert(zvec_index_params_t params, int enable_range, int enable_wildcard);

--- a/src/ZVec.php
+++ b/src/ZVec.php
@@ -106,6 +106,7 @@ class ZVec
 
                 zvec_status_t zvec_collection_create_invert_index(zvec_collection_t coll, const char* field_name, int enable_range, int enable_wildcard);
 zvec_status_t zvec_collection_create_hnsw_index(zvec_collection_t coll, const char* field_name, uint32_t metric_type, int m, int ef_construction, uint32_t quantize_type, uint32_t concurrency);
+zvec_status_t zvec_collection_create_hnsw_rabitq_index(zvec_collection_t coll, const char* field_name, uint32_t metric_type, int total_bits, int num_clusters, int m, int ef_construction, int sample_count, uint32_t concurrency);
 zvec_status_t zvec_collection_create_flat_index(zvec_collection_t coll, const char* field_name, uint32_t metric_type, uint32_t quantize_type, uint32_t concurrency);
 zvec_status_t zvec_collection_create_ivf_index(zvec_collection_t coll, const char* field_name, uint32_t metric_type, int n_list, int n_iters, int use_soar, uint32_t quantize_type, uint32_t concurrency);
                 zvec_status_t zvec_collection_drop_index(zvec_collection_t coll, const char* field_name);
@@ -115,6 +116,7 @@ zvec_status_t zvec_collection_create_ivf_index(zvec_collection_t coll, const cha
                 zvec_index_params_t zvec_index_params_create(int index_type, int metric_type);
                 void zvec_index_params_free(zvec_index_params_t params);
                 void zvec_index_params_set_hnsw(zvec_index_params_t params, int m, int ef_construction, int quantize_type);
+                void zvec_index_params_set_hnsw_rabitq(zvec_index_params_t params, int total_bits, int num_clusters, int m, int ef_construction, int sample_count);
                 void zvec_index_params_set_flat(zvec_index_params_t params, int quantize_type);
                 void zvec_index_params_set_ivf(zvec_index_params_t params, int n_list, int n_iters, int use_soar, int quantize_type);
                 void zvec_index_params_set_invert(zvec_index_params_t params, int enable_range, int enable_wildcard);
@@ -460,6 +462,12 @@ zvec_status_t zvec_collection_create_ivf_index(zvec_collection_t coll, const cha
         $this->createIndex($fieldName, ZVecIndexParams::forHnsw($metricType, $m, $efConstruction, $quantizeType), $concurrency);
     }
 
+    /** @deprecated Use createIndex() with ZVecIndexParams::forHnswRabitq() instead */
+    public function createHnswRabitqIndex(string $fieldName, int $metricType = ZVecSchema::METRIC_IP, int $totalBits = 7, int $numClusters = 16, int $m = 50, int $efConstruction = 500, int $sampleCount = 0, int $concurrency = 0): void
+    {
+        $this->createIndex($fieldName, ZVecIndexParams::forHnswRabitq($metricType, $totalBits, $numClusters, $m, $efConstruction, $sampleCount), $concurrency);
+    }
+
     /** @deprecated Use createIndex() with ZVecIndexParams::forFlat() instead */
     public function createFlatIndex(string $fieldName, int $metricType = ZVecSchema::METRIC_IP, int $quantizeType = 0, int $concurrency = 0): void
     {
@@ -661,12 +669,14 @@ zvec_status_t zvec_collection_create_ivf_index(zvec_collection_t coll, const cha
     public const INDEX_TYPE_HNSW = 1;
     public const INDEX_TYPE_IVF = 2;
     public const INDEX_TYPE_FLAT = 3;
+    public const INDEX_TYPE_HNSW_RABITQ = 4;
     public const INDEX_TYPE_INVERT = 10;
 
     public const QUERY_PARAM_NONE = 0;
     public const QUERY_PARAM_HNSW = 1;
     public const QUERY_PARAM_IVF = 2;
     public const QUERY_PARAM_FLAT = 3;
+    public const QUERY_PARAM_HNSW_RABITQ = 4;
 
     public const LOG_CONSOLE = 0;
     public const LOG_FILE = 1;
@@ -1277,6 +1287,14 @@ class ZVecIndexParams
         return new self($handle);
     }
 
+    public static function forHnswRabitq(int $metricType, int $totalBits = 7, int $numClusters = 16, int $m = 50, int $efConstruction = 500, int $sampleCount = 0): self
+    {
+        $ffi = self::ffi();
+        $handle = $ffi->zvec_index_params_create(ZVec::INDEX_TYPE_HNSW_RABITQ, $metricType);
+        $ffi->zvec_index_params_set_hnsw_rabitq($handle, $totalBits, $numClusters, $m, $efConstruction, $sampleCount);
+        return new self($handle);
+    }
+
     public static function forFlat(int $metricType, int $quantizeType = ZVec::QUANTIZE_UNDEFINED): self
     {
         $ffi = self::ffi();
@@ -1363,6 +1381,13 @@ class ZVecVectorQuery
     public function setHnswParams(int $ef): self
     {
         $this->queryParamType = ZVec::QUERY_PARAM_HNSW;
+        $this->hnswEf = $ef;
+        return $this;
+    }
+
+    public function setHnswRabitqParams(int $ef): self
+    {
+        $this->queryParamType = ZVec::QUERY_PARAM_HNSW_RABITQ;
         $this->hnswEf = $ef;
         return $this;
     }

--- a/tests/test_hnsw_rabitq_index.phpt
+++ b/tests/test_hnsw_rabitq_index.phpt
@@ -1,0 +1,73 @@
+--TEST--
+HNSW RaBitQ index: create, insert with dim >= 64, optimize, query
+--SKIPIF--
+<?php if (!extension_loaded('ffi')) die('skip FFI extension not available'); ?>
+--FILE--
+<?php
+require_once __DIR__ . '/../src/ZVec.php';
+ZVec::init(logType: ZVec::LOG_CONSOLE, logLevel: ZVec::LOG_ERROR);
+
+$path = __DIR__ . '/../test_dbs/hnsw_rabitq_' . uniqid();
+try {
+    $schema = new ZVecSchema('test');
+    $schema->addInt64('id');
+    $schema->addVectorFp32('vec', dimension: 64, metricType: ZVecSchema::METRIC_IP);
+    $coll = ZVec::create($path, $schema);
+
+    $coll->createIndex('vec', ZVecIndexParams::forHnswRabitq(
+        metricType: ZVecSchema::METRIC_IP,
+        m: 50,
+        efConstruction: 500,
+    ));
+
+    // Insert some docs with distinct vectors
+    $data = [];
+    for ($i = 0; $i < 10; $i++) {
+        $vec = [];
+        for ($j = 0; $j < 64; $j++) {
+            $vec[] = $j === $i ? 1.0 : 0.0;
+        }
+        $data[] = $vec;
+        $doc = new ZVecDoc('doc' . $i);
+        $doc->setInt64('id', $i);
+        $doc->setVectorFp32('vec', $vec);
+        $coll->insert($doc);
+    }
+    $coll->optimize();
+
+    $query = new ZVecVectorQuery('vec', $data[0]);
+    $query->setHnswRabitqParams(ef: 100);
+    $results = $coll->query($query);
+
+    echo "Results: " . count($results) . "\n";
+    echo "Top pk: " . $results[0]->getPk() . "\n";
+
+    // Query with legacy method
+    $results2 = $coll->query('vec', $data[0], topk: 3, queryParamType: ZVec::QUERY_PARAM_HNSW_RABITQ, hnswEf: 100);
+    echo "Legacy results: " . count($results2) . "\n";
+
+    $coll->close();
+
+    // Test via deprecated convenience method
+    $coll2 = ZVec::create($path . '_2', $schema);
+    $coll2->createHnswRabitqIndex('vec');
+    $doc2 = new ZVecDoc('d1');
+    $doc2->setInt64('id', 1);
+    $doc2->setVectorFp32('vec', array_fill(0, 64, 0.1));
+    $coll2->insert($doc2);
+    $coll2->optimize();
+    echo "Deprecated method works\n";
+    $coll2->destroy();
+
+    echo "OK\n";
+} finally {
+    exec("rm -rf " . escapeshellarg($path));
+    exec("rm -rf " . escapeshellarg($path . '_2'));
+}
+?>
+--EXPECTF--
+%AResults: %d
+Top pk: doc0
+Legacy results: 3
+%ADeprecated method works
+OK


### PR DESCRIPTION
## Summary

Add HNSW_RABITQ index type (`IndexType = 4`) combining HNSW graph search with RaBitQ (Randomized Binary Quantization) for memory-efficient vector storage.

Closes #29.

## Changes

### FFI Layer (`ffi/zvec_ffi.h` / `ffi/zvec_ffi.cc`)

- `zvec_collection_create_hnsw_rabitq_index()` — create index with RaBitQ-specific params (total_bits, num_clusters, m, ef_construction, sample_count)
- `zvec_index_params_set_hnsw_rabitq()` — unified IndexParams API support
- `IndexParamsHolder` now handles `IndexType::HNSW_RABITQ`
- `apply_query_params()` supports type 4 → uses `HnswRabitqQueryParams(ef, radius, is_linear, is_using_refiner)`
- `validate_query_param_type()` validates type 4 against `IndexType::HNSW_RABITQ`

### PHP Layer (`src/ZVec.php`)

- Constants: `INDEX_TYPE_HNSW_RABITQ = 4`, `QUERY_PARAM_HNSW_RABITQ = 4`
- `createHnswRabitqIndex()` — convenience method (delegates to unified API)
- `ZVecIndexParams::forHnswRabitq()` — unified API method
- `ZVecVectorQuery::setHnswRabitqParams()` — query method

### Tests (`tests/test_hnsw_rabitq_index.phpt`)

- Creates collection with dim=64 FP32 vectors
- Creates HNSW_RABITQ index via unified `createIndex()` + `ZVecIndexParams::forHnswRabitq()$
- Inserts documents, optimizes, queries with `ZVecVectorQuery::setHnswRabitqParams()`
- Verifies legacy method signature (`queryParamType: QUERY_PARAM_HNSW_RABITQ`)
- Tests deprecated `createHnswRabitqIndex()` convenience method

## Notes

- HNSW_RABITQ requires dimension >= 64, only VECTOR_FP32 data type (enforced by upstream)
- Quantize type is always RABITQ (fixed in `HnswRabitqIndexParams` constructor)
- Query params reuse existing `hnswEf` field (same as HNSW)