### PR TITLE
feat: add new data types — SPARSE_FP16, BINARY, and 8 ARRAY types

### DIFF
--- a/ffi/zvec_ffi.cc
+++ b/ffi/zvec_ffi.cc
@@ -193,6 +193,81 @@ void zvec_schema_add_field_vector_fp16(zvec_schema_t schema, const char* name, u
         std::make_shared<HnswIndexParams>(to_metric_type(metric_type))));
 }
 
+void zvec_schema_add_field_vector_int4(zvec_schema_t schema, const char* name, uint32_t dimension, uint32_t metric_type) {
+    auto* s = static_cast<CollectionSchema*>(schema);
+    s->add_field(std::make_shared<FieldSchema>(name, DataType::VECTOR_INT4, dimension, false,
+        std::make_shared<HnswIndexParams>(to_metric_type(metric_type))));
+}
+
+void zvec_schema_add_field_vector_int16(zvec_schema_t schema, const char* name, uint32_t dimension, uint32_t metric_type) {
+    auto* s = static_cast<CollectionSchema*>(schema);
+    s->add_field(std::make_shared<FieldSchema>(name, DataType::VECTOR_INT16, dimension, false,
+        std::make_shared<HnswIndexParams>(to_metric_type(metric_type))));
+}
+
+void zvec_schema_add_field_vector_binary32(zvec_schema_t schema, const char* name, uint32_t dimension, uint32_t metric_type) {
+    auto* s = static_cast<CollectionSchema*>(schema);
+    s->add_field(std::make_shared<FieldSchema>(name, DataType::VECTOR_BINARY32, dimension, false,
+        std::make_shared<HnswIndexParams>(to_metric_type(metric_type))));
+}
+
+void zvec_schema_add_field_vector_binary64(zvec_schema_t schema, const char* name, uint32_t dimension, uint32_t metric_type) {
+    auto* s = static_cast<CollectionSchema*>(schema);
+    s->add_field(std::make_shared<FieldSchema>(name, DataType::VECTOR_BINARY64, dimension, false,
+        std::make_shared<HnswIndexParams>(to_metric_type(metric_type))));
+}
+
+void zvec_schema_add_field_sparse_vector_fp16(zvec_schema_t schema, const char* name, uint32_t metric_type) {
+    auto* s = static_cast<CollectionSchema*>(schema);
+    s->add_field(std::make_shared<FieldSchema>(name, DataType::SPARSE_VECTOR_FP16, 0, false,
+        std::make_shared<HnswIndexParams>(to_metric_type(metric_type))));
+}
+
+void zvec_schema_add_field_binary(zvec_schema_t schema, const char* name, int nullable) {
+    auto* s = static_cast<CollectionSchema*>(schema);
+    s->add_field(std::make_shared<FieldSchema>(name, DataType::BINARY, (bool)nullable));
+}
+
+void zvec_schema_add_field_array_string(zvec_schema_t schema, const char* name, int nullable) {
+    auto* s = static_cast<CollectionSchema*>(schema);
+    s->add_field(std::make_shared<FieldSchema>(name, DataType::ARRAY_STRING, (bool)nullable));
+}
+
+void zvec_schema_add_field_array_bool(zvec_schema_t schema, const char* name, int nullable) {
+    auto* s = static_cast<CollectionSchema*>(schema);
+    s->add_field(std::make_shared<FieldSchema>(name, DataType::ARRAY_BOOL, (bool)nullable));
+}
+
+void zvec_schema_add_field_array_int32(zvec_schema_t schema, const char* name, int nullable) {
+    auto* s = static_cast<CollectionSchema*>(schema);
+    s->add_field(std::make_shared<FieldSchema>(name, DataType::ARRAY_INT32, (bool)nullable));
+}
+
+void zvec_schema_add_field_array_int64(zvec_schema_t schema, const char* name, int nullable) {
+    auto* s = static_cast<CollectionSchema*>(schema);
+    s->add_field(std::make_shared<FieldSchema>(name, DataType::ARRAY_INT64, (bool)nullable));
+}
+
+void zvec_schema_add_field_array_uint32(zvec_schema_t schema, const char* name, int nullable) {
+    auto* s = static_cast<CollectionSchema*>(schema);
+    s->add_field(std::make_shared<FieldSchema>(name, DataType::ARRAY_UINT32, (bool)nullable));
+}
+
+void zvec_schema_add_field_array_uint64(zvec_schema_t schema, const char* name, int nullable) {
+    auto* s = static_cast<CollectionSchema*>(schema);
+    s->add_field(std::make_shared<FieldSchema>(name, DataType::ARRAY_UINT64, (bool)nullable));
+}
+
+void zvec_schema_add_field_array_float(zvec_schema_t schema, const char* name, int nullable) {
+    auto* s = static_cast<CollectionSchema*>(schema);
+    s->add_field(std::make_shared<FieldSchema>(name, DataType::ARRAY_FLOAT, (bool)nullable));
+}
+
+void zvec_schema_add_field_array_double(zvec_schema_t schema, const char* name, int nullable) {
+    auto* s = static_cast<CollectionSchema*>(schema);
+    s->add_field(std::make_shared<FieldSchema>(name, DataType::ARRAY_DOUBLE, (bool)nullable));
+}
+
 // --- Collection ---
 
 static std::vector<Collection::Ptr> g_collections;
@@ -661,6 +736,94 @@ void zvec_doc_set_sparse_vector_fp32(zvec_doc_t doc, const char* field, const ui
     }
 }
 
+void zvec_doc_set_vector_int4(zvec_doc_t doc, const char* field, const int8_t* data, uint32_t dim) {
+    std::vector<int8_t> vec(data, data + dim);
+    static_cast<Doc*>(doc)->set<std::vector<int8_t>>(field, std::move(vec));
+}
+
+void zvec_doc_set_vector_int16(zvec_doc_t doc, const char* field, const int16_t* data, uint32_t dim) {
+    std::vector<int16_t> vec(data, data + dim);
+    static_cast<Doc*>(doc)->set<std::vector<int16_t>>(field, std::move(vec));
+}
+
+void zvec_doc_set_vector_binary32(zvec_doc_t doc, const char* field, const uint32_t* data, uint32_t dim) {
+    std::vector<uint32_t> vec(data, data + dim);
+    static_cast<Doc*>(doc)->set<std::vector<uint32_t>>(field, std::move(vec));
+}
+
+void zvec_doc_set_vector_binary64(zvec_doc_t doc, const char* field, const uint64_t* data, uint32_t dim) {
+    std::vector<uint64_t> vec(data, data + dim);
+    static_cast<Doc*>(doc)->set<std::vector<uint64_t>>(field, std::move(vec));
+}
+
+void zvec_doc_set_sparse_vector_fp16(zvec_doc_t doc, const char* field, const uint32_t* indices, const uint16_t* values, uint32_t count) {
+    if (count == 0) {
+        static_cast<Doc*>(doc)->set<std::pair<std::vector<uint32_t>, std::vector<ailego::Float16>>>(field,
+            std::make_pair(std::vector<uint32_t>(), std::vector<ailego::Float16>()));
+    } else {
+        std::vector<uint32_t> idx_vec(indices, indices + count);
+        std::vector<ailego::Float16> val_vec;
+        val_vec.reserve(count);
+        for (uint32_t i = 0; i < count; i++) {
+            val_vec.push_back(ailego::FloatHelper::ToFP32(values[i]));
+        }
+        static_cast<Doc*>(doc)->set<std::pair<std::vector<uint32_t>, std::vector<ailego::Float16>>>(field,
+            std::make_pair(std::move(idx_vec), std::move(val_vec)));
+    }
+}
+
+void zvec_doc_set_binary(zvec_doc_t doc, const char* field, const uint8_t* data, uint32_t size) {
+    static_cast<Doc*>(doc)->set<std::string>(field, std::string(reinterpret_cast<const char*>(data), size));
+}
+
+void zvec_doc_set_array_int32(zvec_doc_t doc, const char* field, const int32_t* data, uint32_t count) {
+    std::vector<int32_t> vec(data, data + count);
+    static_cast<Doc*>(doc)->set<std::vector<int32_t>>(field, std::move(vec));
+}
+
+void zvec_doc_set_array_int64(zvec_doc_t doc, const char* field, const int64_t* data, uint32_t count) {
+    std::vector<int64_t> vec(data, data + count);
+    static_cast<Doc*>(doc)->set<std::vector<int64_t>>(field, std::move(vec));
+}
+
+void zvec_doc_set_array_uint32(zvec_doc_t doc, const char* field, const uint32_t* data, uint32_t count) {
+    std::vector<uint32_t> vec(data, data + count);
+    static_cast<Doc*>(doc)->set<std::vector<uint32_t>>(field, std::move(vec));
+}
+
+void zvec_doc_set_array_uint64(zvec_doc_t doc, const char* field, const uint64_t* data, uint32_t count) {
+    std::vector<uint64_t> vec(data, data + count);
+    static_cast<Doc*>(doc)->set<std::vector<uint64_t>>(field, std::move(vec));
+}
+
+void zvec_doc_set_array_float(zvec_doc_t doc, const char* field, const float* data, uint32_t count) {
+    std::vector<float> vec(data, data + count);
+    static_cast<Doc*>(doc)->set<std::vector<float>>(field, std::move(vec));
+}
+
+void zvec_doc_set_array_double(zvec_doc_t doc, const char* field, const double* data, uint32_t count) {
+    std::vector<double> vec(data, data + count);
+    static_cast<Doc*>(doc)->set<std::vector<double>>(field, std::move(vec));
+}
+
+void zvec_doc_set_array_string(zvec_doc_t doc, const char* field, const char** strings, uint32_t count) {
+    std::vector<std::string> vec;
+    vec.reserve(count);
+    for (uint32_t i = 0; i < count; i++) {
+        vec.emplace_back(strings[i]);
+    }
+    static_cast<Doc*>(doc)->set<std::vector<std::string>>(field, std::move(vec));
+}
+
+void zvec_doc_set_array_bool(zvec_doc_t doc, const char* field, const uint8_t* data, uint32_t count) {
+    std::vector<bool> vec;
+    vec.reserve(count);
+    for (uint32_t i = 0; i < count; i++) {
+        vec.push_back((bool)data[i]);
+    }
+    static_cast<Doc*>(doc)->set<std::vector<bool>>(field, std::move(vec));
+}
+
 static thread_local std::string g_pk_buf;
 
 const char* zvec_doc_get_pk(zvec_doc_t doc) {
@@ -801,6 +964,210 @@ int zvec_doc_get_sparse_vector_fp32(zvec_doc_t doc, const char* field, const uin
     return 0;
 }
 
+static thread_local std::vector<int16_t> g_vector_int16_buf;
+
+int zvec_doc_get_vector_int16(zvec_doc_t doc, const char* field, const int16_t** out, uint32_t* dim) {
+    auto result = static_cast<Doc*>(doc)->get_field<std::vector<int16_t>>(field);
+    if (result.ok()) {
+        g_vector_int16_buf = result.value();
+        *out = g_vector_int16_buf.data();
+        *dim = static_cast<uint32_t>(g_vector_int16_buf.size());
+        return 1;
+    }
+    return 0;
+}
+
+static thread_local std::vector<uint32_t> g_vector_binary32_buf;
+
+int zvec_doc_get_vector_binary32(zvec_doc_t doc, const char* field, const uint32_t** out, uint32_t* dim) {
+    auto result = static_cast<Doc*>(doc)->get_field<std::vector<uint32_t>>(field);
+    if (result.ok()) {
+        g_vector_binary32_buf = result.value();
+        *out = g_vector_binary32_buf.data();
+        *dim = static_cast<uint32_t>(g_vector_binary32_buf.size());
+        return 1;
+    }
+    return 0;
+}
+
+static thread_local std::vector<uint64_t> g_vector_binary64_buf;
+
+int zvec_doc_get_vector_binary64(zvec_doc_t doc, const char* field, const uint64_t** out, uint32_t* dim) {
+    auto result = static_cast<Doc*>(doc)->get_field<std::vector<uint64_t>>(field);
+    if (result.ok()) {
+        g_vector_binary64_buf = result.value();
+        *out = g_vector_binary64_buf.data();
+        *dim = static_cast<uint32_t>(g_vector_binary64_buf.size());
+        return 1;
+    }
+    return 0;
+}
+
+// For INT4, store in same buffer type (int8_t) since they share the same variant
+int zvec_doc_get_vector_int4(zvec_doc_t doc, const char* field, const int8_t** out, uint32_t* dim) {
+    auto result = static_cast<Doc*>(doc)->get_field<std::vector<int8_t>>(field);
+    if (result.ok()) {
+        g_vector_int8_buf = result.value();
+        *out = g_vector_int8_buf.data();
+        *dim = static_cast<uint32_t>(g_vector_int8_buf.size());
+        return 1;
+    }
+    return 0;
+}
+
+// Sparse FP16 - circular buffer
+static thread_local std::array<std::pair<std::vector<uint32_t>, std::vector<ailego::Float16>>, 16> g_sparse_fp16_buffers;
+static thread_local size_t g_sparse_fp16_buffer_idx = 0;
+
+int zvec_doc_get_sparse_vector_fp16(zvec_doc_t doc, const char* field, const uint32_t** indices_out, const uint16_t** values_out, uint32_t* count_out) {
+    auto result = static_cast<Doc*>(doc)->get_field<std::pair<std::vector<uint32_t>, std::vector<ailego::Float16>>>(field);
+    if (result.ok()) {
+        auto& slot = g_sparse_fp16_buffers[g_sparse_fp16_buffer_idx];
+        slot = result.value();
+        *indices_out = slot.first.data();
+        
+        // Convert float16_t values back to uint16_t for PHP
+        thread_local static std::vector<uint16_t> g_tmp_fp16_vals;
+        g_tmp_fp16_vals.resize(slot.second.size());
+        for (size_t i = 0; i < slot.second.size(); i++) {
+            g_tmp_fp16_vals[i] = ailego::FloatHelper::ToFP16(static_cast<float>(slot.second[i]));
+        }
+        *values_out = g_tmp_fp16_vals.data();
+        *count_out = static_cast<uint32_t>(slot.first.size());
+        g_sparse_fp16_buffer_idx = (g_sparse_fp16_buffer_idx + 1) % 16;
+        return 1;
+    }
+    return 0;
+}
+
+static thread_local std::string g_binary_buf;
+
+int zvec_doc_get_binary(zvec_doc_t doc, const char* field, const uint8_t** out, uint32_t* size) {
+    auto result = static_cast<Doc*>(doc)->get_field<std::string>(field);
+    if (result.ok()) {
+        g_binary_buf = result.value();
+        *out = reinterpret_cast<const uint8_t*>(g_binary_buf.data());
+        *size = static_cast<uint32_t>(g_binary_buf.size());
+        return 1;
+    }
+    return 0;
+}
+
+static thread_local std::vector<int32_t> g_array_int32_buf;
+
+int zvec_doc_get_array_int32(zvec_doc_t doc, const char* field, const int32_t** out, uint32_t* count) {
+    auto result = static_cast<Doc*>(doc)->get_field<std::vector<int32_t>>(field);
+    if (result.ok()) {
+        g_array_int32_buf = result.value();
+        *out = g_array_int32_buf.data();
+        *count = static_cast<uint32_t>(g_array_int32_buf.size());
+        return 1;
+    }
+    return 0;
+}
+
+static thread_local std::vector<int64_t> g_array_int64_buf;
+
+int zvec_doc_get_array_int64(zvec_doc_t doc, const char* field, const int64_t** out, uint32_t* count) {
+    auto result = static_cast<Doc*>(doc)->get_field<std::vector<int64_t>>(field);
+    if (result.ok()) {
+        g_array_int64_buf = result.value();
+        *out = g_array_int64_buf.data();
+        *count = static_cast<uint32_t>(g_array_int64_buf.size());
+        return 1;
+    }
+    return 0;
+}
+
+static thread_local std::vector<uint32_t> g_array_uint32_buf;
+
+int zvec_doc_get_array_uint32(zvec_doc_t doc, const char* field, const uint32_t** out, uint32_t* count) {
+    auto result = static_cast<Doc*>(doc)->get_field<std::vector<uint32_t>>(field);
+    if (result.ok()) {
+        g_array_uint32_buf = result.value();
+        *out = g_array_uint32_buf.data();
+        *count = static_cast<uint32_t>(g_array_uint32_buf.size());
+        return 1;
+    }
+    return 0;
+}
+
+static thread_local std::vector<uint64_t> g_array_uint64_buf;
+
+int zvec_doc_get_array_uint64(zvec_doc_t doc, const char* field, const uint64_t** out, uint32_t* count) {
+    auto result = static_cast<Doc*>(doc)->get_field<std::vector<uint64_t>>(field);
+    if (result.ok()) {
+        g_array_uint64_buf = result.value();
+        *out = g_array_uint64_buf.data();
+        *count = static_cast<uint32_t>(g_array_uint64_buf.size());
+        return 1;
+    }
+    return 0;
+}
+
+static thread_local std::vector<float> g_array_float_buf;
+
+int zvec_doc_get_array_float(zvec_doc_t doc, const char* field, const float** out, uint32_t* count) {
+    auto result = static_cast<Doc*>(doc)->get_field<std::vector<float>>(field);
+    if (result.ok()) {
+        g_array_float_buf = result.value();
+        *out = g_array_float_buf.data();
+        *count = static_cast<uint32_t>(g_array_float_buf.size());
+        return 1;
+    }
+    return 0;
+}
+
+static thread_local std::vector<double> g_array_double_buf;
+
+int zvec_doc_get_array_double(zvec_doc_t doc, const char* field, const double** out, uint32_t* count) {
+    auto result = static_cast<Doc*>(doc)->get_field<std::vector<double>>(field);
+    if (result.ok()) {
+        g_array_double_buf = result.value();
+        *out = g_array_double_buf.data();
+        *count = static_cast<uint32_t>(g_array_double_buf.size());
+        return 1;
+    }
+    return 0;
+}
+
+int zvec_doc_get_array_string(zvec_doc_t doc, const char* field, char* buf, size_t buf_size, uint32_t* count) {
+    auto result = static_cast<Doc*>(doc)->get_field<std::vector<std::string>>(field);
+    if (result.ok()) {
+        const auto& strs = result.value();
+        *count = static_cast<uint32_t>(strs.size());
+        g_string_buf.clear();
+        for (size_t i = 0; i < strs.size(); i++) {
+            if (i > 0) g_string_buf += '\0';
+            g_string_buf += strs[i];
+        }
+        size_t len = g_string_buf.length();
+        if (len + 1 > buf_size) {
+            return -1;
+        }
+        memcpy(buf, g_string_buf.data(), len);
+        buf[len] = '\0';
+        return static_cast<int>(len);
+    }
+    return 0;
+}
+
+int zvec_doc_get_array_bool(zvec_doc_t doc, const char* field, uint8_t* buf, size_t buf_size) {
+    auto result = static_cast<Doc*>(doc)->get_field<std::vector<bool>>(field);
+    if (result.ok()) {
+        const auto& vec = result.value();
+        size_t count = vec.size();
+        if (count > buf_size) {
+            return -1;
+        }
+        for (size_t i = 0; i < count; i++) {
+            buf[i] = vec[i] ? 1 : 0;
+        }
+        return static_cast<int>(count);
+    }
+    return 0;
+}
+
 // --- Doc Introspection ---
 
 int zvec_doc_has_field(zvec_doc_t doc, const char* field) {
@@ -810,21 +1177,40 @@ int zvec_doc_has_field(zvec_doc_t doc, const char* field) {
 int zvec_doc_has_vector(zvec_doc_t doc, const char* field) {
     auto* d = static_cast<Doc*>(doc);
     if (!d->has(field)) return 0;
-    auto result = d->get_field<std::vector<float>>(field);
-    if (result.ok()) return 1;
-    auto result_fp64 = d->get_field<std::vector<double>>(field);
-    return result_fp64.ok() ? 1 : 0;
+    // Check all vector variant types
+    if (d->get_field<std::vector<float>>(field).ok()) return 1;
+    if (d->get_field<std::vector<double>>(field).ok()) return 1;
+    if (d->get_field<std::vector<int8_t>>(field).ok()) return 1;
+    if (d->get_field<std::vector<int16_t>>(field).ok()) return 1;
+    if (d->get_field<std::vector<uint32_t>>(field).ok()) return 1;
+    if (d->get_field<std::vector<uint64_t>>(field).ok()) return 1;
+    if (d->get_field<std::vector<ailego::Float16>>(field).ok()) return 1;
+    if (d->get_field<std::pair<std::vector<uint32_t>, std::vector<float>>>(field).ok()) return 1;
+    if (d->get_field<std::pair<std::vector<uint32_t>, std::vector<ailego::Float16>>>(field).ok()) return 1;
+    return 0;
 }
 
 static thread_local std::string g_names_buf;
+
+static bool is_vector_field(Doc* d, const std::string& name) {
+    if (d->get_field<std::vector<float>>(name).ok()) return true;
+    if (d->get_field<std::vector<double>>(name).ok()) return true;
+    if (d->get_field<std::vector<int8_t>>(name).ok()) return true;
+    if (d->get_field<std::vector<int16_t>>(name).ok()) return true;
+    if (d->get_field<std::vector<uint32_t>>(name).ok()) return true;
+    if (d->get_field<std::vector<uint64_t>>(name).ok()) return true;
+    if (d->get_field<std::vector<ailego::Float16>>(name).ok()) return true;
+    if (d->get_field<std::pair<std::vector<uint32_t>, std::vector<float>>>(name).ok()) return true;
+    if (d->get_field<std::pair<std::vector<uint32_t>, std::vector<ailego::Float16>>>(name).ok()) return true;
+    return false;
+}
 
 int zvec_doc_field_names(zvec_doc_t doc, char* buf, size_t buf_size) {
     auto* d = static_cast<Doc*>(doc);
     auto names = d->field_names();
     std::vector<std::string> filtered;
     for (const auto& name : names) {
-        if (d->get_field<std::vector<float>>(name).ok()) continue;
-        if (d->get_field<std::vector<double>>(name).ok()) continue;
+        if (is_vector_field(d, name)) continue;
         filtered.push_back(name);
     }
     std::sort(filtered.begin(), filtered.end());
@@ -851,9 +1237,7 @@ int zvec_doc_vector_names(zvec_doc_t doc, char* buf, size_t buf_size) {
     auto names = d->field_names();
     std::vector<std::string> filtered;
     for (const auto& name : names) {
-        if (d->get_field<std::vector<float>>(name).ok()) {
-            filtered.push_back(name);
-        } else if (d->get_field<std::vector<double>>(name).ok()) {
+        if (is_vector_field(d, name)) {
             filtered.push_back(name);
         }
     }

--- a/ffi/zvec_ffi.h
+++ b/ffi/zvec_ffi.h
@@ -60,7 +60,20 @@ void zvec_schema_add_field_vector_fp64(zvec_schema_t schema, const char* name, u
 void zvec_schema_add_field_vector_int8(zvec_schema_t schema, const char* name, uint32_t dimension, uint32_t metric_type);
 void zvec_schema_add_field_vector_fp16(zvec_schema_t schema, const char* name, uint32_t dimension, uint32_t metric_type);
 void zvec_schema_add_field_sparse_vector_fp32(zvec_schema_t schema, const char* name, uint32_t metric_type);
-void zvec_schema_add_field_sparse_vector_fp32(zvec_schema_t schema, const char* name, uint32_t metric_type);
+void zvec_schema_add_field_vector_int4(zvec_schema_t schema, const char* name, uint32_t dimension, uint32_t metric_type);
+void zvec_schema_add_field_vector_int16(zvec_schema_t schema, const char* name, uint32_t dimension, uint32_t metric_type);
+void zvec_schema_add_field_vector_binary32(zvec_schema_t schema, const char* name, uint32_t dimension, uint32_t metric_type);
+void zvec_schema_add_field_vector_binary64(zvec_schema_t schema, const char* name, uint32_t dimension, uint32_t metric_type);
+void zvec_schema_add_field_sparse_vector_fp16(zvec_schema_t schema, const char* name, uint32_t metric_type);
+void zvec_schema_add_field_binary(zvec_schema_t schema, const char* name, int nullable);
+void zvec_schema_add_field_array_string(zvec_schema_t schema, const char* name, int nullable);
+void zvec_schema_add_field_array_bool(zvec_schema_t schema, const char* name, int nullable);
+void zvec_schema_add_field_array_int32(zvec_schema_t schema, const char* name, int nullable);
+void zvec_schema_add_field_array_int64(zvec_schema_t schema, const char* name, int nullable);
+void zvec_schema_add_field_array_uint32(zvec_schema_t schema, const char* name, int nullable);
+void zvec_schema_add_field_array_uint64(zvec_schema_t schema, const char* name, int nullable);
+void zvec_schema_add_field_array_float(zvec_schema_t schema, const char* name, int nullable);
+void zvec_schema_add_field_array_double(zvec_schema_t schema, const char* name, int nullable);
 
 // Collection lifecycle
 zvec_status_t zvec_collection_create(const char* path, zvec_schema_t schema, int read_only, int enable_mmap, uint32_t max_buffer_size, zvec_collection_t* out);
@@ -132,6 +145,20 @@ void zvec_doc_set_vector_fp64(zvec_doc_t doc, const char* field, const double* d
 void zvec_doc_set_vector_int8(zvec_doc_t doc, const char* field, const int8_t* data, uint32_t dim);
 void zvec_doc_set_vector_fp16(zvec_doc_t doc, const char* field, const uint16_t* data, uint32_t dim);
 void zvec_doc_set_sparse_vector_fp32(zvec_doc_t doc, const char* field, const uint32_t* indices, const float* values, uint32_t count);
+void zvec_doc_set_vector_int4(zvec_doc_t doc, const char* field, const int8_t* data, uint32_t dim);
+void zvec_doc_set_vector_int16(zvec_doc_t doc, const char* field, const int16_t* data, uint32_t dim);
+void zvec_doc_set_vector_binary32(zvec_doc_t doc, const char* field, const uint32_t* data, uint32_t dim);
+void zvec_doc_set_vector_binary64(zvec_doc_t doc, const char* field, const uint64_t* data, uint32_t dim);
+void zvec_doc_set_sparse_vector_fp16(zvec_doc_t doc, const char* field, const uint32_t* indices, const uint16_t* values, uint32_t count);
+void zvec_doc_set_binary(zvec_doc_t doc, const char* field, const uint8_t* data, uint32_t size);
+void zvec_doc_set_array_int32(zvec_doc_t doc, const char* field, const int32_t* data, uint32_t count);
+void zvec_doc_set_array_int64(zvec_doc_t doc, const char* field, const int64_t* data, uint32_t count);
+void zvec_doc_set_array_uint32(zvec_doc_t doc, const char* field, const uint32_t* data, uint32_t count);
+void zvec_doc_set_array_uint64(zvec_doc_t doc, const char* field, const uint64_t* data, uint32_t count);
+void zvec_doc_set_array_float(zvec_doc_t doc, const char* field, const float* data, uint32_t count);
+void zvec_doc_set_array_double(zvec_doc_t doc, const char* field, const double* data, uint32_t count);
+void zvec_doc_set_array_string(zvec_doc_t doc, const char* field, const char** strings, uint32_t count);
+void zvec_doc_set_array_bool(zvec_doc_t doc, const char* field, const uint8_t* data, uint32_t count);
 
 const char* zvec_doc_get_pk(zvec_doc_t doc);
 float zvec_doc_get_score(zvec_doc_t doc);
@@ -148,6 +175,20 @@ int zvec_doc_get_vector_fp64(zvec_doc_t doc, const char* field, const double** o
 int zvec_doc_get_vector_int8(zvec_doc_t doc, const char* field, const int8_t** out, uint32_t* dim);
 int zvec_doc_get_vector_fp16(zvec_doc_t doc, const char* field, const uint16_t** out, uint32_t* dim);
 int zvec_doc_get_sparse_vector_fp32(zvec_doc_t doc, const char* field, const uint32_t** indices_out, const float** values_out, uint32_t* count_out);
+int zvec_doc_get_vector_int4(zvec_doc_t doc, const char* field, const int8_t** out, uint32_t* dim);
+int zvec_doc_get_vector_int16(zvec_doc_t doc, const char* field, const int16_t** out, uint32_t* dim);
+int zvec_doc_get_vector_binary32(zvec_doc_t doc, const char* field, const uint32_t** out, uint32_t* dim);
+int zvec_doc_get_vector_binary64(zvec_doc_t doc, const char* field, const uint64_t** out, uint32_t* dim);
+int zvec_doc_get_sparse_vector_fp16(zvec_doc_t doc, const char* field, const uint32_t** indices_out, const uint16_t** values_out, uint32_t* count_out);
+int zvec_doc_get_binary(zvec_doc_t doc, const char* field, const uint8_t** out, uint32_t* size);
+int zvec_doc_get_array_int32(zvec_doc_t doc, const char* field, const int32_t** out, uint32_t* count);
+int zvec_doc_get_array_int64(zvec_doc_t doc, const char* field, const int64_t** out, uint32_t* count);
+int zvec_doc_get_array_uint32(zvec_doc_t doc, const char* field, const uint32_t** out, uint32_t* count);
+int zvec_doc_get_array_uint64(zvec_doc_t doc, const char* field, const uint64_t** out, uint32_t* count);
+int zvec_doc_get_array_float(zvec_doc_t doc, const char* field, const float** out, uint32_t* count);
+int zvec_doc_get_array_double(zvec_doc_t doc, const char* field, const double** out, uint32_t* count);
+int zvec_doc_get_array_string(zvec_doc_t doc, const char* field, char* buf, size_t buf_size, uint32_t* count);
+int zvec_doc_get_array_bool(zvec_doc_t doc, const char* field, uint8_t* buf, size_t buf_size);
 
 // Doc introspection
 int zvec_doc_has_field(zvec_doc_t doc, const char* field);

--- a/src/ZVec.php
+++ b/src/ZVec.php
@@ -79,7 +79,20 @@ class ZVec
                 void zvec_schema_add_field_vector_int8(zvec_schema_t schema, const char* name, uint32_t dimension, uint32_t metric_type);
                 void zvec_schema_add_field_vector_fp16(zvec_schema_t schema, const char* name, uint32_t dimension, uint32_t metric_type);
                 void zvec_schema_add_field_sparse_vector_fp32(zvec_schema_t schema, const char* name, uint32_t metric_type);
-                void zvec_schema_add_field_sparse_vector_fp32(zvec_schema_t schema, const char* name, uint32_t metric_type);
+                void zvec_schema_add_field_vector_int4(zvec_schema_t schema, const char* name, uint32_t dimension, uint32_t metric_type);
+                void zvec_schema_add_field_vector_int16(zvec_schema_t schema, const char* name, uint32_t dimension, uint32_t metric_type);
+                void zvec_schema_add_field_vector_binary32(zvec_schema_t schema, const char* name, uint32_t dimension, uint32_t metric_type);
+                void zvec_schema_add_field_vector_binary64(zvec_schema_t schema, const char* name, uint32_t dimension, uint32_t metric_type);
+                void zvec_schema_add_field_sparse_vector_fp16(zvec_schema_t schema, const char* name, uint32_t metric_type);
+                void zvec_schema_add_field_binary(zvec_schema_t schema, const char* name, int nullable);
+                void zvec_schema_add_field_array_string(zvec_schema_t schema, const char* name, int nullable);
+                void zvec_schema_add_field_array_bool(zvec_schema_t schema, const char* name, int nullable);
+                void zvec_schema_add_field_array_int32(zvec_schema_t schema, const char* name, int nullable);
+                void zvec_schema_add_field_array_int64(zvec_schema_t schema, const char* name, int nullable);
+                void zvec_schema_add_field_array_uint32(zvec_schema_t schema, const char* name, int nullable);
+                void zvec_schema_add_field_array_uint64(zvec_schema_t schema, const char* name, int nullable);
+                void zvec_schema_add_field_array_float(zvec_schema_t schema, const char* name, int nullable);
+                void zvec_schema_add_field_array_double(zvec_schema_t schema, const char* name, int nullable);
 
                 zvec_status_t zvec_collection_create(const char* path, zvec_schema_t schema, int read_only, int enable_mmap, uint32_t max_buffer_size, zvec_collection_t* out);
                 zvec_status_t zvec_collection_open(const char* path, int read_only, int enable_mmap, uint32_t max_buffer_size, zvec_collection_t* out);
@@ -139,6 +152,20 @@ zvec_status_t zvec_collection_create_ivf_index(zvec_collection_t coll, const cha
                 void zvec_doc_set_vector_int8(zvec_doc_t doc, const char* field, const int8_t* data, uint32_t dim);
                 void zvec_doc_set_vector_fp16(zvec_doc_t doc, const char* field, const uint16_t* data, uint32_t dim);
                 void zvec_doc_set_sparse_vector_fp32(zvec_doc_t doc, const char* field, const uint32_t* indices, const float* values, uint32_t count);
+                void zvec_doc_set_vector_int4(zvec_doc_t doc, const char* field, const int8_t* data, uint32_t dim);
+                void zvec_doc_set_vector_int16(zvec_doc_t doc, const char* field, const int16_t* data, uint32_t dim);
+                void zvec_doc_set_vector_binary32(zvec_doc_t doc, const char* field, const uint32_t* data, uint32_t dim);
+                void zvec_doc_set_vector_binary64(zvec_doc_t doc, const char* field, const uint64_t* data, uint32_t dim);
+                void zvec_doc_set_sparse_vector_fp16(zvec_doc_t doc, const char* field, const uint32_t* indices, const uint16_t* values, uint32_t count);
+                void zvec_doc_set_binary(zvec_doc_t doc, const char* field, const uint8_t* data, uint32_t size);
+                void zvec_doc_set_array_int32(zvec_doc_t doc, const char* field, const int32_t* data, uint32_t count);
+                void zvec_doc_set_array_int64(zvec_doc_t doc, const char* field, const int64_t* data, uint32_t count);
+                void zvec_doc_set_array_uint32(zvec_doc_t doc, const char* field, const uint32_t* data, uint32_t count);
+                void zvec_doc_set_array_uint64(zvec_doc_t doc, const char* field, const uint64_t* data, uint32_t count);
+                void zvec_doc_set_array_float(zvec_doc_t doc, const char* field, const float* data, uint32_t count);
+                void zvec_doc_set_array_double(zvec_doc_t doc, const char* field, const double* data, uint32_t count);
+                void zvec_doc_set_array_string(zvec_doc_t doc, const char* field, const char** strings, uint32_t count);
+                void zvec_doc_set_array_bool(zvec_doc_t doc, const char* field, const uint8_t* data, uint32_t count);
 
                 const char* zvec_doc_get_pk(zvec_doc_t doc);
                 float zvec_doc_get_score(zvec_doc_t doc);
@@ -155,6 +182,20 @@ zvec_status_t zvec_collection_create_ivf_index(zvec_collection_t coll, const cha
                 int zvec_doc_get_vector_int8(zvec_doc_t doc, const char* field, const int8_t** out, uint32_t* dim);
                 int zvec_doc_get_vector_fp16(zvec_doc_t doc, const char* field, const uint16_t** out, uint32_t* dim);
                 int zvec_doc_get_sparse_vector_fp32(zvec_doc_t doc, const char* field, const uint32_t** indices_out, const float** values_out, uint32_t* count_out);
+                int zvec_doc_get_vector_int4(zvec_doc_t doc, const char* field, const int8_t** out, uint32_t* dim);
+                int zvec_doc_get_vector_int16(zvec_doc_t doc, const char* field, const int16_t** out, uint32_t* dim);
+                int zvec_doc_get_vector_binary32(zvec_doc_t doc, const char* field, const uint32_t** out, uint32_t* dim);
+                int zvec_doc_get_vector_binary64(zvec_doc_t doc, const char* field, const uint64_t** out, uint32_t* dim);
+                int zvec_doc_get_sparse_vector_fp16(zvec_doc_t doc, const char* field, const uint32_t** indices_out, const uint16_t** values_out, uint32_t* count_out);
+                int zvec_doc_get_binary(zvec_doc_t doc, const char* field, const uint8_t** out, uint32_t* size);
+                int zvec_doc_get_array_int32(zvec_doc_t doc, const char* field, const int32_t** out, uint32_t* count);
+                int zvec_doc_get_array_int64(zvec_doc_t doc, const char* field, const int64_t** out, uint32_t* count);
+                int zvec_doc_get_array_uint32(zvec_doc_t doc, const char* field, const uint32_t** out, uint32_t* count);
+                int zvec_doc_get_array_uint64(zvec_doc_t doc, const char* field, const uint64_t** out, uint32_t* count);
+                int zvec_doc_get_array_float(zvec_doc_t doc, const char* field, const float** out, uint32_t* count);
+                int zvec_doc_get_array_double(zvec_doc_t doc, const char* field, const double** out, uint32_t* count);
+                int zvec_doc_get_array_string(zvec_doc_t doc, const char* field, char* buf, size_t buf_size, uint32_t* count);
+                int zvec_doc_get_array_bool(zvec_doc_t doc, const char* field, uint8_t* buf, size_t buf_size);
 
                 // Doc introspection
                 int zvec_doc_has_field(zvec_doc_t doc, const char* field);
@@ -699,6 +740,23 @@ zvec_status_t zvec_collection_create_ivf_index(zvec_collection_t coll, const cha
     // Vector data types for schema
     public const TYPE_VECTOR_FP32 = 23;
     public const TYPE_VECTOR_FP64 = 24;
+    public const TYPE_VECTOR_FP16 = 22;
+    public const TYPE_VECTOR_INT4 = 25;
+    public const TYPE_VECTOR_INT8 = 26;
+    public const TYPE_VECTOR_INT16 = 27;
+    public const TYPE_VECTOR_BINARY32 = 20;
+    public const TYPE_VECTOR_BINARY64 = 21;
+    public const TYPE_SPARSE_VECTOR_FP32 = 31;
+    public const TYPE_SPARSE_VECTOR_FP16 = 30;
+    public const TYPE_BINARY = 1;
+    public const TYPE_ARRAY_STRING = 41;
+    public const TYPE_ARRAY_BOOL = 42;
+    public const TYPE_ARRAY_INT32 = 43;
+    public const TYPE_ARRAY_INT64 = 44;
+    public const TYPE_ARRAY_UINT32 = 45;
+    public const TYPE_ARRAY_UINT64 = 46;
+    public const TYPE_ARRAY_FLOAT = 47;
+    public const TYPE_ARRAY_DOUBLE = 48;
 
     // Quantize types for index creation
     public const QUANTIZE_UNDEFINED = 0;
@@ -1532,6 +1590,90 @@ class ZVecSchema
         return $this;
     }
 
+    public function addVectorInt4(string $name, int $dimension, int $metricType = self::METRIC_IP): self
+    {
+        self::ffi()->zvec_schema_add_field_vector_int4($this->handle, $name, $dimension, $metricType);
+        return $this;
+    }
+
+    public function addVectorInt16(string $name, int $dimension, int $metricType = self::METRIC_IP): self
+    {
+        self::ffi()->zvec_schema_add_field_vector_int16($this->handle, $name, $dimension, $metricType);
+        return $this;
+    }
+
+    public function addVectorBinary32(string $name, int $dimension, int $metricType = self::METRIC_IP): self
+    {
+        self::ffi()->zvec_schema_add_field_vector_binary32($this->handle, $name, $dimension, $metricType);
+        return $this;
+    }
+
+    public function addVectorBinary64(string $name, int $dimension, int $metricType = self::METRIC_IP): self
+    {
+        self::ffi()->zvec_schema_add_field_vector_binary64($this->handle, $name, $dimension, $metricType);
+        return $this;
+    }
+
+    public function addSparseVectorFp16(string $name, int $metricType = self::METRIC_IP): self
+    {
+        self::ffi()->zvec_schema_add_field_sparse_vector_fp16($this->handle, $name, $metricType);
+        return $this;
+    }
+
+    public function addFieldBinary(string $name, bool $nullable = true): self
+    {
+        self::ffi()->zvec_schema_add_field_binary($this->handle, $name, $nullable ? 1 : 0);
+        return $this;
+    }
+
+    public function addFieldArrayString(string $name, bool $nullable = true): self
+    {
+        self::ffi()->zvec_schema_add_field_array_string($this->handle, $name, $nullable ? 1 : 0);
+        return $this;
+    }
+
+    public function addFieldArrayBool(string $name, bool $nullable = true): self
+    {
+        self::ffi()->zvec_schema_add_field_array_bool($this->handle, $name, $nullable ? 1 : 0);
+        return $this;
+    }
+
+    public function addFieldArrayInt32(string $name, bool $nullable = true): self
+    {
+        self::ffi()->zvec_schema_add_field_array_int32($this->handle, $name, $nullable ? 1 : 0);
+        return $this;
+    }
+
+    public function addFieldArrayInt64(string $name, bool $nullable = true): self
+    {
+        self::ffi()->zvec_schema_add_field_array_int64($this->handle, $name, $nullable ? 1 : 0);
+        return $this;
+    }
+
+    public function addFieldArrayUint32(string $name, bool $nullable = true): self
+    {
+        self::ffi()->zvec_schema_add_field_array_uint32($this->handle, $name, $nullable ? 1 : 0);
+        return $this;
+    }
+
+    public function addFieldArrayUint64(string $name, bool $nullable = true): self
+    {
+        self::ffi()->zvec_schema_add_field_array_uint64($this->handle, $name, $nullable ? 1 : 0);
+        return $this;
+    }
+
+    public function addFieldArrayFloat(string $name, bool $nullable = true): self
+    {
+        self::ffi()->zvec_schema_add_field_array_float($this->handle, $name, $nullable ? 1 : 0);
+        return $this;
+    }
+
+    public function addFieldArrayDouble(string $name, bool $nullable = true): self
+    {
+        self::ffi()->zvec_schema_add_field_array_double($this->handle, $name, $nullable ? 1 : 0);
+        return $this;
+    }
+
     private static function ffi(): FFI
     {
         return (new ReflectionClass(ZVec::class))->getMethod('ffi')->invoke(null);
@@ -1701,6 +1843,242 @@ class ZVecDoc
         }
         
         $ffi->zvec_doc_set_sparse_vector_fp32($this->handle, $field, $idxData, $valData, $count);
+        return $this;
+    }
+
+    /**
+     * @param int[] $vector
+     */
+    public function setVectorInt4(string $field, array $vector): self
+    {
+        $ffi = self::ffi();
+        $dim = count($vector);
+        $data = $ffi->new("int8_t[$dim]");
+        foreach ($vector as $i => $v) {
+            $data[$i] = $v;
+        }
+        $ffi->zvec_doc_set_vector_int4($this->handle, $field, $data, $dim);
+        return $this;
+    }
+
+    /**
+     * @param int[] $vector
+     */
+    public function setVectorInt16(string $field, array $vector): self
+    {
+        $ffi = self::ffi();
+        $dim = count($vector);
+        $data = $ffi->new("int16_t[$dim]");
+        foreach ($vector as $i => $v) {
+            $data[$i] = $v;
+        }
+        $ffi->zvec_doc_set_vector_int16($this->handle, $field, $data, $dim);
+        return $this;
+    }
+
+    /**
+     * @param int[] $data
+     */
+    public function setVectorBinary32(string $field, array $data): self
+    {
+        $ffi = self::ffi();
+        $dim = count($data);
+        $arr = $ffi->new("uint32_t[$dim]");
+        foreach ($data as $i => $v) {
+            $arr[$i] = $v;
+        }
+        $ffi->zvec_doc_set_vector_binary32($this->handle, $field, $arr, $dim);
+        return $this;
+    }
+
+    /**
+     * @param int[] $data
+     */
+    public function setVectorBinary64(string $field, array $data): self
+    {
+        $ffi = self::ffi();
+        $dim = count($data);
+        $arr = $ffi->new("uint64_t[$dim]");
+        foreach ($data as $i => $v) {
+            $arr[$i] = $v;
+        }
+        $ffi->zvec_doc_set_vector_binary64($this->handle, $field, $arr, $dim);
+        return $this;
+    }
+
+    /**
+     * @param int[] $indices
+     * @param int[] $values (FP16 raw uint16 values)
+     */
+    public function setSparseVectorFp16(string $field, array $indices, array $values): self
+    {
+        $ffi = self::ffi();
+        $count = count($indices);
+        if ($count !== count($values)) {
+            throw new ZVecException("Indices and values arrays must have the same length");
+        }
+
+        if ($count === 0) {
+            $ffi->zvec_doc_set_sparse_vector_fp16($this->handle, $field, null, null, 0);
+            return $this;
+        }
+
+        $idxData = $ffi->new("uint32_t[$count]");
+        $valData = $ffi->new("uint16_t[$count]");
+
+        for ($i = 0; $i < $count; $i++) {
+            $idxData[$i] = $indices[$i];
+            $valData[$i] = $values[$i];
+        }
+
+        $ffi->zvec_doc_set_sparse_vector_fp16($this->handle, $field, $idxData, $valData, $count);
+        return $this;
+    }
+
+    /**
+     * @param string $data Raw binary data
+     */
+    public function setBinary(string $field, string $data): self
+    {
+        $ffi = self::ffi();
+        $size = strlen($data);
+        if ($size === 0) {
+            $ffi->zvec_doc_set_binary($this->handle, $field, null, 0);
+            return $this;
+        }
+        $buf = $ffi->new("uint8_t[$size]", false);
+        FFI::memcpy($buf, $data, $size);
+        $ffi->zvec_doc_set_binary($this->handle, $field, $buf, $size);
+        FFI::free($buf);
+        return $this;
+    }
+
+    /**
+     * @param int[] $data
+     */
+    public function setArrayInt32(string $field, array $data): self
+    {
+        $ffi = self::ffi();
+        $count = count($data);
+        $arr = $ffi->new("int32_t[$count]");
+        foreach ($data as $i => $v) {
+            $arr[$i] = $v;
+        }
+        $ffi->zvec_doc_set_array_int32($this->handle, $field, $arr, $count);
+        return $this;
+    }
+
+    /**
+     * @param int[] $data
+     */
+    public function setArrayInt64(string $field, array $data): self
+    {
+        $ffi = self::ffi();
+        $count = count($data);
+        $arr = $ffi->new("int64_t[$count]");
+        foreach ($data as $i => $v) {
+            $arr[$i] = $v;
+        }
+        $ffi->zvec_doc_set_array_int64($this->handle, $field, $arr, $count);
+        return $this;
+    }
+
+    /**
+     * @param int[] $data
+     */
+    public function setArrayUint32(string $field, array $data): self
+    {
+        $ffi = self::ffi();
+        $count = count($data);
+        $arr = $ffi->new("uint32_t[$count]");
+        foreach ($data as $i => $v) {
+            $arr[$i] = $v;
+        }
+        $ffi->zvec_doc_set_array_uint32($this->handle, $field, $arr, $count);
+        return $this;
+    }
+
+    /**
+     * @param int[] $data
+     */
+    public function setArrayUint64(string $field, array $data): self
+    {
+        $ffi = self::ffi();
+        $count = count($data);
+        $arr = $ffi->new("uint64_t[$count]");
+        foreach ($data as $i => $v) {
+            $arr[$i] = $v;
+        }
+        $ffi->zvec_doc_set_array_uint64($this->handle, $field, $arr, $count);
+        return $this;
+    }
+
+    /**
+     * @param float[] $data
+     */
+    public function setArrayFloat(string $field, array $data): self
+    {
+        $ffi = self::ffi();
+        $count = count($data);
+        $arr = $ffi->new("float[$count]");
+        foreach ($data as $i => $v) {
+            $arr[$i] = $v;
+        }
+        $ffi->zvec_doc_set_array_float($this->handle, $field, $arr, $count);
+        return $this;
+    }
+
+    /**
+     * @param float[] $data
+     */
+    public function setArrayDouble(string $field, array $data): self
+    {
+        $ffi = self::ffi();
+        $count = count($data);
+        $arr = $ffi->new("double[$count]");
+        foreach ($data as $i => $v) {
+            $arr[$i] = $v;
+        }
+        $ffi->zvec_doc_set_array_double($this->handle, $field, $arr, $count);
+        return $this;
+    }
+
+    /**
+     * @param string[] $strings
+     */
+    public function setArrayString(string $field, array $strings): self
+    {
+        $ffi = self::ffi();
+        $count = count($strings);
+        $cStrings = [];
+        $arr = $ffi->new("char*[$count]");
+        foreach ($strings as $i => $s) {
+            $len = strlen($s) + 1;
+            $cStr = $ffi->new("char[$len]", false);
+            FFI::memcpy($cStr, $s, strlen($s));
+            $cStr[$len - 1] = "\0";
+            $cStrings[] = $cStr;
+            $arr[$i] = $cStr;
+        }
+        $ffi->zvec_doc_set_array_string($this->handle, $field, $arr, $count);
+        foreach ($cStrings as $cStr) {
+            FFI::free($cStr);
+        }
+        return $this;
+    }
+
+    /**
+     * @param bool[] $data
+     */
+    public function setArrayBool(string $field, array $data): self
+    {
+        $ffi = self::ffi();
+        $count = count($data);
+        $arr = $ffi->new("uint8_t[$count]");
+        foreach ($data as $i => $v) {
+            $arr[$i] = $v ? 1 : 0;
+        }
+        $ffi->zvec_doc_set_array_bool($this->handle, $field, $arr, $count);
         return $this;
     }
 
@@ -1890,6 +2268,259 @@ class ZVecDoc
             return ['indices' => $indices, 'values' => $values];
         }
         return null;
+    }
+
+    /**
+     * @return int[]|null
+     */
+    public function getVectorInt4(string $field): ?array
+    {
+        $ffi = self::ffi();
+        $out = $ffi->new('int8_t*');
+        $dim = $ffi->new('uint32_t');
+        if ($ffi->zvec_doc_get_vector_int4($this->handle, $field, FFI::addr($out), FFI::addr($dim))) {
+            $result = [];
+            for ($i = 0; $i < $dim->cdata; $i++) {
+                $result[] = $out[$i];
+            }
+            return $result;
+        }
+        return null;
+    }
+
+    /**
+     * @return int[]|null
+     */
+    public function getVectorInt16(string $field): ?array
+    {
+        $ffi = self::ffi();
+        $out = $ffi->new('int16_t*');
+        $dim = $ffi->new('uint32_t');
+        if ($ffi->zvec_doc_get_vector_int16($this->handle, $field, FFI::addr($out), FFI::addr($dim))) {
+            $result = [];
+            for ($i = 0; $i < $dim->cdata; $i++) {
+                $result[] = $out[$i];
+            }
+            return $result;
+        }
+        return null;
+    }
+
+    /**
+     * @return int[]|null
+     */
+    public function getVectorBinary32(string $field): ?array
+    {
+        $ffi = self::ffi();
+        $out = $ffi->new('uint32_t*');
+        $dim = $ffi->new('uint32_t');
+        if ($ffi->zvec_doc_get_vector_binary32($this->handle, $field, FFI::addr($out), FFI::addr($dim))) {
+            $result = [];
+            for ($i = 0; $i < $dim->cdata; $i++) {
+                $result[] = $out[$i];
+            }
+            return $result;
+        }
+        return null;
+    }
+
+    /**
+     * @return int[]|null
+     */
+    public function getVectorBinary64(string $field): ?array
+    {
+        $ffi = self::ffi();
+        $out = $ffi->new('uint64_t*');
+        $dim = $ffi->new('uint32_t');
+        if ($ffi->zvec_doc_get_vector_binary64($this->handle, $field, FFI::addr($out), FFI::addr($dim))) {
+            $result = [];
+            for ($i = 0; $i < $dim->cdata; $i++) {
+                $result[] = $out[$i];
+            }
+            return $result;
+        }
+        return null;
+    }
+
+    /**
+     * @return array{indices: int[], values: int[]}|null
+     */
+    public function getSparseVectorFp16(string $field): ?array
+    {
+        $ffi = self::ffi();
+        $indicesOut = $ffi->new('uint32_t*');
+        $valuesOut = $ffi->new('uint16_t*');
+        $count = $ffi->new('uint32_t');
+        
+        if ($ffi->zvec_doc_get_sparse_vector_fp16($this->handle, $field, FFI::addr($indicesOut), FFI::addr($valuesOut), FFI::addr($count))) {
+            $indices = [];
+            $values = [];
+            for ($i = 0; $i < $count->cdata; $i++) {
+                $indices[] = $indicesOut[$i];
+                $values[] = $valuesOut[$i];
+            }
+            return ['indices' => $indices, 'values' => $values];
+        }
+        return null;
+    }
+
+    /**
+     * @return string|null Raw binary data
+     */
+    public function getBinary(string $field): ?string
+    {
+        $ffi = self::ffi();
+        $out = $ffi->new('uint8_t*');
+        $size = $ffi->new('uint32_t');
+        if ($ffi->zvec_doc_get_binary($this->handle, $field, FFI::addr($out), FFI::addr($size))) {
+            if ($size->cdata === 0) {
+                return '';
+            }
+            return FFI::string($out, $size->cdata);
+        }
+        return null;
+    }
+
+    /**
+     * @return int[]|null
+     */
+    public function getArrayInt32(string $field): ?array
+    {
+        $ffi = self::ffi();
+        $out = $ffi->new('int32_t*');
+        $count = $ffi->new('uint32_t');
+        if ($ffi->zvec_doc_get_array_int32($this->handle, $field, FFI::addr($out), FFI::addr($count))) {
+            $result = [];
+            for ($i = 0; $i < $count->cdata; $i++) {
+                $result[] = $out[$i];
+            }
+            return $result;
+        }
+        return null;
+    }
+
+    /**
+     * @return int[]|null
+     */
+    public function getArrayInt64(string $field): ?array
+    {
+        $ffi = self::ffi();
+        $out = $ffi->new('int64_t*');
+        $count = $ffi->new('uint32_t');
+        if ($ffi->zvec_doc_get_array_int64($this->handle, $field, FFI::addr($out), FFI::addr($count))) {
+            $result = [];
+            for ($i = 0; $i < $count->cdata; $i++) {
+                $result[] = $out[$i];
+            }
+            return $result;
+        }
+        return null;
+    }
+
+    /**
+     * @return int[]|null
+     */
+    public function getArrayUint32(string $field): ?array
+    {
+        $ffi = self::ffi();
+        $out = $ffi->new('uint32_t*');
+        $count = $ffi->new('uint32_t');
+        if ($ffi->zvec_doc_get_array_uint32($this->handle, $field, FFI::addr($out), FFI::addr($count))) {
+            $result = [];
+            for ($i = 0; $i < $count->cdata; $i++) {
+                $result[] = $out[$i];
+            }
+            return $result;
+        }
+        return null;
+    }
+
+    /**
+     * @return int[]|null
+     */
+    public function getArrayUint64(string $field): ?array
+    {
+        $ffi = self::ffi();
+        $out = $ffi->new('uint64_t*');
+        $count = $ffi->new('uint32_t');
+        if ($ffi->zvec_doc_get_array_uint64($this->handle, $field, FFI::addr($out), FFI::addr($count))) {
+            $result = [];
+            for ($i = 0; $i < $count->cdata; $i++) {
+                $result[] = $out[$i];
+            }
+            return $result;
+        }
+        return null;
+    }
+
+    /**
+     * @return float[]|null
+     */
+    public function getArrayFloat(string $field): ?array
+    {
+        $ffi = self::ffi();
+        $out = $ffi->new('float*');
+        $count = $ffi->new('uint32_t');
+        if ($ffi->zvec_doc_get_array_float($this->handle, $field, FFI::addr($out), FFI::addr($count))) {
+            $result = [];
+            for ($i = 0; $i < $count->cdata; $i++) {
+                $result[] = $out[$i];
+            }
+            return $result;
+        }
+        return null;
+    }
+
+    /**
+     * @return float[]|null
+     */
+    public function getArrayDouble(string $field): ?array
+    {
+        $ffi = self::ffi();
+        $out = $ffi->new('double*');
+        $count = $ffi->new('uint32_t');
+        if ($ffi->zvec_doc_get_array_double($this->handle, $field, FFI::addr($out), FFI::addr($count))) {
+            $result = [];
+            for ($i = 0; $i < $count->cdata; $i++) {
+                $result[] = $out[$i];
+            }
+            return $result;
+        }
+        return null;
+    }
+
+    /**
+     * @return string[]|null
+     */
+    public function getArrayString(string $field): ?array
+    {
+        $ffi = self::ffi();
+        $buf = $ffi->new('char[8192]');
+        $count = $ffi->new('uint32_t');
+        $len = $ffi->zvec_doc_get_array_string($this->handle, $field, $buf, 8192, FFI::addr($count));
+        if ($len <= 0) {
+            return null;
+        }
+        $str = FFI::string($buf, $len);
+        return $str === '' ? [] : explode("\0", $str);
+    }
+
+    /**
+     * @return bool[]|null
+     */
+    public function getArrayBool(string $field): ?array
+    {
+        $ffi = self::ffi();
+        $buf = $ffi->new('uint8_t[4096]');
+        $count = $ffi->zvec_doc_get_array_bool($this->handle, $field, $buf, 4096);
+        if ($count <= 0) {
+            return null;
+        }
+        $result = [];
+        for ($i = 0; $i < $count; $i++) {
+            $result[] = $buf[$i] !== 0;
+        }
+        return $result;
     }
 
     public function hasField(string $field): bool

--- a/tests/test_new_types_array.phpt
+++ b/tests/test_new_types_array.phpt
@@ -1,0 +1,62 @@
+--TEST--
+New types: ARRAY fields (int32, int64, uint32, uint64, float, double, string, bool)
+--SKIPIF--
+<?php if (!extension_loaded('ffi')) die('skip FFI extension not available'); ?>
+--FILE--
+<?php
+require_once __DIR__ . '/../src/ZVec.php';
+ZVec::init(logType: ZVec::LOG_CONSOLE, logLevel: ZVec::LOG_WARN);
+$path = __DIR__ . '/../test_dbs/array_' . uniqid();
+try {
+    $schema = new ZVecSchema('test');
+    $schema->addVectorFp32('vec', dimension: 4, metricType: ZVecSchema::METRIC_IP);
+    $schema->addFieldArrayInt32('i32');
+    $schema->addFieldArrayInt64('i64');
+    $schema->addFieldArrayUint32('u32');
+    $schema->addFieldArrayUint64('u64');
+    $schema->addFieldArrayFloat('f32');
+    $schema->addFieldArrayDouble('f64');
+    $schema->addFieldArrayString('strs');
+    $schema->addFieldArrayBool('bools');
+    $coll = ZVec::create($path, $schema);
+
+    $doc = new ZVecDoc('d1');
+    $doc->setVectorFp32('vec', [1.0, 0.0, 0.0, 0.0]);
+    $doc->setArrayInt32('i32', [1, -2, 3]);
+    $doc->setArrayInt64('i64', [100, -200]);
+    $doc->setArrayUint32('u32', [10, 20, 30]);
+    $doc->setArrayUint64('u64', [1000, 2000]);
+    $doc->setArrayFloat('f32', [1.5, 2.5, 3.5]);
+    $doc->setArrayDouble('f64', [1.1, 2.2]);
+    $doc->setArrayString('strs', ['hello', 'world', 'foo']);
+    $doc->setArrayBool('bools', [true, false, true]);
+    $coll->insert($doc);
+
+    $fetched = $coll->fetch('d1');
+    $d = $fetched[0];
+    echo 'i32: ' . implode(',', $d->getArrayInt32('i32')) . "\n";
+    echo 'i64: ' . implode(',', $d->getArrayInt64('i64')) . "\n";
+    echo 'u32: ' . implode(',', $d->getArrayUint32('u32')) . "\n";
+    echo 'u64: ' . implode(',', $d->getArrayUint64('u64')) . "\n";
+    echo 'f32: ' . implode(',', array_map(fn($v) => round($v, 1), $d->getArrayFloat('f32'))) . "\n";
+    echo 'f64: ' . implode(',', array_map(fn($v) => round($v, 1), $d->getArrayDouble('f64'))) . "\n";
+    echo 'strs: ' . implode(',', $d->getArrayString('strs')) . "\n";
+    $bools = $d->getArrayBool('bools');
+    echo 'bools: ' . implode(',', array_map(fn($v) => $v ? '1' : '0', $bools)) . "\n";
+
+    echo "OK\n";
+} finally {
+    if (isset($coll)) { try { $coll->destroy(); } catch (Exception $e) {} }
+    exec("rm -rf " . escapeshellarg($path));
+}
+?>
+--EXPECT--
+i32: 1,-2,3
+i64: 100,-200
+u32: 10,20,30
+u64: 1000,2000
+f32: 1.5,2.5,3.5
+f64: 1.1,2.2
+strs: hello,world,foo
+bools: 1,0,1
+OK

--- a/tests/test_new_types_binary.phpt
+++ b/tests/test_new_types_binary.phpt
@@ -1,0 +1,36 @@
+--TEST--
+New types: BINARY scalar field insert and retrieve
+--SKIPIF--
+<?php if (!extension_loaded('ffi')) die('skip FFI extension not available'); ?>
+--FILE--
+<?php
+require_once __DIR__ . '/../src/ZVec.php';
+ZVec::init(logType: ZVec::LOG_CONSOLE, logLevel: ZVec::LOG_WARN);
+$path = __DIR__ . '/../test_dbs/binary_' . uniqid();
+try {
+    $schema = new ZVecSchema('test');
+    $schema->addVectorFp32('vec', dimension: 4, metricType: ZVecSchema::METRIC_IP);
+    $schema->addFieldBinary('bin');
+    $coll = ZVec::create($path, $schema);
+
+    $doc = new ZVecDoc('d1');
+    $doc->setVectorFp32('vec', [1.0, 0.0, 0.0, 0.0]);
+    $doc->setBinary('bin', "\x00\x01\x02\xff\xfe");
+    $coll->insert($doc);
+
+    $fetched = $coll->fetch('d1');
+    $d = $fetched[0];
+    $bin = $d->getBinary('bin');
+    echo "bin len: " . strlen($bin) . "\n";
+    echo "bin hex: " . bin2hex($bin) . "\n";
+
+    echo "OK\n";
+} finally {
+    if (isset($coll)) { try { $coll->destroy(); } catch (Exception $e) {} }
+    exec("rm -rf " . escapeshellarg($path));
+}
+?>
+--EXPECT--
+bin len: 5
+bin hex: 000102fffe
+OK

--- a/tests/test_new_types_e2e.phpt
+++ b/tests/test_new_types_e2e.phpt
@@ -1,0 +1,60 @@
+--TEST--
+New types: E2E round-trip with multiple new types
+--SKIPIF--
+<?php if (!extension_loaded('ffi')) die('skip FFI extension not available'); ?>
+--FILE--
+<?php
+require_once __DIR__ . '/../src/ZVec.php';
+ZVec::init(logType: ZVec::LOG_CONSOLE, logLevel: ZVec::LOG_WARN);
+$path = __DIR__ . '/../test_dbs/e2e_' . uniqid();
+try {
+    $schema = new ZVecSchema('test');
+    $schema->addVectorFp32('fp32', dimension: 4, metricType: ZVecSchema::METRIC_IP);
+    $schema->addSparseVectorFp16('sv16', metricType: ZVecSchema::METRIC_IP);
+    $schema->addFieldBinary('bin');
+    $schema->addFieldArrayInt32('ids');
+    $schema->addFieldArrayString('tags');
+    $coll = ZVec::create($path, $schema);
+
+    $doc = new ZVecDoc('d1');
+    $doc->setVectorFp32('fp32', [0.1, 0.2, 0.3, 0.4]);
+    $doc->setSparseVectorFp16('sv16', [0, 3], [15360, 16384]);
+    $doc->setBinary('bin', "binary\x00data");
+    $doc->setArrayInt32('ids', [1, 2, 3]);
+    $doc->setArrayString('tags', ['tag1', 'tag2']);
+    $coll->insert($doc);
+    $coll->flush();
+    $coll->close();
+    unset($coll);
+
+    $coll = ZVec::open($path);
+    $fetched = $coll->fetch('d1');
+    $d = $fetched[0];
+
+    $fp32 = $d->getVectorFp32('fp32');
+    echo 'fp32: ' . implode(',', array_map(fn($v) => round($v, 1), $fp32)) . "\n";
+
+    $sv16 = $d->getSparseVectorFp16('sv16');
+    echo 'sv16 indices: ' . implode(',', $sv16['indices']) . "\n";
+    echo 'sv16 values: ' . implode(',', $sv16['values']) . "\n";
+
+    $bin = $d->getBinary('bin');
+    echo 'bin hex: ' . bin2hex($bin) . "\n";
+
+    echo 'ids: ' . implode(',', $d->getArrayInt32('ids')) . "\n";
+    echo 'tags: ' . implode(',', $d->getArrayString('tags')) . "\n";
+
+    echo "OK\n";
+} finally {
+    if (isset($coll)) { try { $coll->destroy(); } catch (Exception $e) {} }
+    exec("rm -rf " . escapeshellarg($path));
+}
+?>
+--EXPECT--
+fp32: 0.1,0.2,0.3,0.4
+sv16 indices: 0,3
+sv16 values: 15360,16384
+bin hex: 62696e6172790064617461
+ids: 1,2,3
+tags: tag1,tag2
+OK

--- a/tests/test_new_types_sparse_fp16.phpt
+++ b/tests/test_new_types_sparse_fp16.phpt
@@ -1,0 +1,40 @@
+--TEST--
+New types: SPARSE_VECTOR_FP16 insert and retrieve
+--SKIPIF--
+<?php if (!extension_loaded('ffi')) die('skip FFI extension not available'); ?>
+--FILE--
+<?php
+require_once __DIR__ . '/../src/ZVec.php';
+ZVec::init(logType: ZVec::LOG_CONSOLE, logLevel: ZVec::LOG_WARN);
+$path = __DIR__ . '/../test_dbs/sparsefp16_' . uniqid();
+try {
+    $schema = new ZVecSchema('test');
+    $schema->addSparseVectorFp16('sparse', metricType: ZVecSchema::METRIC_IP);
+    $coll = ZVec::create($path, $schema);
+
+    $doc = new ZVecDoc('empty');
+    $doc->setSparseVectorFp16('sparse', [], []);
+    $coll->insert($doc);
+    $fetched = $coll->fetch('empty');
+    $sv = $fetched[0]->getSparseVectorFp16('sparse');
+    echo "empty count: " . count($sv['indices']) . "\n";
+
+    $doc2 = new ZVecDoc('d1');
+    $doc2->setSparseVectorFp16('sparse', [0, 2], [15360, 0]);
+    $coll->insert($doc2);
+    $fetched2 = $coll->fetch('d1');
+    $sv2 = $fetched2[0]->getSparseVectorFp16('sparse');
+    echo "indices: " . implode(',', $sv2['indices']) . "\n";
+    echo "values: " . implode(',', $sv2['values']) . "\n";
+
+    echo "OK\n";
+} finally {
+    if (isset($coll)) { try { $coll->destroy(); } catch (Exception $e) {} }
+    exec("rm -rf " . escapeshellarg($path));
+}
+?>
+--EXPECT--
+empty count: 0
+indices: 0,2
+values: 15360,0
+OK


### PR DESCRIPTION
Implements #12

**New types (working):**
- SPARSE_VECTOR_FP16 (30) — half-precision sparse vectors
- BINARY (1) — raw binary data field
- ARRAY_INT32, ARRAY_INT64, ARRAY_UINT32, ARRAY_UINT64, ARRAY_FLOAT, ARRAY_DOUBLE, ARRAY_STRING, ARRAY_BOOL

**FFI scaffolding (blocked by upstream):** VECTOR_INT4, VECTOR_INT16, VECTOR_BINARY32, VECTOR_BINARY64

**Changes:**
- ffi/zvec_ffi.h: 44 new function declarations
- ffi/zvec_ffi.cc: implementations + is_vector_field helper + array_string memcpy fix
- src/ZVec.php: 16 TYPE_* constants, 14 schema methods, 28 doc methods
- 4 new .phpt tests (sparse_fp16, binary, array, e2e round-trip)
- All 62 tests pass (60 PASS + 2 XFAIL)