### PR TITLE
feat: add use_contiguous_memory parameter to HNSW index creation (issue #28)

### DIFF
--- a/ffi/zvec_ffi.cc
+++ b/ffi/zvec_ffi.cc
@@ -623,18 +623,20 @@ struct IndexParamsHolder {
     int rabitq_total_bits_;
     int rabitq_num_clusters_;
     int rabitq_sample_count_;
+    bool hnsw_use_contiguous_memory_;
 
     IndexParamsHolder(IndexType type, MetricType metric_type)
         : type_(type), metric_type_(metric_type), quantize_type_(QuantizeType::UNDEFINED),
           hnsw_m_(50), hnsw_ef_construction_(500),
           ivf_n_list_(1024), ivf_n_iters_(10), ivf_use_soar_(false),
           invert_enable_range_(true), invert_enable_wildcard_(false),
-          rabitq_total_bits_(7), rabitq_num_clusters_(16), rabitq_sample_count_(0) {}
+          rabitq_total_bits_(7), rabitq_num_clusters_(16), rabitq_sample_count_(0),
+          hnsw_use_contiguous_memory_(false) {}
 
     IndexParams::Ptr build() const {
         switch (type_) {
             case IndexType::HNSW:
-                return std::make_shared<HnswIndexParams>(metric_type_, hnsw_m_, hnsw_ef_construction_, quantize_type_);
+                return std::make_shared<HnswIndexParams>(metric_type_, hnsw_m_, hnsw_ef_construction_, quantize_type_, hnsw_use_contiguous_memory_);
             case IndexType::HNSW_RABITQ:
                 return std::make_shared<HnswRabitqIndexParams>(metric_type_, rabitq_total_bits_, rabitq_num_clusters_, hnsw_m_, hnsw_ef_construction_, rabitq_sample_count_);
             case IndexType::FLAT:
@@ -669,11 +671,12 @@ void zvec_index_params_free(zvec_index_params_t params) {
     delete static_cast<IndexParamsHolder*>(params);
 }
 
-void zvec_index_params_set_hnsw(zvec_index_params_t params, int m, int ef_construction, int quantize_type) {
+void zvec_index_params_set_hnsw(zvec_index_params_t params, int m, int ef_construction, int quantize_type, int use_contiguous_memory) {
     auto* h = static_cast<IndexParamsHolder*>(params);
     h->hnsw_m_ = m;
     h->hnsw_ef_construction_ = ef_construction;
     h->quantize_type_ = to_quantize_type(quantize_type);
+    h->hnsw_use_contiguous_memory_ = (bool)use_contiguous_memory;
 }
 
 void zvec_index_params_set_flat(zvec_index_params_t params, int quantize_type) {

--- a/ffi/zvec_ffi.h
+++ b/ffi/zvec_ffi.h
@@ -133,7 +133,7 @@ typedef void* zvec_index_params_t;
 
 zvec_index_params_t zvec_index_params_create(int index_type, int metric_type);
 void zvec_index_params_free(zvec_index_params_t params);
-void zvec_index_params_set_hnsw(zvec_index_params_t params, int m, int ef_construction, int quantize_type);
+void zvec_index_params_set_hnsw(zvec_index_params_t params, int m, int ef_construction, int quantize_type, int use_contiguous_memory);
 void zvec_index_params_set_hnsw_rabitq(zvec_index_params_t params, int total_bits, int num_clusters, int m, int ef_construction, int sample_count);
 void zvec_index_params_set_flat(zvec_index_params_t params, int quantize_type);
 void zvec_index_params_set_ivf(zvec_index_params_t params, int n_list, int n_iters, int use_soar, int quantize_type);

--- a/src/ZVec.php
+++ b/src/ZVec.php
@@ -174,7 +174,7 @@ zvec_status_t zvec_collection_create_ivf_index(zvec_collection_t coll, const cha
 
                 zvec_index_params_t zvec_index_params_create(int index_type, int metric_type);
                 void zvec_index_params_free(zvec_index_params_t params);
-                void zvec_index_params_set_hnsw(zvec_index_params_t params, int m, int ef_construction, int quantize_type);
+                void zvec_index_params_set_hnsw(zvec_index_params_t params, int m, int ef_construction, int quantize_type, int use_contiguous_memory);
                 void zvec_index_params_set_hnsw_rabitq(zvec_index_params_t params, int total_bits, int num_clusters, int m, int ef_construction, int sample_count);
                 void zvec_index_params_set_flat(zvec_index_params_t params, int quantize_type);
                 void zvec_index_params_set_ivf(zvec_index_params_t params, int n_list, int n_iters, int use_soar, int quantize_type);
@@ -563,9 +563,9 @@ zvec_status_t zvec_collection_create_ivf_index(zvec_collection_t coll, const cha
     }
 
     /** @deprecated Use createIndex() with ZVecIndexParams::forHnsw() instead */
-    public function createHnswIndex(string $fieldName, int $metricType = ZVecSchema::METRIC_IP, int $m = 50, int $efConstruction = 500, int $quantizeType = 0, int $concurrency = 0): void
+    public function createHnswIndex(string $fieldName, int $metricType = ZVecSchema::METRIC_IP, int $m = 50, int $efConstruction = 500, int $quantizeType = 0, int $concurrency = 0, bool $useContiguousMemory = false): void
     {
-        $this->createIndex($fieldName, ZVecIndexParams::forHnsw($metricType, $m, $efConstruction, $quantizeType), $concurrency);
+        $this->createIndex($fieldName, ZVecIndexParams::forHnsw($metricType, $m, $efConstruction, $quantizeType, $useContiguousMemory), $concurrency);
     }
 
     /** @deprecated Use createIndex() with ZVecIndexParams::forHnswRabitq() instead */
@@ -1424,11 +1424,11 @@ class ZVecIndexParams
         return $this->handle;
     }
 
-    public static function forHnsw(int $metricType, int $m = 50, int $efConstruction = 500, int $quantizeType = ZVec::QUANTIZE_UNDEFINED): self
+    public static function forHnsw(int $metricType, int $m = 50, int $efConstruction = 500, int $quantizeType = ZVec::QUANTIZE_UNDEFINED, bool $useContiguousMemory = false): self
     {
         $ffi = self::ffi();
         $handle = $ffi->zvec_index_params_create(ZVec::INDEX_TYPE_HNSW, $metricType);
-        $ffi->zvec_index_params_set_hnsw($handle, $m, $efConstruction, $quantizeType);
+        $ffi->zvec_index_params_set_hnsw($handle, $m, $efConstruction, $quantizeType, $useContiguousMemory ? 1 : 0);
         return new self($handle);
     }
 

--- a/tests/test_contiguous_memory.phpt
+++ b/tests/test_contiguous_memory.phpt
@@ -1,0 +1,63 @@
+--TEST--
+use_contiguous_memory: HNSW index with contiguous memory allocation
+--SKIPIF--
+<?php if (!extension_loaded('ffi')) die('skip FFI extension not available'); ?>
+--FILE--
+<?php
+require_once __DIR__ . '/../src/ZVec.php';
+ZVec::init(logType: ZVec::LOG_CONSOLE, logLevel: ZVec::LOG_WARN);
+
+$path = __DIR__ . '/../test_dbs/contigmem_' . uniqid();
+try {
+    $schema = new ZVecSchema('test');
+    $schema->addVectorFp32('vec', 4, ZVecSchema::METRIC_COSINE);
+    $coll = ZVec::create($path, $schema);
+
+    // Unified API with useContiguousMemory = true
+    $params = ZVecIndexParams::forHnsw(
+        metricType: ZVecSchema::METRIC_COSINE,
+        m: 16,
+        efConstruction: 200,
+        quantizeType: ZVec::QUANTIZE_UNDEFINED,
+        useContiguousMemory: true
+    );
+    $coll->createIndex('vec', $params);
+    echo "HNSW with contiguous memory via unified API\n";
+
+    // Insert and query
+    $coll->insert(
+        (new ZVecDoc('d1'))->setVectorFp32('vec', [1.0, 0.0, 0.0, 0.0]),
+        (new ZVecDoc('d2'))->setVectorFp32('vec', [0.0, 1.0, 0.0, 0.0])
+    );
+    $coll->optimize();
+    $results = $coll->query('vec', [1.0, 0.1, 0.0, 0.0], topk: 3);
+    echo "Query returned " . count($results) . " results\n";
+
+    // UseContiguousMemory = false (default) via unified API
+    $coll->dropIndex('vec');
+    $params2 = ZVecIndexParams::forHnsw(
+        metricType: ZVecSchema::METRIC_COSINE,
+        m: 16,
+        efConstruction: 200,
+        useContiguousMemory: false
+    );
+    $coll->createIndex('vec', $params2);
+    echo "HNSW without contiguous memory via unified API\n";
+
+    // Legacy deprecated API with useContiguousMemory
+    $coll->dropIndex('vec');
+    $coll->createHnswIndex('vec', metricType: ZVecSchema::METRIC_COSINE, m: 16, efConstruction: 200, useContiguousMemory: true);
+    echo "HNSW with contiguous memory via legacy API\n";
+
+    $coll->close();
+    echo "OK\n";
+} finally {
+    exec("rm -rf " . escapeshellarg($path));
+}
+?>
+--EXPECT--
+HNSW with contiguous memory via unified API
+Query returned 2 results
+HNSW without contiguous memory via unified API
+HNSW with contiguous memory via legacy API
+OK


### PR DESCRIPTION
## Summary

Adds `use_contiguous_memory` parameter to HNSW index creation. When enabled, HNSW stores graph data in contiguous memory instead of fragmented allocations, improving cache locality and query performance.

Closes #28

## Changes

### FFI Layer
- **ffi/zvec_ffi.h**: Added `int use_contiguous_memory` parameter to `zvec_index_params_set_hnsw()`
- **ffi/zvec_ffi.cc**: Added `hnsw_use_contiguous_memory_` field to `IndexParamsHolder`, passed to `HnswIndexParams` constructor in `build()`

### PHP Layer
- **src/ZVec.php**: Updated cdef declaration, `ZVecIndexParams::forHnsw()` now accepts `bool $useContiguousMemory = false`, deprecated `ZVec::createHnswIndex()` accepts the new param

### Tests
- **tests/test_contiguous_memory.phpt**: Tests both unified and legacy APIs with `true` and `false` values, verifies insert + query works

## Build
- FFI library rebuilt. All 64 tests pass.