### PR TITLE
feat: add Vamana (DiskANN) index support via unified IndexParams API (#30)

### DIFF
--- a/ffi/zvec_ffi.cc
+++ b/ffi/zvec_ffi.cc
@@ -656,6 +656,12 @@ struct IndexParamsHolder {
     int rabitq_num_clusters_;
     int rabitq_sample_count_;
     bool hnsw_use_contiguous_memory_;
+    int vamana_max_degree_;
+    int vamana_search_list_size_;
+    float vamana_alpha_;
+    bool vamana_saturate_graph_;
+    bool vamana_use_contiguous_memory_;
+    bool vamana_use_id_map_;
 
     IndexParamsHolder(IndexType type, MetricType metric_type)
         : type_(type), metric_type_(metric_type), quantize_type_(QuantizeType::UNDEFINED),
@@ -663,7 +669,9 @@ struct IndexParamsHolder {
           ivf_n_list_(1024), ivf_n_iters_(10), ivf_use_soar_(false),
           invert_enable_range_(true), invert_enable_wildcard_(false),
           rabitq_total_bits_(7), rabitq_num_clusters_(16), rabitq_sample_count_(0),
-          hnsw_use_contiguous_memory_(false) {}
+          hnsw_use_contiguous_memory_(false),
+          vamana_max_degree_(64), vamana_search_list_size_(100), vamana_alpha_(1.2f),
+          vamana_saturate_graph_(false), vamana_use_contiguous_memory_(false), vamana_use_id_map_(false) {}
 
     IndexParams::Ptr build() const {
         switch (type_) {
@@ -677,6 +685,8 @@ struct IndexParamsHolder {
                 return std::make_shared<IVFIndexParams>(metric_type_, ivf_n_list_, ivf_n_iters_, ivf_use_soar_, quantize_type_);
             case IndexType::INVERT:
                 return std::make_shared<InvertIndexParams>(invert_enable_range_, invert_enable_wildcard_);
+            case IndexType::VAMANA:
+                return std::make_shared<VamanaIndexParams>(metric_type_, vamana_max_degree_, vamana_search_list_size_, vamana_alpha_, vamana_saturate_graph_, vamana_use_contiguous_memory_, vamana_use_id_map_, quantize_type_);
             default:
                 return nullptr;
         }
@@ -689,6 +699,7 @@ static IndexType to_index_type(int v) {
         case 2: return IndexType::IVF;
         case 3: return IndexType::FLAT;
         case 4: return IndexType::HNSW_RABITQ;
+        case 5: return IndexType::VAMANA;
         case 10: return IndexType::INVERT;
         default: return IndexType::UNDEFINED;
     }
@@ -731,6 +742,17 @@ void zvec_index_params_set_hnsw_rabitq(zvec_index_params_t params, int total_bit
     h->hnsw_m_ = m;
     h->hnsw_ef_construction_ = ef_construction;
     h->rabitq_sample_count_ = sample_count;
+}
+
+void zvec_index_params_set_vamana(zvec_index_params_t params, int max_degree, int search_list_size, float alpha, int saturate_graph, int use_contiguous_memory, int use_id_map, int quantize_type) {
+    auto* h = static_cast<IndexParamsHolder*>(params);
+    h->vamana_max_degree_ = max_degree;
+    h->vamana_search_list_size_ = search_list_size;
+    h->vamana_alpha_ = alpha;
+    h->vamana_saturate_graph_ = (bool)saturate_graph;
+    h->vamana_use_contiguous_memory_ = (bool)use_contiguous_memory;
+    h->vamana_use_id_map_ = (bool)use_id_map;
+    h->quantize_type_ = to_quantize_type(quantize_type);
 }
 
 void zvec_index_params_set_invert(zvec_index_params_t params, int enable_range, int enable_wildcard) {
@@ -1776,6 +1798,7 @@ static zvec_status_t validate_query_param_type(Collection* c, const char* field_
         case 2: expected_index_type = IndexType::IVF; break;
         case 3: expected_index_type = IndexType::FLAT; break;
         case 4: expected_index_type = IndexType::HNSW_RABITQ; break;
+        case 5: expected_index_type = IndexType::VAMANA; break;
     }
     
     if (expected_index_type != IndexType::UNDEFINED && 
@@ -1811,6 +1834,9 @@ static void apply_query_params(VectorQuery& query, int type, int hnsw_ef, int iv
         query.query_params_ = params;
     } else if (type == 4) {
         query.query_params_ = std::make_shared<HnswRabitqQueryParams>(
+            hnsw_ef, radius, (bool)is_linear, (bool)is_using_refiner);
+    } else if (type == 5) {
+        query.query_params_ = std::make_shared<VamanaQueryParams>(
             hnsw_ef, radius, (bool)is_linear, (bool)is_using_refiner);
     }
 }
@@ -2006,6 +2032,9 @@ zvec_status_t zvec_collection_group_by_query(zvec_collection_t coll, const char*
         params->set_radius(radius);
         params->set_is_linear((bool)is_linear);
         query.query_params_ = params;
+    } else if (query_param_type == 5) {
+        query.query_params_ = std::make_shared<VamanaQueryParams>(
+            hnsw_ef, radius, (bool)is_linear, (bool)is_using_refiner);
     }
 
     auto res = c->GroupByQuery(query);

--- a/ffi/zvec_ffi.h
+++ b/ffi/zvec_ffi.h
@@ -144,6 +144,7 @@ void zvec_index_params_set_hnsw(zvec_index_params_t params, int m, int ef_constr
 void zvec_index_params_set_hnsw_rabitq(zvec_index_params_t params, int total_bits, int num_clusters, int m, int ef_construction, int sample_count);
 void zvec_index_params_set_flat(zvec_index_params_t params, int quantize_type);
 void zvec_index_params_set_ivf(zvec_index_params_t params, int n_list, int n_iters, int use_soar, int quantize_type);
+void zvec_index_params_set_vamana(zvec_index_params_t params, int max_degree, int search_list_size, float alpha, int saturate_graph, int use_contiguous_memory, int use_id_map, int quantize_type);
 void zvec_index_params_set_invert(zvec_index_params_t params, int enable_range, int enable_wildcard);
 void zvec_index_params_set_quantize_type(zvec_index_params_t params, int quantize_type);
 void zvec_index_params_set_metric_type(zvec_index_params_t params, int metric_type);

--- a/src/ZVec.php
+++ b/src/ZVec.php
@@ -178,6 +178,7 @@ zvec_status_t zvec_collection_create_ivf_index(zvec_collection_t coll, const cha
                 void zvec_index_params_set_hnsw_rabitq(zvec_index_params_t params, int total_bits, int num_clusters, int m, int ef_construction, int sample_count);
                 void zvec_index_params_set_flat(zvec_index_params_t params, int quantize_type);
                 void zvec_index_params_set_ivf(zvec_index_params_t params, int n_list, int n_iters, int use_soar, int quantize_type);
+                void zvec_index_params_set_vamana(zvec_index_params_t params, int max_degree, int search_list_size, float alpha, int saturate_graph, int use_contiguous_memory, int use_id_map, int quantize_type);
                 void zvec_index_params_set_invert(zvec_index_params_t params, int enable_range, int enable_wildcard);
                 void zvec_index_params_set_quantize_type(zvec_index_params_t params, int quantize_type);
                 void zvec_index_params_set_metric_type(zvec_index_params_t params, int metric_type);
@@ -782,6 +783,7 @@ zvec_status_t zvec_collection_create_ivf_index(zvec_collection_t coll, const cha
     public const INDEX_TYPE_IVF = 2;
     public const INDEX_TYPE_FLAT = 3;
     public const INDEX_TYPE_HNSW_RABITQ = 4;
+    public const INDEX_TYPE_VAMANA = 5;
     public const INDEX_TYPE_INVERT = 10;
 
     public const QUERY_PARAM_NONE = 0;
@@ -789,6 +791,7 @@ zvec_status_t zvec_collection_create_ivf_index(zvec_collection_t coll, const cha
     public const QUERY_PARAM_IVF = 2;
     public const QUERY_PARAM_FLAT = 3;
     public const QUERY_PARAM_HNSW_RABITQ = 4;
+    public const QUERY_PARAM_VAMANA = 5;
 
     public const LOG_CONSOLE = 0;
     public const LOG_FILE = 1;
@@ -1487,6 +1490,14 @@ class ZVecIndexParams
         return new self($handle);
     }
 
+    public static function forVamana(int $metricType, int $maxDegree = 64, int $searchListSize = 100, float $alpha = 1.2, bool $saturateGraph = false, bool $useContiguousMemory = false, bool $useIdMap = false, int $quantizeType = ZVec::QUANTIZE_UNDEFINED): self
+    {
+        $ffi = self::ffi();
+        $handle = $ffi->zvec_index_params_create(ZVec::INDEX_TYPE_VAMANA, $metricType);
+        $ffi->zvec_index_params_set_vamana($handle, $maxDegree, $searchListSize, $alpha, $saturateGraph ? 1 : 0, $useContiguousMemory ? 1 : 0, $useIdMap ? 1 : 0, $quantizeType);
+        return new self($handle);
+    }
+
     public static function forInvert(bool $enableRange = true, bool $enableWildcard = false): self
     {
         $ffi = self::ffi();
@@ -1578,6 +1589,13 @@ class ZVecVectorQuery
     public function setFlatParams(): self
     {
         $this->queryParamType = ZVec::QUERY_PARAM_FLAT;
+        return $this;
+    }
+
+    public function setVamanaParams(int $efSearch): self
+    {
+        $this->queryParamType = ZVec::QUERY_PARAM_VAMANA;
+        $this->hnswEf = $efSearch;
         return $this;
     }
 

--- a/tests/test_index_params.phpt
+++ b/tests/test_index_params.phpt
@@ -1,5 +1,5 @@
 --TEST--
-IndexParams: unified createIndex() with ZVecIndexParams (all 4 types)
+IndexParams: unified createIndex() with ZVecIndexParams (all 5 types)
 --SKIPIF--
 <?php if (!extension_loaded('ffi')) die('skip FFI extension not available'); ?>
 --FILE--
@@ -46,6 +46,18 @@ try {
     $coll->createIndex('vec', $params4);
     echo "IVF via unified API\n";
 
+    // Vamana via unified API (only unified API, no legacy wrapper)
+    $params5 = ZVecIndexParams::forVamana(
+        metricType: ZVecSchema::METRIC_COSINE,
+        maxDegree: 32,
+        searchListSize: 50,
+        alpha: 1.0,
+        saturateGraph: false,
+        quantizeType: ZVec::QUANTIZE_UNDEFINED
+    );
+    $coll->createIndex('vec', $params5);
+    echo "Vamana via unified API\n";
+
     // Deprecated wrappers still work
     $coll->createHnswIndex('vec', metricType: ZVecSchema::METRIC_COSINE, m: 16, efConstruction: 200);
     echo "HNSW via legacy API\n";
@@ -70,6 +82,7 @@ HNSW via unified API
 Flat via unified API
 Invert via unified API
 IVF via unified API
+Vamana via unified API
 HNSW via legacy API
 Flat via legacy API
 Invert via legacy API

--- a/tests/test_vamana_index.phpt
+++ b/tests/test_vamana_index.phpt
@@ -1,7 +1,8 @@
 --TEST--
 Vamana index: create via unified IndexParams API, insert, optimize, query, query with ZVecVectorQuery
 --SKIPIF--
-<?php if (!extension_loaded('zvec') && !extension_loaded('ffi')) die('skip Neither zvec extension nor FFI available'); ?>
+<?php if (extension_loaded('zvec')) die('skip This test uses ZVecIndexParams which only works via FFI'); ?>
+<?php if (!extension_loaded('ffi')) die('skip FFI extension not available'); ?>
 --FILE--
 <?php
 require_once __DIR__ . '/../src/ZVec.php';

--- a/tests/test_vamana_index.phpt
+++ b/tests/test_vamana_index.phpt
@@ -1,0 +1,104 @@
+--TEST--
+Vamana index: create via unified IndexParams API, insert, optimize, query, query with ZVecVectorQuery
+--SKIPIF--
+<?php if (!extension_loaded('zvec') && !extension_loaded('ffi')) die('skip Neither zvec extension nor FFI available'); ?>
+--FILE--
+<?php
+require_once __DIR__ . '/../src/ZVec.php';
+require_once __DIR__ . '/../src/ZVecRrfReRanker.php';
+ZVec::init(logType: ZVec::LOG_CONSOLE, logLevel: ZVec::LOG_WARN);
+
+$path = __DIR__ . '/../test_dbs/vamana_' . uniqid();
+
+try {
+    $schema = new ZVecSchema('vamana_test');
+    $schema->addInt64('id', nullable: false)
+        ->addString('label', nullable: true)
+        ->addVectorFp32('v', dimension: 4, metricType: ZVecSchema::METRIC_IP);
+
+    $c = ZVec::create($path, $schema);
+
+    // Test 1: Create Vamana index via ZVecIndexParams::forVamana()
+    $params = ZVecIndexParams::forVamana(
+        metricType: ZVecSchema::METRIC_IP,
+        maxDegree: 32,
+        searchListSize: 50,
+        alpha: 1.0,
+        saturateGraph: false,
+        quantizeType: ZVec::QUANTIZE_UNDEFINED
+    );
+    $c->createIndex('v', $params);
+    echo "Vamana index created OK\n";
+
+    // Insert docs and optimize
+    $docs = [
+        (new ZVecDoc('doc1'))->setInt64('id', 1)->setString('label', 'a')->setVectorFp32('v', [1.0, 0.0, 0.0, 0.0]),
+        (new ZVecDoc('doc2'))->setInt64('id', 2)->setString('label', 'b')->setVectorFp32('v', [0.0, 1.0, 0.0, 0.0]),
+        (new ZVecDoc('doc3'))->setInt64('id', 3)->setString('label', 'c')->setVectorFp32('v', [0.0, 0.0, 1.0, 0.0]),
+        (new ZVecDoc('doc4'))->setInt64('id', 4)->setString('label', 'd')->setVectorFp32('v', [0.0, 0.0, 0.0, 1.0]),
+        (new ZVecDoc('doc5'))->setInt64('id', 5)->setString('label', 'e')->setVectorFp32('v', [0.9, 0.1, 0.0, 0.0]),
+    ];
+    $c->insert(...$docs);
+    $c->optimize();
+    echo "Inserted 5 docs and optimized OK\n";
+
+    // Test 2: Query with default params
+    $results = $c->query('v', [1.0, 0.1, 0.0, 0.0], topk: 3);
+    assert(count($results) === 3, 'Expected 3 results');
+    echo "Query (default) returned 3 results, top: " . $results[0]->getPk() . "\n";
+
+    // Test 3: Query with ZVecVectorQuery and setVamanaParams
+    $vq = new ZVecVectorQuery('v', [1.0, 0.1, 0.0, 0.0]);
+    $vq->setVamanaParams(efSearch: 50);
+    $results2 = $c->query($vq, topk: 3);
+    assert(count($results2) === 3, 'Expected 3 results');
+    echo "Query (Vamana efSearch=50) returned 3 results, top: " . $results2[0]->getPk() . "\n";
+
+    // Test 4: Recreate index with different params
+    $c->dropIndex('v');
+    $params2 = ZVecIndexParams::forVamana(
+        metricType: ZVecSchema::METRIC_IP,
+        maxDegree: 16,
+        searchListSize: 30,
+        alpha: 1.2,
+        saturateGraph: false
+    );
+    $c->createIndex('v', $params2);
+    $c->optimize();
+    echo "Vamana index recreated with custom params OK\n";
+
+    $results3 = $c->query('v', [1.0, 0.1, 0.0, 0.0], topk: 3);
+    assert(count($results3) === 3, 'Expected 3 results');
+    echo "Query after recreate OK\n";
+
+    // Test 5: queryByFilter
+    $filterResults = $c->queryByFilter('id >= 3', topk: 10);
+    assert(count($filterResults) > 0, 'Expected results from filter query');
+    echo "queryByFilter returned " . count($filterResults) . " results OK\n";
+
+    // Test 6: Error - wrong query param type vs actual index
+    try {
+        $vqBad = new ZVecVectorQuery('v', [1.0, 0.1, 0.0, 0.0]);
+        $vqBad->setHnswParams(ef: 200);
+        $c->query($vqBad, topk: 3);
+        echo "UNEXPECTED: Should have thrown\n";
+    } catch (ZVecException $e) {
+        echo "Query param type mismatch correctly caught: " . $e->getErrorCodeString() . "\n";
+    }
+
+    $c->close();
+    echo "PASS: All Vamana index scenarios work\n";
+} finally {
+    exec("rm -rf " . escapeshellarg($path));
+}
+?>
+--EXPECT--
+Vamana index created OK
+Inserted 5 docs and optimized OK
+Query (default) returned 3 results, top: doc1
+Query (Vamana efSearch=50) returned 3 results, top: doc1
+Vamana index recreated with custom params OK
+Query after recreate OK
+queryByFilter returned 3 results OK
+Query param type mismatch correctly caught: INVALID_ARGUMENT
+PASS: All Vamana index scenarios work


### PR DESCRIPTION
Closes #30

## Summary

Add Vamana index type (DiskANN) for billion-scale disk-backed similarity search. Vamana is the graph algorithm used by Microsoft's DiskANN system.

## Changes

### FFI Layer
- Add `zvec_index_params_set_vamana()` to configure Vamana index params (max_degree, search_list_size, alpha, saturate_graph, use_contiguous_memory, use_id_map, quantize_type)
- Add VAMANA (5) to `to_index_type()`, `validate_query_param_type()`, and `apply_query_params()`
- Add `VamanaIndexParams::build()` to `IndexParamsHolder`
- Add `VamanaQueryParams` support in `query_ex`, `query_fp64_ex`, and `group_by_query`

### PHP Layer
- Add `INDEX_TYPE_VAMANA = 5` constant
- Add `QUERY_PARAM_VAMANA = 5` constant
- Add `ZVecIndexParams::forVamana()` static factory
- Add `ZVecVectorQuery::setVamanaParams(efSearch)` fluent setter

### Tests
- `tests/test_vamana_index.phpt` — E2E test: create index, insert, optimize, query, ZVecVectorQuery, drop/recreate, queryByFilter, query param mismatch error
- `tests/test_index_params.phpt` — add Vamana to unified API test (now all 5 types)

## Usage

```php
// Create index
 = ZVecIndexParams::forVamana(
    metricType: ZVecSchema::METRIC_COSINE,
    maxDegree: 64,
    searchListSize: 100,
    alpha: 1.2
);
$coll->createIndex('vec', $params);

// Query with Vamana params
$vq = new ZVecVectorQuery('vec', [0.1, 0.2, 0.3]);
$vq->setVamanaParams(efSearch: 200);
$results = $coll->query($vq, topk: 10);
```

## Test Results
- 64/66 tests pass (2 pre-existing XFAIL: bug_0002, fp64_vectors)