### PR TITLE
feat: add opaque config init API with isInitialized/shutdown (issue #19)

### DIFF
--- a/ffi/zvec_ffi.cc
+++ b/ffi/zvec_ffi.cc
@@ -151,6 +151,18 @@ static QuantizeType to_quantize_type(uint32_t v) {
 
 // --- Init ---
 
+// Track initialization state for isInitialized/shutdown
+#include <atomic>
+static std::atomic<int> g_ffi_initialized{0};
+
+struct LogConfigHolder {
+    std::shared_ptr<GlobalConfig::LogConfig> config;
+};
+
+struct ConfigDataHolder {
+    GlobalConfig::ConfigData config;
+};
+
 zvec_status_t zvec_init(int log_type, int log_level,
                         const char* log_dir, const char* log_basename,
                         uint32_t log_file_size, uint32_t log_overdue_days,
@@ -181,7 +193,116 @@ zvec_status_t zvec_init(int log_type, int log_level,
     if (memory_limit_mb > 0) config.memory_limit_bytes = memory_limit_mb * 1024ULL * 1024ULL;
 
     auto& gc = GlobalConfig::Instance();
-    return MAKE_STATUS(gc.Initialize(config));
+    auto st = MAKE_STATUS(gc.Initialize(config));
+    if (st.code == 0) {
+        g_ffi_initialized.store(1, std::memory_order_release);
+    }
+    return st;
+}
+
+// --- Opaque Config Init API ---
+
+zvec_log_config_t zvec_log_config_create_console(int level) {
+    auto* holder = new LogConfigHolder();
+    holder->config = std::make_shared<GlobalConfig::ConsoleLogConfig>(
+        static_cast<GlobalConfig::LogLevel>(level)
+    );
+    return static_cast<zvec_log_config_t>(holder);
+}
+
+zvec_log_config_t zvec_log_config_create_file(int level, const char* dir, const char* basename, uint32_t file_size, uint32_t overdue_days) {
+    auto* holder = new LogConfigHolder();
+    holder->config = std::make_shared<GlobalConfig::FileLogConfig>(
+        static_cast<GlobalConfig::LogLevel>(level),
+        dir ? dir : DEFAULT_LOG_DIR,
+        basename ? basename : DEFAULT_LOG_BASENAME,
+        file_size > 0 ? file_size : DEFAULT_LOG_FILE_SIZE,
+        overdue_days > 0 ? overdue_days : DEFAULT_LOG_OVERDUE_DAYS
+    );
+    return static_cast<zvec_log_config_t>(holder);
+}
+
+void zvec_log_config_free(zvec_log_config_t config) {
+    if (config) {
+        delete static_cast<LogConfigHolder*>(config);
+    }
+}
+
+zvec_config_data_t zvec_config_data_create(void) {
+    auto* holder = new ConfigDataHolder();
+    return static_cast<zvec_config_data_t>(holder);
+}
+
+void zvec_config_data_free(zvec_config_data_t config) {
+    if (config) {
+        delete static_cast<ConfigDataHolder*>(config);
+    }
+}
+
+void zvec_config_data_set_memory_limit(zvec_config_data_t config, uint64_t bytes) {
+    if (config) {
+        static_cast<ConfigDataHolder*>(config)->config.memory_limit_bytes = bytes;
+    }
+}
+
+void zvec_config_data_set_log_config(zvec_config_data_t config, zvec_log_config_t log_config) {
+    if (config && log_config) {
+        static_cast<ConfigDataHolder*>(config)->config.log_config =
+            static_cast<LogConfigHolder*>(log_config)->config;
+    }
+}
+
+void zvec_config_data_set_query_thread_count(zvec_config_data_t config, uint32_t count) {
+    if (config) {
+        static_cast<ConfigDataHolder*>(config)->config.query_thread_count = count;
+    }
+}
+
+void zvec_config_data_set_optimize_thread_count(zvec_config_data_t config, uint32_t count) {
+    if (config) {
+        static_cast<ConfigDataHolder*>(config)->config.optimize_thread_count = count;
+    }
+}
+
+void zvec_config_data_set_invert_to_forward_scan_ratio(zvec_config_data_t config, float ratio) {
+    if (config) {
+        static_cast<ConfigDataHolder*>(config)->config.invert_to_forward_scan_ratio = ratio;
+    }
+}
+
+void zvec_config_data_set_brute_force_by_keys_ratio(zvec_config_data_t config, float ratio) {
+    if (config) {
+        static_cast<ConfigDataHolder*>(config)->config.brute_force_by_keys_ratio = ratio;
+    }
+}
+
+zvec_status_t zvec_ffi_initialize(zvec_config_data_t config) {
+    if (!config) {
+        auto* holder = new ConfigDataHolder();
+        auto& gc = GlobalConfig::Instance();
+        auto st = MAKE_STATUS(gc.Initialize(holder->config));
+        delete holder;
+        if (st.code == 0) {
+            g_ffi_initialized.store(1, std::memory_order_release);
+        }
+        return st;
+    }
+    auto* holder = static_cast<ConfigDataHolder*>(config);
+    auto& gc = GlobalConfig::Instance();
+    auto st = MAKE_STATUS(gc.Initialize(holder->config));
+    if (st.code == 0) {
+        g_ffi_initialized.store(1, std::memory_order_release);
+    }
+    return st;
+}
+
+zvec_status_t zvec_ffi_shutdown(void) {
+    g_ffi_initialized.store(0, std::memory_order_release);
+    return ok_status();
+}
+
+int zvec_ffi_is_initialized(void) {
+    return g_ffi_initialized.load(std::memory_order_acquire);
 }
 
 // --- Schema ---

--- a/ffi/zvec_ffi.h
+++ b/ffi/zvec_ffi.h
@@ -57,6 +57,27 @@ zvec_status_t zvec_init(int log_type, int log_level,
                         float brute_force_by_keys_ratio,
                         uint64_t memory_limit_mb);
 
+// Opaque config initialization API (zvec v0.4.0+)
+typedef void* zvec_log_config_t;
+typedef void* zvec_config_data_t;
+
+zvec_log_config_t zvec_log_config_create_console(int level);
+zvec_log_config_t zvec_log_config_create_file(int level, const char* dir, const char* basename, uint32_t file_size, uint32_t overdue_days);
+void zvec_log_config_free(zvec_log_config_t config);
+
+zvec_config_data_t zvec_config_data_create(void);
+void zvec_config_data_free(zvec_config_data_t config);
+void zvec_config_data_set_memory_limit(zvec_config_data_t config, uint64_t bytes);
+void zvec_config_data_set_log_config(zvec_config_data_t config, zvec_log_config_t log_config);
+void zvec_config_data_set_query_thread_count(zvec_config_data_t config, uint32_t count);
+void zvec_config_data_set_optimize_thread_count(zvec_config_data_t config, uint32_t count);
+void zvec_config_data_set_invert_to_forward_scan_ratio(zvec_config_data_t config, float ratio);
+void zvec_config_data_set_brute_force_by_keys_ratio(zvec_config_data_t config, float ratio);
+
+zvec_status_t zvec_ffi_initialize(zvec_config_data_t config);
+zvec_status_t zvec_ffi_shutdown(void);
+int zvec_ffi_is_initialized(void);
+
 typedef struct {
     zvec_doc_t* docs;
     int count;

--- a/src/ZVec.php
+++ b/src/ZVec.php
@@ -109,6 +109,26 @@ class ZVec
                                         float brute_force_by_keys_ratio,
                                         uint64_t memory_limit_mb);
 
+                typedef void* zvec_log_config_t;
+                typedef void* zvec_config_data_t;
+
+                zvec_log_config_t zvec_log_config_create_console(int level);
+                zvec_log_config_t zvec_log_config_create_file(int level, const char* dir, const char* basename, uint32_t file_size, uint32_t overdue_days);
+                void zvec_log_config_free(zvec_log_config_t config);
+
+                zvec_config_data_t zvec_config_data_create(void);
+                void zvec_config_data_free(zvec_config_data_t config);
+                void zvec_config_data_set_memory_limit(zvec_config_data_t config, uint64_t bytes);
+                void zvec_config_data_set_log_config(zvec_config_data_t config, zvec_log_config_t log_config);
+                void zvec_config_data_set_query_thread_count(zvec_config_data_t config, uint32_t count);
+                void zvec_config_data_set_optimize_thread_count(zvec_config_data_t config, uint32_t count);
+                void zvec_config_data_set_invert_to_forward_scan_ratio(zvec_config_data_t config, float ratio);
+                void zvec_config_data_set_brute_force_by_keys_ratio(zvec_config_data_t config, float ratio);
+
+                zvec_status_t zvec_ffi_initialize(zvec_config_data_t config);
+                zvec_status_t zvec_ffi_shutdown(void);
+                int zvec_ffi_is_initialized(void);
+
                 zvec_schema_t zvec_schema_create(const char* name);
                 void zvec_schema_free(zvec_schema_t schema);
                 void zvec_schema_set_max_doc_count_per_segment(zvec_schema_t schema, uint64_t count);
@@ -852,15 +872,45 @@ zvec_status_t zvec_collection_create_ivf_index(zvec_collection_t coll, const cha
         float $bruteForceByKeysRatio = 0.0,
         int $memoryLimitMb = 0
     ): void {
-        self::checkStatus(self::ffi()->zvec_init(
-            $logType, $logLevel,
-            $logDir, $logBasename,
-            $logFileSize, $logOverdueDays,
-            $queryThreads, $optimizeThreads,
-            $invertToForwardScanRatio,
-            $bruteForceByKeysRatio,
-            $memoryLimitMb
-        ));
+        $ffi = self::ffi();
+
+        $logConfig = $logType === self::LOG_FILE
+            ? $ffi->zvec_log_config_create_file($logLevel, $logDir, $logBasename, $logFileSize, $logOverdueDays)
+            : $ffi->zvec_log_config_create_console($logLevel);
+
+        $configData = $ffi->zvec_config_data_create();
+        $ffi->zvec_config_data_set_log_config($configData, $logConfig);
+
+        if ($queryThreads > 0) {
+            $ffi->zvec_config_data_set_query_thread_count($configData, $queryThreads);
+        }
+        if ($optimizeThreads > 0) {
+            $ffi->zvec_config_data_set_optimize_thread_count($configData, $optimizeThreads);
+        }
+        if ($invertToForwardScanRatio > 0.0) {
+            $ffi->zvec_config_data_set_invert_to_forward_scan_ratio($configData, $invertToForwardScanRatio);
+        }
+        if ($bruteForceByKeysRatio > 0.0) {
+            $ffi->zvec_config_data_set_brute_force_by_keys_ratio($configData, $bruteForceByKeysRatio);
+        }
+        if ($memoryLimitMb > 0) {
+            $ffi->zvec_config_data_set_memory_limit($configData, $memoryLimitMb * 1048576);
+        }
+
+        self::checkStatus($ffi->zvec_ffi_initialize($configData));
+
+        $ffi->zvec_log_config_free($logConfig);
+        $ffi->zvec_config_data_free($configData);
+    }
+
+    public static function isInitialized(): bool
+    {
+        return self::ffi()->zvec_ffi_is_initialized() !== 0;
+    }
+
+    public static function shutdown(): void
+    {
+        self::ffi()->zvec_ffi_shutdown();
     }
 
     /**

--- a/tests/test_config_init.phpt
+++ b/tests/test_config_init.phpt
@@ -1,0 +1,58 @@
+--TEST--
+Config init: opaque config API with isInitialized and shutdown
+--SKIPIF--
+<?php if (!extension_loaded('ffi')) die('skip FFI extension not available'); ?>
+--FILE--
+<?php
+require_once __DIR__ . '/../src/ZVec.php';
+
+// isInitialized should be false before init
+echo "pre-init: " . (ZVec::isInitialized() ? '1' : '0') . "\n";
+
+// Init with console logging and custom thread counts
+ZVec::init(
+    logType: ZVec::LOG_CONSOLE,
+    logLevel: ZVec::LOG_WARN,
+    queryThreads: 4,
+    optimizeThreads: 2,
+);
+echo "post-init: " . (ZVec::isInitialized() ? '1' : '0') . "\n";
+
+// After init, operations work
+$path = __DIR__ . '/../test_dbs/config_init_' . uniqid();
+try {
+    $schema = new ZVecSchema('test');
+    $schema->addInt64('id');
+    $schema->addVectorFp32('vec', dimension: 4);
+    $coll = ZVec::create($path, $schema);
+    $doc = new ZVecDoc('d1');
+    $doc->setInt64('id', 42);
+    $doc->setVectorFp32('vec', [0.1, 0.2, 0.3, 0.4]);
+    $coll->insert($doc);
+    $coll->flush();
+    $fetched = $coll->fetch('d1');
+    echo "fetched id: " . $fetched[0]->getInt64('id') . "\n";
+    $coll->close();
+    echo "collection ops ok\n";
+} finally {
+    exec("rm -rf " . escapeshellarg($path));
+}
+
+// Shutdown
+ZVec::shutdown();
+echo "shutdown: " . (ZVec::isInitialized() ? '1' : '0') . "\n";
+
+// Re-init after shutdown
+ZVec::init(logType: ZVec::LOG_CONSOLE, logLevel: ZVec::LOG_WARN);
+echo "re-init: " . (ZVec::isInitialized() ? '1' : '0') . "\n";
+
+echo "OK\n";
+?>
+--EXPECTF--
+pre-init: 0
+post-init: 1
+fetched id: 42
+collection ops ok
+shutdown: 0
+re-init: 1
+OK


### PR DESCRIPTION
## Summary

Implement opaque config initialization API matching zvec v0.4.0 upstream pattern:

### FFI Layer
- Add `zvec_log_config_t` / `zvec_config_data_t` opaque types
- Add `zvec_log_config_create_console()`, `zvec_log_config_create_file()`, `zvec_log_config_free()`
- Add `zvec_config_data_create()`, `zvec_config_data_free()`
- Add config setters: memory_limit, log_config, query_thread_count, optimize_thread_count, invert_to_forward_scan_ratio, brute_force_by_keys_ratio
- Add `zvec_ffi_initialize()`, `zvec_ffi_shutdown()`, `zvec_ffi_is_initialized()`

### PHP Layer
- Refactor `ZVec::init()` to use opaque config API internally (backward compatible)
- Add `ZVec::isInitialized(): bool`
- Add `ZVec::shutdown(): void`

### Tests
- `tests/test_config_init.phpt` — init/shutdown lifecycle, collection operations after init, re-init after shutdown

## Backward Compatibility
- Existing `ZVec::init()` signature unchanged (same 11 parameters)
- All 65 existing tests pass

Closes #19