### PR TITLE
feat: structured CollectionStats object — replace JSON stats string with typed ZVecCollectionStats (issue #14)

### DIFF
--- a/ffi/zvec_ffi.cc
+++ b/ffi/zvec_ffi.cc
@@ -2288,7 +2288,73 @@ void zvec_query_result_free_array(zvec_query_result_t* result) {
     }
 }
 
-// --- Stats ---
+// --- CollectionStats struct ---
+
+struct CollectionStatsHolder {
+    zvec::CollectionStats stats;
+    // Thread-local buffers for index names
+    std::vector<std::string> index_names;
+};
+
+static CollectionStatsHolder* stats_holder_from_coll(Collection* c) {
+    auto res = c->Stats();
+    if (!res.has_value()) {
+        return nullptr;
+    }
+    auto* holder = new CollectionStatsHolder();
+    holder->stats = std::move(res.value());
+    // Extract index names into vector for indexed access
+    for (const auto& pair : holder->stats.index_completeness) {
+        holder->index_names.push_back(pair.first);
+    }
+    return holder;
+}
+
+zvec_status_t zvec_collection_get_stats_struct(zvec_collection_t coll, zvec_collection_stats_t* out) {
+    auto* c = static_cast<Collection*>(coll);
+    auto* holder = stats_holder_from_coll(c);
+    if (!holder) {
+        *out = nullptr;
+        auto res = c->Stats();
+        if (!res.has_value()) {
+            return MAKE_STATUS(res.error());
+        }
+        return MAKE_STATUS(Status(StatusCode::INTERNAL_ERROR, "Failed to create stats holder"));
+    }
+    *out = static_cast<zvec_collection_stats_t>(holder);
+    return ok_status();
+}
+
+void zvec_collection_stats_free(zvec_collection_stats_t stats) {
+    delete static_cast<CollectionStatsHolder*>(stats);
+}
+
+uint64_t zvec_collection_stats_get_doc_count(zvec_collection_stats_t stats) {
+    auto* holder = static_cast<CollectionStatsHolder*>(stats);
+    return holder->stats.doc_count;
+}
+
+uint32_t zvec_collection_stats_get_index_count(zvec_collection_stats_t stats) {
+    auto* holder = static_cast<CollectionStatsHolder*>(stats);
+    return static_cast<uint32_t>(holder->index_names.size());
+}
+
+const char* zvec_collection_stats_get_index_name(zvec_collection_stats_t stats, uint32_t index) {
+    auto* holder = static_cast<CollectionStatsHolder*>(stats);
+    if (index >= holder->index_names.size()) return nullptr;
+    return holder->index_names[index].c_str();
+}
+
+float zvec_collection_stats_get_index_completeness(zvec_collection_stats_t stats, uint32_t index) {
+    auto* holder = static_cast<CollectionStatsHolder*>(stats);
+    if (index >= holder->index_names.size()) return 0.0f;
+    const auto& name = holder->index_names[index];
+    auto it = holder->stats.index_completeness.find(name);
+    if (it != holder->stats.index_completeness.end()) {
+        return it->second;
+    }
+    return 0.0f;
+}
 
 zvec_status_t zvec_collection_stats(zvec_collection_t coll, char* buf, size_t buf_size) {
     auto* c = static_cast<Collection*>(coll);

--- a/ffi/zvec_ffi.h
+++ b/ffi/zvec_ffi.h
@@ -343,6 +343,17 @@ zvec_status_t zvec_collection_group_by_query(zvec_collection_t coll, const char*
                                               zvec_group_results_t* result);
 void zvec_group_results_free(zvec_group_results_t* result);
 
+// CollectionStats
+typedef void* zvec_collection_stats_t;
+
+zvec_status_t zvec_collection_get_stats_struct(zvec_collection_t coll, zvec_collection_stats_t* out);
+void zvec_collection_stats_free(zvec_collection_stats_t stats);
+
+uint64_t zvec_collection_stats_get_doc_count(zvec_collection_stats_t stats);
+uint32_t zvec_collection_stats_get_index_count(zvec_collection_stats_t stats);
+const char* zvec_collection_stats_get_index_name(zvec_collection_stats_t stats, uint32_t index);
+float zvec_collection_stats_get_index_completeness(zvec_collection_stats_t stats, uint32_t index);
+
 void zvec_query_result_free(zvec_query_result_t* result);
 void zvec_query_result_free_array(zvec_query_result_t* result);
 

--- a/src/ZVec.php
+++ b/src/ZVec.php
@@ -375,6 +375,16 @@ zvec_status_t zvec_collection_create_ivf_index(zvec_collection_t coll, const cha
 
                 zvec_status_t zvec_collection_stats(zvec_collection_t coll, char* buf, size_t buf_size);
 
+                // CollectionStats
+                typedef void* zvec_collection_stats_t;
+
+                zvec_status_t zvec_collection_get_stats_struct(zvec_collection_t coll, zvec_collection_stats_t* out);
+                void zvec_collection_stats_free(zvec_collection_stats_t stats);
+                uint64_t zvec_collection_stats_get_doc_count(zvec_collection_stats_t stats);
+                uint32_t zvec_collection_stats_get_index_count(zvec_collection_stats_t stats);
+                const char* zvec_collection_stats_get_index_name(zvec_collection_stats_t stats, uint32_t index);
+                float zvec_collection_stats_get_index_completeness(zvec_collection_stats_t stats, uint32_t index);
+
                 typedef struct {
                     int code;
                     const char* message;
@@ -1500,6 +1510,87 @@ zvec_status_t zvec_collection_create_ivf_index(zvec_collection_t coll, const cha
         $buf = $ffi->new('char[4096]');
         self::checkStatus($ffi->zvec_collection_stats($this->handle, $buf, 4096));
         return FFI::string($buf);
+    }
+
+    /**
+     * Get structured collection stats.
+     */
+    public function getStatsStruct(): ZVecCollectionStats
+    {
+        $this->checkClosed();
+        $ffi = self::ffi();
+        $out = $ffi->new('zvec_collection_stats_t');
+        self::checkStatus($ffi->zvec_collection_get_stats_struct($this->handle, FFI::addr($out)));
+        return new ZVecCollectionStats($out);
+    }
+}
+
+class ZVecCollectionStats
+{
+    private FFI\CData $handle;
+
+    public function __construct(FFI\CData $handle)
+    {
+        $this->handle = $handle;
+    }
+
+    public function __destruct()
+    {
+        self::ffi()->zvec_collection_stats_free($this->handle);
+    }
+
+    public function getDocCount(): int
+    {
+        return self::ffi()->zvec_collection_stats_get_doc_count($this->handle);
+    }
+
+    public function getIndexCount(): int
+    {
+        return self::ffi()->zvec_collection_stats_get_index_count($this->handle);
+    }
+
+    public function getIndexName(int $index): string
+    {
+        $ptr = self::ffi()->zvec_collection_stats_get_index_name($this->handle, $index);
+        if ($ptr === null) {
+            throw new ZVecException("Index out of range: $index");
+        }
+        return is_string($ptr) ? $ptr : FFI::string($ptr);
+    }
+
+    public function getIndexCompleteness(int $index): float
+    {
+        return self::ffi()->zvec_collection_stats_get_index_completeness($this->handle, $index);
+    }
+
+    /**
+     * @return array<string, float>
+     */
+    public function getAllIndexCompleteness(): array
+    {
+        $count = $this->getIndexCount();
+        $result = [];
+        for ($i = 0; $i < $count; $i++) {
+            $name = $this->getIndexName($i);
+            $result[$name] = $this->getIndexCompleteness($i);
+        }
+        return $result;
+    }
+
+    /**
+     * @return array{doc_count: int, index_completeness: array<string, float>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'doc_count' => $this->getDocCount(),
+            'index_completeness' => $this->getAllIndexCompleteness(),
+        ];
+    }
+
+    private static function ffi(): FFI
+    {
+        return (new ReflectionClass(ZVec::class))->getMethod('ffi')->invoke(null);
     }
 }
 

--- a/tests/test_collection_stats.phpt
+++ b/tests/test_collection_stats.phpt
@@ -1,0 +1,91 @@
+--TEST--
+CollectionStats: structured stats access with typed getters
+--SKIPIF--
+<?php if (!extension_loaded('ffi')) die('skip FFI extension not available'); ?>
+--FILE--
+<?php
+require_once __DIR__ . '/../src/ZVec.php';
+ZVec::init(logType: ZVec::LOG_CONSOLE, logLevel: ZVec::LOG_WARN);
+
+$path = __DIR__ . '/../test_dbs/collstats_' . uniqid();
+try {
+    $schema = new ZVecSchema('test');
+    $schema->addInt64('id')
+        ->addVectorFp32('vec', dimension: 4, metricType: ZVecSchema::METRIC_IP);
+    $c = ZVec::create($path, $schema);
+
+    // Test 1: Stats with no docs (index may already exist from schema)
+    $stats = $c->getStatsStruct();
+    echo "docCount (empty): " . $stats->getDocCount() . "\n";
+
+    // Test 2: Create explicit index and verify
+    $c->createIndex('vec', ZVecIndexParams::forHnsw(ZVecSchema::METRIC_IP));
+    $stats2 = $c->getStatsStruct();
+    $ic = $stats2->getIndexCount();
+    echo "indexCount (after create): " . $ic . "\n";
+    for ($i = 0; $i < $ic; $i++) {
+        echo "  index[$i] name: " . $stats2->getIndexName($i) . "\n";
+    }
+
+    // Test 3: Insert docs, optimize, check completeness
+    $c->insert(
+        (new ZVecDoc('d1'))->setInt64('id', 1)->setVectorFp32('vec', [1.0, 0.0, 0.0, 0.0]),
+        (new ZVecDoc('d2'))->setInt64('id', 2)->setVectorFp32('vec', [0.0, 1.0, 0.0, 0.0]),
+    );
+    echo "docCount (after insert): " . $c->getStatsStruct()->getDocCount() . "\n";
+
+    $c->optimize();
+    $stats3 = $c->getStatsStruct();
+    echo "docCount (after optimize): " . $stats3->getDocCount() . "\n";
+    echo "completeness (after optimize): " . $stats3->getIndexCompleteness(0) . "\n";
+
+    // Test 4: getAllIndexCompleteness and toArray
+    $allIc = $stats3->getAllIndexCompleteness();
+    echo "getAllIndexCompleteness keys: " . implode(',', array_keys($allIc)) . "\n";
+
+    $arr = $stats3->toArray();
+    echo "toArray doc_count: " . $arr['doc_count'] . "\n";
+    echo "toArray has vec: " . (isset($arr['index_completeness']['vec']) ? '1' : '0') . "\n";
+
+    // Test 5: JSON stats backward compat
+    $json = $c->stats();
+    echo "JSON stats contains doc_count: " . (str_contains($json, 'doc_count') ? '1' : '0') . "\n";
+
+    // Test 6: Error on out of range index
+    $stats4 = $c->getStatsStruct();
+    try {
+        $stats4->getIndexName(999);
+        echo "UNEXPECTED: Should have thrown\n";
+    } catch (ZVecException $e) {
+        echo "Out of range index correctly caught\n";
+    }
+
+    $c->close();
+
+    // Test 7: Error on closed collection
+    try {
+        $c->getStatsStruct();
+        echo "UNEXPECTED: Should have thrown\n";
+    } catch (ZVecException $e) {
+        echo "Closed collection error correctly caught\n";
+    }
+
+    echo "PASS\n";
+} finally {
+    exec("rm -rf " . escapeshellarg($path));
+}
+?>
+--EXPECTF--
+docCount (empty): 0
+indexCount (after create): %d
+%s index[0] name: vec
+docCount (after insert): 2
+docCount (after optimize): 2
+completeness (after optimize): 1
+getAllIndexCompleteness keys: vec
+toArray doc_count: 2
+toArray has vec: 1
+JSON stats contains doc_count: 1
+Out of range index correctly caught
+Closed collection error correctly caught
+PASS


### PR DESCRIPTION
## Summary

Add `ZVecCollectionStats` PHP class providing typed, structured access to collection statistics via FFI, replacing the previous JSON-only `stats()` method.

## Changes

### FFI Layer (`ffi/zvec_ffi.h/.cc`)
- Add `zvec_collection_stats_t` opaque type
- Add `zvec_collection_get_stats_struct()` to retrieve stats from collection
- Add typed getters: `get_doc_count`, `get_index_count`, `get_index_name`, `get_index_completeness`
- Add `zvec_collection_stats_free()` for cleanup

### PHP Layer (`src/ZVec.php`)
- Add `ZVecCollectionStats` class with `getDocCount()`, `getIndexCount()`, `getIndexName()`, `getIndexCompleteness()`, `getAllIndexCompleteness()`, and `toArray()` methods
- Add `getStatsStruct()` method to `ZVec`
- Backward compatible: old `stats()` JSON method unchanged

### Tests (`tests/test_collection_stats.phpt`)
- Empty collection stats
- Index creation and stats tracking
- Insert/optimize/completeness verification
- getAllIndexCompleteness and toArray()
- JSON backward compat
- Error handling: out of range index, closed collection

## Testing

All 69 tests pass (67 pass + 2 XFAIL for known upstream issues).