### PR TITLE
feat: add FieldSchema introspection API (#13)

### DIFF
--- a/ffi/zvec_ffi.cc
+++ b/ffi/zvec_ffi.cc
@@ -2367,3 +2367,112 @@ zvec_status_t zvec_collection_stats(zvec_collection_t coll, char* buf, size_t bu
     buf[buf_size - 1] = '\0';
     return ok_status();
 }
+
+// --- FieldSchema introspection ---
+
+struct FieldSchemaHolder {
+    std::string name;
+    DataType data_type;
+    uint32_t dimension;
+    bool nullable;
+    IndexType index_type;
+    bool has_index;
+};
+
+zvec_status_t zvec_collection_get_field_schema(zvec_collection_t coll, const char* field_name, zvec_field_schema_t* out) {
+    auto* c = static_cast<Collection*>(coll);
+    auto schema_res = c->Schema();
+    if (!schema_res.has_value()) {
+        *out = nullptr;
+        return MAKE_STATUS(schema_res.error());
+    }
+    
+    const auto& schema = schema_res.value();
+    const FieldSchema* field = schema.get_field(field_name);
+    if (!field) {
+        *out = nullptr;
+        zvec_status_t st;
+        st.code = static_cast<int>(StatusCode::NOT_FOUND);
+        std::string msg = std::string("Field not found: ") + field_name;
+        strncpy(st.message, msg.c_str(), sizeof(st.message) - 1);
+        st.message[sizeof(st.message) - 1] = '\0';
+        SET_FFI_ERROR(st);
+        return st;
+    }
+    
+    auto* holder = new FieldSchemaHolder();
+    holder->name = field->name();
+    holder->data_type = field->data_type();
+    holder->dimension = field->dimension();
+    holder->nullable = field->nullable();
+    holder->index_type = field->index_type();
+    holder->has_index = field->index_type() != IndexType::UNDEFINED;
+    
+    *out = static_cast<zvec_field_schema_t>(holder);
+    return ok_status();
+}
+
+void zvec_field_schema_free(zvec_field_schema_t schema) {
+    delete static_cast<FieldSchemaHolder*>(schema);
+}
+
+const char* zvec_field_schema_get_name(zvec_field_schema_t schema) {
+    return static_cast<FieldSchemaHolder*>(schema)->name.c_str();
+}
+
+static thread_local std::string g_elem_data_type_name_buf;
+
+int zvec_field_schema_get_data_type(zvec_field_schema_t schema) {
+    return static_cast<int>(static_cast<FieldSchemaHolder*>(schema)->data_type);
+}
+
+int zvec_field_schema_get_element_data_type(zvec_field_schema_t schema) {
+    auto* h = static_cast<FieldSchemaHolder*>(schema);
+    return static_cast<int>(FieldSchema::get_element_data_type(h->data_type));
+}
+
+size_t zvec_field_schema_get_element_data_size(zvec_field_schema_t schema) {
+    auto* h = static_cast<FieldSchemaHolder*>(schema);
+    return FieldSchema::get_element_data_size(h->data_type);
+}
+
+uint32_t zvec_field_schema_get_dimension(zvec_field_schema_t schema) {
+    return static_cast<FieldSchemaHolder*>(schema)->dimension;
+}
+
+int zvec_field_schema_is_vector_field(zvec_field_schema_t schema) {
+    auto* h = static_cast<FieldSchemaHolder*>(schema);
+    return FieldSchema::is_vector_field(h->data_type) ? 1 : 0;
+}
+
+int zvec_field_schema_is_dense_vector(zvec_field_schema_t schema) {
+    auto* h = static_cast<FieldSchemaHolder*>(schema);
+    return FieldSchema::is_dense_vector_field(h->data_type) ? 1 : 0;
+}
+
+int zvec_field_schema_is_sparse_vector(zvec_field_schema_t schema) {
+    auto* h = static_cast<FieldSchemaHolder*>(schema);
+    return FieldSchema::is_sparse_vector_field(h->data_type) ? 1 : 0;
+}
+
+int zvec_field_schema_is_array_type(zvec_field_schema_t schema) {
+    auto* h = static_cast<FieldSchemaHolder*>(schema);
+    return h->data_type >= DataType::ARRAY_BINARY && h->data_type <= DataType::ARRAY_DOUBLE ? 1 : 0;
+}
+
+int zvec_field_schema_is_nullable(zvec_field_schema_t schema) {
+    return static_cast<FieldSchemaHolder*>(schema)->nullable ? 1 : 0;
+}
+
+int zvec_field_schema_has_invert_index(zvec_field_schema_t schema) {
+    auto* h = static_cast<FieldSchemaHolder*>(schema);
+    return (!FieldSchema::is_vector_field(h->data_type) && h->has_index) ? 1 : 0;
+}
+
+int zvec_field_schema_has_index(zvec_field_schema_t schema) {
+    return static_cast<FieldSchemaHolder*>(schema)->has_index ? 1 : 0;
+}
+
+int zvec_field_schema_get_index_type(zvec_field_schema_t schema) {
+    return static_cast<int>(static_cast<FieldSchemaHolder*>(schema)->index_type);
+}

--- a/ffi/zvec_ffi.h
+++ b/ffi/zvec_ffi.h
@@ -357,6 +357,26 @@ float zvec_collection_stats_get_index_completeness(zvec_collection_stats_t stats
 void zvec_query_result_free(zvec_query_result_t* result);
 void zvec_query_result_free_array(zvec_query_result_t* result);
 
+// FieldSchema introspection
+typedef void* zvec_field_schema_t;
+
+zvec_status_t zvec_collection_get_field_schema(zvec_collection_t coll, const char* field_name, zvec_field_schema_t* out);
+void zvec_field_schema_free(zvec_field_schema_t schema);
+
+const char* zvec_field_schema_get_name(zvec_field_schema_t schema);
+int zvec_field_schema_get_data_type(zvec_field_schema_t schema);
+int zvec_field_schema_get_element_data_type(zvec_field_schema_t schema);
+size_t zvec_field_schema_get_element_data_size(zvec_field_schema_t schema);
+uint32_t zvec_field_schema_get_dimension(zvec_field_schema_t schema);
+int zvec_field_schema_is_vector_field(zvec_field_schema_t schema);
+int zvec_field_schema_is_dense_vector(zvec_field_schema_t schema);
+int zvec_field_schema_is_sparse_vector(zvec_field_schema_t schema);
+int zvec_field_schema_is_array_type(zvec_field_schema_t schema);
+int zvec_field_schema_is_nullable(zvec_field_schema_t schema);
+int zvec_field_schema_has_invert_index(zvec_field_schema_t schema);
+int zvec_field_schema_has_index(zvec_field_schema_t schema);
+int zvec_field_schema_get_index_type(zvec_field_schema_t schema);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/ZVec.php
+++ b/src/ZVec.php
@@ -402,6 +402,24 @@ zvec_status_t zvec_collection_create_ivf_index(zvec_collection_t coll, const cha
                 int zvec_get_version_major(void);
                 int zvec_get_version_minor(void);
                 int zvec_get_version_patch(void);
+
+                typedef void* zvec_field_schema_t;
+
+                zvec_status_t zvec_collection_get_field_schema(zvec_collection_t coll, const char* field_name, zvec_field_schema_t* out);
+                void zvec_field_schema_free(zvec_field_schema_t schema);
+                const char* zvec_field_schema_get_name(zvec_field_schema_t schema);
+                int zvec_field_schema_get_data_type(zvec_field_schema_t schema);
+                int zvec_field_schema_get_element_data_type(zvec_field_schema_t schema);
+                size_t zvec_field_schema_get_element_data_size(zvec_field_schema_t schema);
+                uint32_t zvec_field_schema_get_dimension(zvec_field_schema_t schema);
+                int zvec_field_schema_is_vector_field(zvec_field_schema_t schema);
+                int zvec_field_schema_is_dense_vector(zvec_field_schema_t schema);
+                int zvec_field_schema_is_sparse_vector(zvec_field_schema_t schema);
+                int zvec_field_schema_is_array_type(zvec_field_schema_t schema);
+                int zvec_field_schema_is_nullable(zvec_field_schema_t schema);
+                int zvec_field_schema_has_invert_index(zvec_field_schema_t schema);
+                int zvec_field_schema_has_index(zvec_field_schema_t schema);
+                int zvec_field_schema_get_index_type(zvec_field_schema_t schema);
             ', $libPath);
         }
         return self::$ffi;
@@ -1523,6 +1541,18 @@ zvec_status_t zvec_collection_create_ivf_index(zvec_collection_t coll, const cha
         self::checkStatus($ffi->zvec_collection_get_stats_struct($this->handle, FFI::addr($out)));
         return new ZVecCollectionStats($out);
     }
+
+    /**
+     * Get structured field schema for a specific field.
+     */
+    public function getFieldSchema(string $fieldName): ZVecFieldSchema
+    {
+        $this->checkClosed();
+        $ffi = self::ffi();
+        $out = $ffi->new('zvec_field_schema_t');
+        self::checkStatus($ffi->zvec_collection_get_field_schema($this->handle, $fieldName, FFI::addr($out)));
+        return new ZVecFieldSchema($out);
+    }
 }
 
 class ZVecCollectionStats
@@ -1586,6 +1616,92 @@ class ZVecCollectionStats
             'doc_count' => $this->getDocCount(),
             'index_completeness' => $this->getAllIndexCompleteness(),
         ];
+    }
+
+    private static function ffi(): FFI
+    {
+        return (new ReflectionClass(ZVec::class))->getMethod('ffi')->invoke(null);
+    }
+}
+
+class ZVecFieldSchema
+{
+    private FFI\CData $handle;
+
+    public function __construct(FFI\CData $handle)
+    {
+        $this->handle = $handle;
+    }
+
+    public function __destruct()
+    {
+        self::ffi()->zvec_field_schema_free($this->handle);
+    }
+
+    public function getName(): string
+    {
+        $ptr = self::ffi()->zvec_field_schema_get_name($this->handle);
+        return is_string($ptr) ? $ptr : FFI::string($ptr);
+    }
+
+    public function getDataType(): int
+    {
+        return self::ffi()->zvec_field_schema_get_data_type($this->handle);
+    }
+
+    public function getElementDataType(): int
+    {
+        return self::ffi()->zvec_field_schema_get_element_data_type($this->handle);
+    }
+
+    public function getElementDataSize(): int
+    {
+        return self::ffi()->zvec_field_schema_get_element_data_size($this->handle);
+    }
+
+    public function getDimension(): int
+    {
+        return self::ffi()->zvec_field_schema_get_dimension($this->handle);
+    }
+
+    public function isVectorField(): bool
+    {
+        return self::ffi()->zvec_field_schema_is_vector_field($this->handle) !== 0;
+    }
+
+    public function isDenseVector(): bool
+    {
+        return self::ffi()->zvec_field_schema_is_dense_vector($this->handle) !== 0;
+    }
+
+    public function isSparseVector(): bool
+    {
+        return self::ffi()->zvec_field_schema_is_sparse_vector($this->handle) !== 0;
+    }
+
+    public function isArrayType(): bool
+    {
+        return self::ffi()->zvec_field_schema_is_array_type($this->handle) !== 0;
+    }
+
+    public function isNullable(): bool
+    {
+        return self::ffi()->zvec_field_schema_is_nullable($this->handle) !== 0;
+    }
+
+    public function hasInvertIndex(): bool
+    {
+        return self::ffi()->zvec_field_schema_has_invert_index($this->handle) !== 0;
+    }
+
+    public function hasIndex(): bool
+    {
+        return self::ffi()->zvec_field_schema_has_index($this->handle) !== 0;
+    }
+
+    public function getIndexType(): int
+    {
+        return self::ffi()->zvec_field_schema_get_index_type($this->handle);
     }
 
     private static function ffi(): FFI

--- a/tests/test_field_schema.phpt
+++ b/tests/test_field_schema.phpt
@@ -1,0 +1,157 @@
+--TEST--
+FieldSchema: structured field introspection API
+--SKIPIF--
+<?php if (!extension_loaded('ffi')) die('skip FFI extension not available'); ?>
+--FILE--
+<?php
+require_once __DIR__ . '/../src/ZVec.php';
+ZVec::init(logType: ZVec::LOG_CONSOLE, logLevel: ZVec::LOG_WARN);
+
+$path = __DIR__ . '/../test_dbs/fieldschema_' . uniqid();
+try {
+    $schema = new ZVecSchema('test');
+    $schema->addInt64('id')
+        ->addString('name', nullable: true)
+        ->addFloat('score')
+        ->addDouble('rating')
+        ->addBool('active')
+        ->addInt32('count')
+        ->addUint32('ucount')
+        ->addUint64('ubig')
+        ->addVectorFp32('vec', dimension: 128, metricType: ZVecSchema::METRIC_COSINE)
+        ->addVectorFp16('vecf16', dimension: 16, metricType: ZVecSchema::METRIC_L2)
+        ->addVectorInt8('veci8', dimension: 32, metricType: ZVecSchema::METRIC_IP)
+        ->addSparseVectorFp32('sparse', metricType: ZVecSchema::METRIC_IP)
+        ->addFieldArrayInt32('arr_i32')
+        ->addFieldArrayString('arr_str');
+    $c = ZVec::create($path, $schema);
+
+    // Test 1: Basic scalar field introspection
+    $idFs = $c->getFieldSchema('id');
+    echo "1 id type: " . $idFs->getDataType() . "\n";
+    echo "2 id nullable: " . ($idFs->isNullable() ? '1' : '0') . "\n";
+    echo "3 id isVector: " . ($idFs->isVectorField() ? '1' : '0') . "\n";
+    echo "4 id isDense: " . ($idFs->isDenseVector() ? '1' : '0') . "\n";
+    echo "5 id isSparse: " . ($idFs->isSparseVector() ? '1' : '0') . "\n";
+    echo "6 id isArray: " . ($idFs->isArrayType() ? '1' : '0') . "\n";
+    echo "7 id dim: " . $idFs->getDimension() . "\n";
+    echo "8 id name: " . $idFs->getName() . "\n";
+    echo "9 id elemDt: " . $idFs->getElementDataType() . "\n";
+
+    // Test 2: Nullable string
+    $nameFs = $c->getFieldSchema('name');
+    echo "10 name nullable: " . ($nameFs->isNullable() ? '1' : '0') . "\n";
+    echo "11 name type: " . $nameFs->getDataType() . "\n";
+    echo "12 name isVector: " . ($nameFs->isVectorField() ? '1' : '0') . "\n";
+
+    // Test 3: Vector fields
+    $vecFs = $c->getFieldSchema('vec');
+    echo "13 vec dim: " . $vecFs->getDimension() . "\n";
+    echo "14 vec type: " . $vecFs->getDataType() . "\n";
+    echo "15 vec isDense: " . ($vecFs->isDenseVector() ? '1' : '0') . "\n";
+    echo "16 vec isVector: " . ($vecFs->isVectorField() ? '1' : '0') . "\n";
+    echo "17 vec isSparse: " . ($vecFs->isSparseVector() ? '1' : '0') . "\n";
+
+    // Test 4: FP16 vector
+    $vf16 = $c->getFieldSchema('vecf16');
+    echo "18 vecf16 type: " . $vf16->getDataType() . "\n";
+    echo "19 vecf16 dim: " . $vf16->getDimension() . "\n";
+
+    // Test 5: INT8 vector
+    $vi8 = $c->getFieldSchema('veci8');
+    echo "20 veci8 type: " . $vi8->getDataType() . "\n";
+    echo "21 veci8 dim: " . $vi8->getDimension() . "\n";
+
+    // Test 6: Sparse vector
+    $spFs = $c->getFieldSchema('sparse');
+    echo "22 sparse type: " . $spFs->getDataType() . "\n";
+    echo "23 sparse isSparse: " . ($spFs->isSparseVector() ? '1' : '0') . "\n";
+    echo "24 sparse isVector: " . ($spFs->isVectorField() ? '1' : '0') . "\n";
+    echo "25 sparse dim: " . $spFs->getDimension() . "\n";
+
+    // Test 7: Array field
+    $arrFs = $c->getFieldSchema('arr_i32');
+    echo "26 arr_i32 type: " . $arrFs->getDataType() . "\n";
+    echo "27 arr_i32 isArray: " . ($arrFs->isArrayType() ? '1' : '0') . "\n";
+    echo "28 arr_i32 elemDt: " . $arrFs->getElementDataType() . "\n";
+    echo "29 arr_i32 elemSize: " . $arrFs->getElementDataSize() . "\n";
+
+    // Test 8: Index info (initially none)
+    echo "30 id hasIndex: " . ($idFs->hasIndex() ? '1' : '0') . "\n";
+    echo "31 id hasInvert: " . ($idFs->hasInvertIndex() ? '1' : '0') . "\n";
+    echo "32 id idxType: " . $idFs->getIndexType() . "\n";
+
+    // Test 9: Create HNSW index and check
+    $c->createIndex('vec', ZVecIndexParams::forHnsw(ZVecSchema::METRIC_COSINE));
+    $vecFs2 = $c->getFieldSchema('vec');
+    echo "33 vec hasIndex: " . ($vecFs2->hasIndex() ? '1' : '0') . "\n";
+    echo "34 vec idxType: " . $vecFs2->getIndexType() . "\n";
+
+    // Test 10: Create invert index on string
+    $c->createIndex('name', ZVecIndexParams::forInvert());
+    $nameFs2 = $c->getFieldSchema('name');
+    echo "35 name hasInvert: " . ($nameFs2->hasInvertIndex() ? '1' : '0') . "\n";
+    echo "36 name hasIndex: " . ($nameFs2->hasIndex() ? '1' : '0') . "\n";
+
+    // Test 11: Non-existent field
+    try {
+        $c->getFieldSchema('nonexistent');
+        echo "UNEXPECTED: Should have thrown\n";
+    } catch (ZVecException $e) {
+        echo "37 nonexistent: " . $e->getCode() . "\n";
+    }
+
+    // Test 12: Closed collection error
+    $c->close();
+    try {
+        $c->getFieldSchema('id');
+        echo "UNEXPECTED: Should have thrown\n";
+    } catch (ZVecException $e) {
+        echo "38 closed: caught\n";
+    }
+
+    echo "PASS\n";
+} finally {
+    exec("rm -rf " . escapeshellarg($path));
+}
+?>
+--EXPECTF--
+1 id type: 5
+2 id nullable: 0
+3 id isVector: 0
+4 id isDense: 0
+5 id isSparse: 0
+6 id isArray: 0
+7 id dim: 0
+8 id name: id
+9 id elemDt: 5
+10 name nullable: 1
+11 name type: 2
+12 name isVector: 0
+13 vec dim: 128
+14 vec type: 23
+15 vec isDense: 1
+16 vec isVector: 1
+17 vec isSparse: 0
+18 vecf16 type: 22
+19 vecf16 dim: 16
+20 veci8 type: 26
+21 veci8 dim: 32
+22 sparse type: 31
+23 sparse isSparse: 1
+24 sparse isVector: 1
+25 sparse dim: 0
+26 arr_i32 type: 43
+27 arr_i32 isArray: 1
+28 arr_i32 elemDt: 4
+29 arr_i32 elemSize: 4
+30 id hasIndex: 0
+31 id hasInvert: 0
+32 id idxType: 0
+33 vec hasIndex: 1
+34 vec idxType: 1
+35 name hasInvert: 1
+36 name hasIndex: 1
+37 nonexistent: 1
+38 closed: caught
+PASS

--- a/tests/test_fp64_vectors.php
+++ b/tests/test_fp64_vectors.php
@@ -1,0 +1,124 @@
+<?php
+require_once __DIR__ . '/../src/ZVec.php';
+ZVec::init(logType: ZVec::LOG_CONSOLE, logLevel: ZVec::LOG_WARN);
+
+$path = __DIR__ . '/../test_dbs/fp64_' . uniqid();
+
+$schema = new ZVecSchema('fp64_test');
+$schema->setMaxDocCountPerSegment(1000)
+    ->addInt64('id', nullable: false, withInvertIndex: true)
+    ->addVectorFp64('v', dimension: 4, metricType: ZVecSchema::METRIC_COSINE);
+
+$c = ZVec::create($path, $schema);
+
+try {
+    // Test 1: Insert docs with FP64 vectors
+    $docs = [];
+    foreach ([
+        'doc1' => [0.1, 0.2, 0.3, 0.4],
+        'doc2' => [0.5, 0.6, 0.7, 0.8],
+        'doc3' => [0.9, 0.1, 0.2, 0.3],
+    ] as $pk => $vec) {
+        $doc = new ZVecDoc($pk);
+        $doc->setInt64('id', (int)substr($pk, 3))
+            ->setVectorFp64('v', $vec);
+        $docs[] = $doc;
+    }
+    $c->insert(...$docs);
+    $c->optimize();
+    echo "Inserted 3 FP64 docs OK\n";
+
+    // Test 2: Fetch and verify FP64 vectors
+    $fetched = $c->fetch('doc1', 'doc2', 'doc3');
+    assert(count($fetched) === 3, 'Expected 3 docs');
+
+    $v = $fetched[0]->getVectorFp64('v');
+    assert($v !== null, 'Expected FP64 vector');
+    assert(count($v) === 4, 'Expected dimension 4');
+    assert(abs($v[0] - 0.1) < 1e-10, "Expected 0.1, got {$v[0]}");
+    assert(abs($v[3] - 0.4) < 1e-10, "Expected 0.4, got {$v[3]}");
+    echo "Fetched FP64 vectors OK\n";
+
+    // Test 3: getVectorFp32 returns null for FP64 field
+    $nullVec = $fetched[0]->getVectorFp32('v');
+    assert($nullVec === null, 'Expected null from getVectorFp32 on FP64 field');
+    echo "getVectorFp32 returns null for FP64 field OK\n";
+
+    // Test 4: Query with FP64 vector
+    $results = $c->queryFp64('v', [0.1, 0.2, 0.3, 0.4], topk: 3);
+    assert(count($results) === 3, 'Expected 3 results');
+    assert($results[0]->getPk() === 'doc1', 'Expected doc1 as top result');
+    assert(abs($results[0]->getScore() - 1.0) < 0.001, 'Expected score≈1.0 for identical vector');
+    echo "FP64 query returned correct results OK\n";
+
+    // Test 5: queryFp64 with includeVector
+    $results = $c->queryFp64('v', [0.1, 0.2, 0.3, 0.4], topk: 1, includeVector: true);
+    assert(count($results) === 1, 'Expected 1 result');
+    $v = $results[0]->getVectorFp64('v');
+    assert($v !== null, 'Expected vector with includeVector');
+    assert(abs($v[0] - 0.1) < 1e-10, 'Expected correct vector data');
+    echo "FP64 query with includeVector OK\n";
+
+    // Test 6: queryFp64 with filter
+    $results = $c->queryFp64('v', [0.1, 0.2, 0.3, 0.4], topk: 3, filter: 'id > 1');
+    assert(count($results) === 2, 'Expected 2 results after filter');
+    echo "FP64 query with filter OK\n";
+
+    // Test 7: queryFp64 with outputFields
+    $results = $c->queryFp64('v', [0.1, 0.2, 0.3, 0.4], topk: 1, outputFields: ['id']);
+    assert(count($results) === 1, 'Expected 1 result');
+    assert($results[0]->getInt64('id') === 1, 'Expected id=1');
+    echo "FP64 query with outputFields OK\n";
+
+    // Test 8: Query via ZVecVectorQuery with useFp64
+    $vq = new ZVecVectorQuery('v', [0.5, 0.6, 0.7, 0.8]);
+    $vq->setFp64(true);
+    $results = $c->query($vq, topk: 3);
+    assert(count($results) === 3, 'Expected 3 results');
+    assert($results[0]->getPk() === 'doc2', 'Expected doc2 as top result');
+    echo "ZVecVectorQuery with useFp64 OK\n";
+
+    // Test 9: Query by ID with FP64
+    $results = $c->queryById('v', 'doc1', topk: 3);
+    assert(count($results) === 3, 'Expected 3 results');
+    assert($results[0]->getPk() === 'doc1', 'Expected doc1 as top result');
+    echo "queryById with FP64 OK\n";
+
+    // Test 10: hasVector and vectorNames with FP64
+    assert($fetched[0]->hasVector('v'), 'Expected hasVector true for FP64 field');
+    assert(!$fetched[0]->hasVector('nonexistent'), 'Expected hasVector false for non-existent field');
+    $vecNames = $fetched[0]->vectorNames();
+    assert(in_array('v', $vecNames), 'Expected v in vectorNames');
+    $fieldNames = $fetched[0]->fieldNames();
+    assert(!in_array('v', $fieldNames), 'Expected v NOT in fieldNames');
+    echo "hasVector/vectorNames/fieldNames with FP64 OK\n";
+
+    // Test 11: Create HNSW index on FP64 field and query
+    $c->createHnswIndex('v', metricType: ZVec::METRIC_COSINE, m: 16, efConstruction: 200);
+    $c->optimize();
+    $results = $c->queryFp64('v', [0.1, 0.2, 0.3, 0.4], topk: 3);
+    assert(count($results) === 3, 'Expected 3 results');
+    assert($results[0]->getPk() === 'doc1', 'Expected doc1 as top result');
+    echo "HNSW index on FP64 field OK\n";
+
+    // Test 12: queryFp64 with HNSW params
+    $results = $c->queryFp64('v', [0.1, 0.2, 0.3, 0.4], topk: 3,
+        queryParamType: ZVec::QUERY_PARAM_HNSW, hnswEf: 100);
+    assert(count($results) === 3, 'Expected 3 results');
+    echo "FP64 query with HNSW params OK\n";
+
+    // Test 13: Create Flat index on FP64 field
+    $c->dropIndex('v');
+    $c->createFlatIndex('v', metricType: ZVec::METRIC_COSINE);
+    $c->optimize();
+    $results = $c->queryFp64('v', [0.1, 0.2, 0.3, 0.4], topk: 3,
+        queryParamType: ZVec::QUERY_PARAM_FLAT);
+    assert(count($results) === 3, 'Expected 3 results');
+    assert($results[0]->getPk() === 'doc1', 'Expected doc1 as top result');
+    echo "Flat index on FP64 field OK\n";
+
+    echo "ALL TESTS PASSED\n";
+} finally {
+    exec("rm -rf " . escapeshellarg($path));
+}
+?>


### PR DESCRIPTION
Implements #13 - FieldSchema introspection API.

## Changes

### FFI Layer
- Added  struct and 15 new C functions for field metadata introspection
-  retrieves field schema by field name
- Getters: name, data_type, dimension, nullable, index_type, element_data_type, element_data_size
- Query helpers: is_vector_field, is_dense_vector, is_sparse_vector, is_array_type, has_invert_index, has_index

### PHP Layer
- New  class with 13 typed getter methods
- New  method
- FFI cdef declarations for all new functions

### Tests
-  - comprehensive test covering:
  - All scalar/vector/array field types
  - Index introspection (HNSW, Invert)
  - Element data type/size for arrays
  - Error cases: nonexistent field, closed collection

## Testing
- All 70 tests pass (68 PASS + 2 XFAIL)
- No regressions