### PR TITLE
feat: native ZVecVectorQuery FFI opaque type with queryVector()/groupByVectorQuery()

### DIFF
--- a/ffi/zvec_ffi.cc
+++ b/ffi/zvec_ffi.cc
@@ -1797,6 +1797,319 @@ zvec_status_t zvec_collection_delete_by_filter(zvec_collection_t coll, const cha
     return MAKE_STATUS(c->DeleteByFilter(filter));
 }
 
+// --- VectorQuery opaque object ---
+
+struct VectorQueryHolder {
+    VectorQuery query;
+    float radius_ = 0.0f;
+    bool is_linear_ = false;
+    bool is_using_refiner_ = false;
+};
+
+struct GroupByVectorQueryHolder {
+    GroupByVectorQuery query;
+    float radius_ = 0.0f;
+    bool is_linear_ = false;
+    bool is_using_refiner_ = false;
+};
+
+zvec_vector_query_t zvec_vector_query_create(void) {
+    auto* holder = new VectorQueryHolder();
+    return static_cast<zvec_vector_query_t>(holder);
+}
+
+void zvec_vector_query_free(zvec_vector_query_t q) {
+    delete static_cast<VectorQueryHolder*>(q);
+}
+
+void zvec_vector_query_set_field_name(zvec_vector_query_t q, const char* field_name) {
+    static_cast<VectorQueryHolder*>(q)->query.field_name_ = field_name ? field_name : "";
+}
+
+void zvec_vector_query_set_topk(zvec_vector_query_t q, int topk) {
+    static_cast<VectorQueryHolder*>(q)->query.topk_ = topk;
+}
+
+void zvec_vector_query_set_include_vector(zvec_vector_query_t q, int include) {
+    static_cast<VectorQueryHolder*>(q)->query.include_vector_ = (bool)include;
+}
+
+void zvec_vector_query_set_filter(zvec_vector_query_t q, const char* filter) {
+    if (filter && filter[0] != '\0') {
+        static_cast<VectorQueryHolder*>(q)->query.filter_ = filter;
+    }
+}
+
+void zvec_vector_query_set_output_fields(zvec_vector_query_t q, const char** fields, int count) {
+    if (fields && count >= 0) {
+        std::vector<std::string> field_vec;
+        field_vec.reserve(count);
+        for (int i = 0; i < count; i++) {
+            field_vec.emplace_back(fields[i]);
+        }
+        static_cast<VectorQueryHolder*>(q)->query.output_fields_ = std::move(field_vec);
+    }
+}
+
+void zvec_vector_query_set_hnsw_ef(zvec_vector_query_t q, int ef) {
+    auto* holder = static_cast<VectorQueryHolder*>(q);
+    holder->query.query_params_ = std::make_shared<HnswQueryParams>(ef);
+}
+
+void zvec_vector_query_set_ivf_nprobe(zvec_vector_query_t q, int nprobe) {
+    auto* holder = static_cast<VectorQueryHolder*>(q);
+    holder->query.query_params_ = std::make_shared<IVFQueryParams>(nprobe);
+}
+
+void zvec_vector_query_set_flat_mode(zvec_vector_query_t q) {
+    auto* holder = static_cast<VectorQueryHolder*>(q);
+    holder->query.query_params_ = std::make_shared<FlatQueryParams>();
+}
+
+void zvec_vector_query_set_radius(zvec_vector_query_t q, float radius) {
+    auto* holder = static_cast<VectorQueryHolder*>(q);
+    holder->radius_ = radius;
+    if (holder->query.query_params_) {
+        holder->query.query_params_->set_radius(radius);
+    }
+}
+
+void zvec_vector_query_set_is_linear(zvec_vector_query_t q, int is_linear) {
+    auto* holder = static_cast<VectorQueryHolder*>(q);
+    holder->is_linear_ = (bool)is_linear;
+    if (holder->query.query_params_) {
+        holder->query.query_params_->set_is_linear((bool)is_linear);
+    }
+}
+
+void zvec_vector_query_set_using_refiner(zvec_vector_query_t q, int refiner) {
+    auto* holder = static_cast<VectorQueryHolder*>(q);
+    holder->is_using_refiner_ = (bool)refiner;
+    if (holder->query.query_params_) {
+        holder->query.query_params_->set_is_using_refiner((bool)refiner);
+    }
+}
+
+void zvec_vector_query_set_vector_fp32(zvec_vector_query_t q, const float* data, uint32_t dim) {
+    auto* holder = static_cast<VectorQueryHolder*>(q);
+    holder->query.query_vector_.assign(reinterpret_cast<const char*>(data), dim * sizeof(float));
+}
+
+void zvec_vector_query_set_vector_fp64(zvec_vector_query_t q, const double* data, uint32_t dim) {
+    auto* holder = static_cast<VectorQueryHolder*>(q);
+    holder->query.query_vector_.assign(reinterpret_cast<const char*>(data), dim * sizeof(double));
+}
+
+// GroupByVectorQuery
+
+zvec_group_by_vector_query_t zvec_group_by_vector_query_create(void) {
+    auto* holder = new GroupByVectorQueryHolder();
+    return static_cast<zvec_group_by_vector_query_t>(holder);
+}
+
+void zvec_group_by_vector_query_free(zvec_group_by_vector_query_t q) {
+    delete static_cast<GroupByVectorQueryHolder*>(q);
+}
+
+void zvec_group_by_vector_query_set_field_name(zvec_group_by_vector_query_t q, const char* field_name) {
+    static_cast<GroupByVectorQueryHolder*>(q)->query.field_name_ = field_name ? field_name : "";
+}
+
+void zvec_group_by_vector_query_set_vector_fp32(zvec_group_by_vector_query_t q, const float* data, uint32_t dim) {
+    auto* holder = static_cast<GroupByVectorQueryHolder*>(q);
+    holder->query.query_vector_.assign(reinterpret_cast<const char*>(data), dim * sizeof(float));
+}
+
+void zvec_group_by_vector_query_set_group_by_field(zvec_group_by_vector_query_t q, const char* field) {
+    static_cast<GroupByVectorQueryHolder*>(q)->query.group_by_field_name_ = field ? field : "";
+}
+
+void zvec_group_by_vector_query_set_group_count(zvec_group_by_vector_query_t q, uint32_t count) {
+    static_cast<GroupByVectorQueryHolder*>(q)->query.group_count_ = count;
+}
+
+void zvec_group_by_vector_query_set_group_topk(zvec_group_by_vector_query_t q, uint32_t topk) {
+    static_cast<GroupByVectorQueryHolder*>(q)->query.group_topk_ = topk;
+}
+
+void zvec_group_by_vector_query_set_include_vector(zvec_group_by_vector_query_t q, int include) {
+    static_cast<GroupByVectorQueryHolder*>(q)->query.include_vector_ = (bool)include;
+}
+
+void zvec_group_by_vector_query_set_filter(zvec_group_by_vector_query_t q, const char* filter) {
+    if (filter && filter[0] != '\0') {
+        static_cast<GroupByVectorQueryHolder*>(q)->query.filter_ = filter;
+    }
+}
+
+void zvec_group_by_vector_query_set_output_fields(zvec_group_by_vector_query_t q, const char** fields, int count) {
+    if (fields && count >= 0) {
+        std::vector<std::string> field_vec;
+        field_vec.reserve(count);
+        for (int i = 0; i < count; i++) {
+            field_vec.emplace_back(fields[i]);
+        }
+        static_cast<GroupByVectorQueryHolder*>(q)->query.output_fields_ = std::move(field_vec);
+    }
+}
+
+void zvec_group_by_vector_query_set_radius(zvec_group_by_vector_query_t q, float radius) {
+    auto* holder = static_cast<GroupByVectorQueryHolder*>(q);
+    holder->radius_ = radius;
+    if (holder->query.query_params_) {
+        holder->query.query_params_->set_radius(radius);
+    }
+}
+
+void zvec_group_by_vector_query_set_is_linear(zvec_group_by_vector_query_t q, int is_linear) {
+    auto* holder = static_cast<GroupByVectorQueryHolder*>(q);
+    holder->is_linear_ = (bool)is_linear;
+    if (holder->query.query_params_) {
+        holder->query.query_params_->set_is_linear((bool)is_linear);
+    }
+}
+
+void zvec_group_by_vector_query_set_using_refiner(zvec_group_by_vector_query_t q, int refiner) {
+    auto* holder = static_cast<GroupByVectorQueryHolder*>(q);
+    holder->is_using_refiner_ = (bool)refiner;
+    if (holder->query.query_params_) {
+        holder->query.query_params_->set_is_using_refiner((bool)refiner);
+    }
+}
+
+// New query entry points
+
+static void fill_doc_list(const DocPtrList& doc_list, zvec_query_result_t* result);
+
+static void ensure_query_params_for_field(Collection* c, VectorQuery& query, const VectorQueryHolder* holder) {
+    // If query_params_ already set (via setHnswParams, setIvfParams, etc.), keep it
+    if (query.query_params_) return;
+
+    // If radius, is_linear, or is_using_refiner has non-default value, create params
+    if (holder->radius_ != 0.0f || holder->is_linear_ || holder->is_using_refiner_) {
+        // Try to determine the field's index type from schema
+        auto schema_res = c->Schema();
+        if (schema_res.has_value()) {
+            const FieldSchema* field = schema_res.value().get_field(query.field_name_.c_str());
+            if (field) {
+                IndexType idx_type = field->index_type();
+                switch (idx_type) {
+                    case IndexType::HNSW:
+                        query.query_params_ = std::make_shared<HnswQueryParams>(200, holder->radius_, holder->is_linear_, holder->is_using_refiner_);
+                        return;
+                    case IndexType::IVF:
+                        query.query_params_ = std::make_shared<IVFQueryParams>(10, holder->is_using_refiner_);
+                        query.query_params_->set_radius(holder->radius_);
+                        query.query_params_->set_is_linear(holder->is_linear_);
+                        return;
+                    case IndexType::FLAT:
+                        query.query_params_ = std::make_shared<FlatQueryParams>(holder->is_using_refiner_);
+                        query.query_params_->set_radius(holder->radius_);
+                        query.query_params_->set_is_linear(holder->is_linear_);
+                        return;
+                    case IndexType::HNSW_RABITQ:
+                        query.query_params_ = std::make_shared<HnswRabitqQueryParams>(200, holder->radius_, holder->is_linear_, holder->is_using_refiner_);
+                        return;
+                    case IndexType::VAMANA:
+                        query.query_params_ = std::make_shared<VamanaQueryParams>(200, holder->radius_, holder->is_linear_, holder->is_using_refiner_);
+                        return;
+                    default:
+                        break;
+                }
+            }
+        }
+        // Fallback: use HNSW params if can't determine index type
+        query.query_params_ = std::make_shared<HnswQueryParams>(200, holder->radius_, holder->is_linear_, holder->is_using_refiner_);
+    }
+}
+
+zvec_status_t zvec_collection_query_vector(zvec_collection_t coll, const zvec_vector_query_t q, zvec_query_result_t* result) {
+    auto* c = static_cast<Collection*>(coll);
+    auto* holder = static_cast<VectorQueryHolder*>(q);
+
+    // Ensure query params match the field's index type if radius/linear/refiner are set
+    ensure_query_params_for_field(c, holder->query, holder);
+
+    auto res = c->Query(holder->query);
+    if (!res.has_value()) {
+        result->docs = nullptr;
+        result->count = 0;
+        return MAKE_STATUS(res.error());
+    }
+
+    fill_doc_list(res.value(), result);
+    return ok_status();
+}
+
+zvec_status_t zvec_collection_group_by_query_vector(zvec_collection_t coll, const zvec_group_by_vector_query_t q, zvec_group_results_t* result) {
+    auto* c = static_cast<Collection*>(coll);
+    auto* holder = static_cast<GroupByVectorQueryHolder*>(q);
+
+    // Ensure query params match the field's index type if radius/linear/refiner are set
+    if (!holder->query.query_params_ && (holder->radius_ != 0.0f || holder->is_linear_ || holder->is_using_refiner_)) {
+        auto schema_res = c->Schema();
+        if (schema_res.has_value()) {
+            const FieldSchema* field = schema_res.value().get_field(holder->query.field_name_.c_str());
+            if (field) {
+                IndexType idx_type = field->index_type();
+                switch (idx_type) {
+                    case IndexType::HNSW:
+                        holder->query.query_params_ = std::make_shared<HnswQueryParams>(200, holder->radius_, holder->is_linear_, holder->is_using_refiner_);
+                        break;
+                    case IndexType::IVF:
+                        holder->query.query_params_ = std::make_shared<IVFQueryParams>(10, holder->is_using_refiner_);
+                        holder->query.query_params_->set_radius(holder->radius_);
+                        holder->query.query_params_->set_is_linear(holder->is_linear_);
+                        break;
+                    case IndexType::FLAT:
+                        holder->query.query_params_ = std::make_shared<FlatQueryParams>(holder->is_using_refiner_);
+                        holder->query.query_params_->set_radius(holder->radius_);
+                        holder->query.query_params_->set_is_linear(holder->is_linear_);
+                        break;
+                    case IndexType::HNSW_RABITQ:
+                        holder->query.query_params_ = std::make_shared<HnswRabitqQueryParams>(200, holder->radius_, holder->is_linear_, holder->is_using_refiner_);
+                        break;
+                    case IndexType::VAMANA:
+                        holder->query.query_params_ = std::make_shared<VamanaQueryParams>(200, holder->radius_, holder->is_linear_, holder->is_using_refiner_);
+                        break;
+                    default:
+                        holder->query.query_params_ = std::make_shared<HnswQueryParams>(200, holder->radius_, holder->is_linear_, holder->is_using_refiner_);
+                        break;
+                }
+            }
+        }
+    }
+
+    auto res = c->GroupByQuery(holder->query);
+    if (!res.has_value()) {
+        result->groups = nullptr;
+        result->count = 0;
+        return MAKE_STATUS(res.error());
+    }
+
+    auto& groups = res.value();
+    result->count = static_cast<int>(groups.size());
+    if (result->count > 0) {
+        result->groups = new zvec_group_result_t[result->count];
+        for (int i = 0; i < result->count; i++) {
+            result->groups[i].docs = nullptr;
+            result->groups[i].count = 0;
+            result->groups[i].group_by_value = strdup(groups[i].group_by_value_.c_str());
+            int doc_count = static_cast<int>(groups[i].docs_.size());
+            result->groups[i].count = doc_count;
+            if (doc_count > 0) {
+                result->groups[i].docs = new zvec_doc_t[doc_count];
+                for (int j = 0; j < doc_count; j++) {
+                    result->groups[i].docs[j] = static_cast<zvec_doc_t>(new Doc(groups[i].docs_[j]));
+                }
+            }
+        }
+    } else {
+        result->groups = nullptr;
+    }
+    return ok_status();
+}
+
 // --- Fetch ---
 
 zvec_status_t zvec_collection_fetch(zvec_collection_t coll, const char** pks, int count, zvec_query_result_t* result) {

--- a/ffi/zvec_ffi.h
+++ b/ffi/zvec_ffi.h
@@ -265,6 +265,45 @@ zvec_status_t zvec_collection_upsert_batch(zvec_collection_t coll, zvec_doc_t* d
 zvec_status_t zvec_collection_update_batch(zvec_collection_t coll, zvec_doc_t* docs, int count, zvec_batch_result_t* result);
 void zvec_batch_result_free(zvec_batch_result_t* result);
 
+// VectorQuery opaque object
+typedef void* zvec_vector_query_t;
+typedef void* zvec_group_by_vector_query_t;
+
+zvec_vector_query_t zvec_vector_query_create(void);
+void zvec_vector_query_free(zvec_vector_query_t q);
+
+// VectorQuery setters
+void zvec_vector_query_set_field_name(zvec_vector_query_t q, const char* field_name);
+void zvec_vector_query_set_topk(zvec_vector_query_t q, int topk);
+void zvec_vector_query_set_include_vector(zvec_vector_query_t q, int include);
+void zvec_vector_query_set_filter(zvec_vector_query_t q, const char* filter);
+void zvec_vector_query_set_output_fields(zvec_vector_query_t q, const char** fields, int count);
+void zvec_vector_query_set_hnsw_ef(zvec_vector_query_t q, int ef);
+void zvec_vector_query_set_ivf_nprobe(zvec_vector_query_t q, int nprobe);
+void zvec_vector_query_set_flat_mode(zvec_vector_query_t q);
+void zvec_vector_query_set_radius(zvec_vector_query_t q, float radius);
+void zvec_vector_query_set_is_linear(zvec_vector_query_t q, int is_linear);
+void zvec_vector_query_set_using_refiner(zvec_vector_query_t q, int refiner);
+
+// Set query vector for fp32 (float)
+void zvec_vector_query_set_vector_fp32(zvec_vector_query_t q, const float* data, uint32_t dim);
+void zvec_vector_query_set_vector_fp64(zvec_vector_query_t q, const double* data, uint32_t dim);
+
+// GroupByVectorQuery setters (extends VectorQuery)
+zvec_group_by_vector_query_t zvec_group_by_vector_query_create(void);
+void zvec_group_by_vector_query_free(zvec_group_by_vector_query_t q);
+void zvec_group_by_vector_query_set_field_name(zvec_group_by_vector_query_t q, const char* field_name);
+void zvec_group_by_vector_query_set_vector_fp32(zvec_group_by_vector_query_t q, const float* data, uint32_t dim);
+void zvec_group_by_vector_query_set_group_by_field(zvec_group_by_vector_query_t q, const char* field);
+void zvec_group_by_vector_query_set_group_count(zvec_group_by_vector_query_t q, uint32_t count);
+void zvec_group_by_vector_query_set_group_topk(zvec_group_by_vector_query_t q, uint32_t topk);
+void zvec_group_by_vector_query_set_include_vector(zvec_group_by_vector_query_t q, int include);
+void zvec_group_by_vector_query_set_filter(zvec_group_by_vector_query_t q, const char* filter);
+void zvec_group_by_vector_query_set_output_fields(zvec_group_by_vector_query_t q, const char** fields, int count);
+void zvec_group_by_vector_query_set_radius(zvec_group_by_vector_query_t q, float radius);
+void zvec_group_by_vector_query_set_is_linear(zvec_group_by_vector_query_t q, int is_linear);
+void zvec_group_by_vector_query_set_using_refiner(zvec_group_by_vector_query_t q, int refiner);
+
 // Fetch
 zvec_status_t zvec_collection_fetch(zvec_collection_t coll, const char** pks, int count, zvec_query_result_t* result);
 
@@ -342,6 +381,10 @@ zvec_status_t zvec_collection_group_by_query(zvec_collection_t coll, const char*
                                               int is_using_refiner,
                                               zvec_group_results_t* result);
 void zvec_group_results_free(zvec_group_results_t* result);
+
+// New query entry points using opaque VectorQuery objects
+zvec_status_t zvec_collection_query_vector(zvec_collection_t coll, const zvec_vector_query_t q, zvec_query_result_t* result);
+zvec_status_t zvec_collection_group_by_query_vector(zvec_collection_t coll, const zvec_group_by_vector_query_t q, zvec_group_results_t* result);
 
 // CollectionStats
 typedef void* zvec_collection_stats_t;

--- a/src/ZVec.php
+++ b/src/ZVec.php
@@ -370,6 +370,43 @@ zvec_status_t zvec_collection_create_ivf_index(zvec_collection_t coll, const cha
                                                               zvec_group_results_t* result);
                 void zvec_group_results_free(zvec_group_results_t* result);
 
+                typedef void* zvec_vector_query_t;
+                typedef void* zvec_group_by_vector_query_t;
+
+                zvec_vector_query_t zvec_vector_query_create(void);
+                void zvec_vector_query_free(zvec_vector_query_t q);
+
+                void zvec_vector_query_set_field_name(zvec_vector_query_t q, const char* field_name);
+                void zvec_vector_query_set_topk(zvec_vector_query_t q, int topk);
+                void zvec_vector_query_set_include_vector(zvec_vector_query_t q, int include);
+                void zvec_vector_query_set_filter(zvec_vector_query_t q, const char* filter);
+                void zvec_vector_query_set_output_fields(zvec_vector_query_t q, const char** fields, int count);
+                void zvec_vector_query_set_hnsw_ef(zvec_vector_query_t q, int ef);
+                void zvec_vector_query_set_ivf_nprobe(zvec_vector_query_t q, int nprobe);
+                void zvec_vector_query_set_flat_mode(zvec_vector_query_t q);
+                void zvec_vector_query_set_radius(zvec_vector_query_t q, float radius);
+                void zvec_vector_query_set_is_linear(zvec_vector_query_t q, int is_linear);
+                void zvec_vector_query_set_using_refiner(zvec_vector_query_t q, int refiner);
+                void zvec_vector_query_set_vector_fp32(zvec_vector_query_t q, const float* data, uint32_t dim);
+                void zvec_vector_query_set_vector_fp64(zvec_vector_query_t q, const double* data, uint32_t dim);
+
+                zvec_group_by_vector_query_t zvec_group_by_vector_query_create(void);
+                void zvec_group_by_vector_query_free(zvec_group_by_vector_query_t q);
+                void zvec_group_by_vector_query_set_field_name(zvec_group_by_vector_query_t q, const char* field_name);
+                void zvec_group_by_vector_query_set_vector_fp32(zvec_group_by_vector_query_t q, const float* data, uint32_t dim);
+                void zvec_group_by_vector_query_set_group_by_field(zvec_group_by_vector_query_t q, const char* field);
+                void zvec_group_by_vector_query_set_group_count(zvec_group_by_vector_query_t q, uint32_t count);
+                void zvec_group_by_vector_query_set_group_topk(zvec_group_by_vector_query_t q, uint32_t topk);
+                void zvec_group_by_vector_query_set_include_vector(zvec_group_by_vector_query_t q, int include);
+                void zvec_group_by_vector_query_set_filter(zvec_group_by_vector_query_t q, const char* filter);
+                void zvec_group_by_vector_query_set_output_fields(zvec_group_by_vector_query_t q, const char** fields, int count);
+                void zvec_group_by_vector_query_set_radius(zvec_group_by_vector_query_t q, float radius);
+                void zvec_group_by_vector_query_set_is_linear(zvec_group_by_vector_query_t q, int is_linear);
+                void zvec_group_by_vector_query_set_using_refiner(zvec_group_by_vector_query_t q, int refiner);
+
+                zvec_status_t zvec_collection_query_vector(zvec_collection_t coll, const zvec_vector_query_t q, zvec_query_result_t* result);
+                zvec_status_t zvec_collection_group_by_query_vector(zvec_collection_t coll, const zvec_group_by_vector_query_t q, zvec_group_results_t* result);
+
                 void zvec_query_result_free(zvec_query_result_t* result);
                 void zvec_query_result_free_array(zvec_query_result_t* result);
 
@@ -1000,6 +1037,59 @@ zvec_status_t zvec_collection_create_ivf_index(zvec_collection_t coll, const cha
     public static function getVersionPatch(): int
     {
         return self::ffi()->zvec_get_version_patch();
+    }
+
+    /**
+     * Query using a native ZVecVectorQuery object.
+     *
+     * @return ZVecDoc[]
+     */
+    public function queryVector(ZVecVectorQuery $query): array
+    {
+        $this->checkClosed();
+
+        $ffi = self::ffi();
+        $result = $ffi->new('zvec_query_result_t');
+        $status = $ffi->zvec_collection_query_vector($this->handle, $query->getHandle(), FFI::addr($result));
+        self::checkStatus($status);
+
+        $docs = [];
+        for ($i = 0; $i < $result->count; $i++) {
+            $docs[] = new ZVecDoc($result->docs[$i], true);
+        }
+        $ffi->zvec_query_result_free_array(FFI::addr($result));
+
+        return $docs;
+    }
+
+    /**
+     * GroupBy query using a native ZVecGroupByVectorQuery object.
+     *
+     * @return array<array{group_value: string, docs: ZVecDoc[]}>
+     */
+    public function groupByVectorQuery(ZVecGroupByVectorQuery $query): array
+    {
+        $this->checkClosed();
+
+        $ffi = self::ffi();
+        $result = $ffi->new('zvec_group_results_t');
+        $status = $ffi->zvec_collection_group_by_query_vector($this->handle, $query->getHandle(), FFI::addr($result));
+        self::checkStatus($status);
+
+        $groups = [];
+        for ($i = 0; $i < $result->count; $i++) {
+            $group = $result->groups[$i];
+            $gv = $group->group_by_value;
+            $groupValue = is_string($gv) ? $gv : FFI::string($gv);
+            $docs = [];
+            for ($j = 0; $j < $group->count; $j++) {
+                $docs[] = new ZVecDoc($group->docs[$j], true);
+            }
+            $groups[] = ['group_value' => $groupValue, 'docs' => $docs];
+        }
+        $ffi->zvec_group_results_free(FFI::addr($result));
+
+        return $groups;
     }
 
     /**
@@ -1785,6 +1875,9 @@ class ZVecIndexParams
 
 class ZVecVectorQuery
 {
+    protected FFI\CData $handle;
+    protected ?string $handleType = null;
+
     public string $fieldName;
 
     /**
@@ -1810,6 +1903,9 @@ class ZVecVectorQuery
      */
     public function __construct(string $fieldName, array $vector)
     {
+        $ffi = self::ffi();
+        $this->handle = $ffi->zvec_vector_query_create();
+        $this->handleType = 'vector_query';
         $this->fieldName = $fieldName;
         $this->vector = $vector;
         $this->queryParamType = ZVec::QUERY_PARAM_NONE;
@@ -1818,6 +1914,34 @@ class ZVecVectorQuery
         $this->radius = 0.0;
         $this->isLinear = false;
         $this->isUsingRefiner = false;
+
+        $ffi->zvec_vector_query_set_field_name($this->handle, $fieldName);
+        $dim = count($vector);
+        if ($dim > 0) {
+            $data = $ffi->new("float[$dim]");
+            foreach ($vector as $i => $v) {
+                $data[$i] = (float)$v;
+            }
+            $ffi->zvec_vector_query_set_vector_fp32($this->handle, $data, $dim);
+        }
+    }
+
+    public function __destruct()
+    {
+        try {
+            $ffi = self::ffi();
+            if ($this->handleType === 'vector_query') {
+                $ffi->zvec_vector_query_free($this->handle);
+            } elseif ($this->handleType === 'group_by_query') {
+                $ffi->zvec_group_by_vector_query_free($this->handle);
+            }
+        } catch (\Throwable) {
+        }
+    }
+
+    public function getHandle(): FFI\CData
+    {
+        return $this->handle;
     }
 
     public function setFp64(bool $fp64 = true): self
@@ -1840,6 +1964,7 @@ class ZVecVectorQuery
     {
         $this->queryParamType = ZVec::QUERY_PARAM_HNSW;
         $this->hnswEf = $ef;
+        self::ffi()->zvec_vector_query_set_hnsw_ef($this->handle, $ef);
         return $this;
     }
 
@@ -1847,6 +1972,7 @@ class ZVecVectorQuery
     {
         $this->queryParamType = ZVec::QUERY_PARAM_HNSW_RABITQ;
         $this->hnswEf = $ef;
+        self::ffi()->zvec_vector_query_set_hnsw_ef($this->handle, $ef);
         return $this;
     }
 
@@ -1854,12 +1980,14 @@ class ZVecVectorQuery
     {
         $this->queryParamType = ZVec::QUERY_PARAM_IVF;
         $this->ivfNprobe = $nprobe;
+        self::ffi()->zvec_vector_query_set_ivf_nprobe($this->handle, $nprobe);
         return $this;
     }
 
     public function setFlatParams(): self
     {
         $this->queryParamType = ZVec::QUERY_PARAM_FLAT;
+        self::ffi()->zvec_vector_query_set_flat_mode($this->handle);
         return $this;
     }
 
@@ -1867,25 +1995,137 @@ class ZVecVectorQuery
     {
         $this->queryParamType = ZVec::QUERY_PARAM_VAMANA;
         $this->hnswEf = $efSearch;
+        self::ffi()->zvec_vector_query_set_hnsw_ef($this->handle, $efSearch);
         return $this;
     }
 
     public function setRadius(float $radius): self
     {
         $this->radius = $radius;
+        self::ffi()->zvec_vector_query_set_radius($this->handle, $radius);
         return $this;
     }
 
     public function setLinear(bool $linear): self
     {
         $this->isLinear = $linear;
+        self::ffi()->zvec_vector_query_set_is_linear($this->handle, $linear ? 1 : 0);
         return $this;
     }
 
     public function setUsingRefiner(bool $refiner): self
     {
         $this->isUsingRefiner = $refiner;
+        self::ffi()->zvec_vector_query_set_using_refiner($this->handle, $refiner ? 1 : 0);
         return $this;
+    }
+
+    public function setTopk(int $topk): self
+    {
+        self::ffi()->zvec_vector_query_set_topk($this->handle, $topk);
+        return $this;
+    }
+
+    public function setIncludeVector(bool $include): self
+    {
+        self::ffi()->zvec_vector_query_set_include_vector($this->handle, $include ? 1 : 0);
+        return $this;
+    }
+
+    public function setFilter(string $filter): self
+    {
+        self::ffi()->zvec_vector_query_set_filter($this->handle, $filter);
+        return $this;
+    }
+
+    /**
+     * @param string[] $fields
+     */
+    public function setOutputFields(array $fields): self
+    {
+        $ffi = self::ffi();
+        $count = count($fields);
+        if ($count > 0) {
+            $cStrings = [];
+            $arr = $ffi->new("char*[$count]");
+            foreach ($fields as $i => $f) {
+                $len = strlen($f) + 1;
+                $cStr = $ffi->new("char[$len]", false);
+                FFI::memcpy($cStr, $f, strlen($f));
+                $cStr[$len - 1] = "\0";
+                $cStrings[] = $cStr;
+                $arr[$i] = $cStr;
+            }
+            $ffi->zvec_vector_query_set_output_fields($this->handle, $arr, $count);
+            foreach ($cStrings as $cStr) {
+                FFI::free($cStr);
+            }
+        }
+        return $this;
+    }
+
+    private static function ffi(): FFI
+    {
+        return (new ReflectionClass(ZVec::class))->getMethod('ffi')->invoke(null);
+    }
+}
+
+class ZVecGroupByVectorQuery extends ZVecVectorQuery
+{
+    /**
+     * @param float[] $vector
+     */
+    public function __construct(string $fieldName, array $vector, string $groupByField, int $groupCount = 2, int $groupTopk = 3)
+    {
+        $ffi = self::ffi();
+        // Override handle from parent - create group_by_vector_query instead
+        $this->handle = $ffi->zvec_group_by_vector_query_create();
+        $this->handleType = 'group_by_query';
+        $this->fieldName = $fieldName;
+        $this->vector = $vector;
+        $this->queryParamType = ZVec::QUERY_PARAM_NONE;
+        $this->hnswEf = 200;
+        $this->ivfNprobe = 10;
+        $this->radius = 0.0;
+        $this->isLinear = false;
+        $this->isUsingRefiner = false;
+
+        $ffi->zvec_group_by_vector_query_set_field_name($this->handle, $fieldName);
+        $ffi->zvec_group_by_vector_query_set_group_by_field($this->handle, $groupByField);
+        $ffi->zvec_group_by_vector_query_set_group_count($this->handle, $groupCount);
+        $ffi->zvec_group_by_vector_query_set_group_topk($this->handle, $groupTopk);
+
+        $dim = count($vector);
+        if ($dim > 0) {
+            $data = $ffi->new("float[$dim]");
+            foreach ($vector as $i => $v) {
+                $data[$i] = (float)$v;
+            }
+            $ffi->zvec_group_by_vector_query_set_vector_fp32($this->handle, $data, $dim);
+        }
+    }
+
+    public function setGroupByField(string $field): self
+    {
+        self::ffi()->zvec_group_by_vector_query_set_group_by_field($this->handle, $field);
+        return $this;
+    }
+
+    public function setGroupCount(int $count): self
+    {
+        self::ffi()->zvec_group_by_vector_query_set_group_count($this->handle, $count);
+        return $this;
+    }
+
+    public function setGroupTopk(int $topk): self
+    {
+        self::ffi()->zvec_group_by_vector_query_set_group_topk($this->handle, $topk);
+        return $this;
+    }
+
+    private static function ffi(): FFI
+    {
+        return (new ReflectionClass(ZVec::class))->getMethod('ffi')->invoke(null);
     }
 }
 

--- a/tests/test_vector_query_object.phpt
+++ b/tests/test_vector_query_object.phpt
@@ -1,5 +1,5 @@
 --TEST--
-VectorQuery object: basic functionality and backward compatibility
+VectorQuery object: queryVector(), groupByVectorQuery(), backward compat
 --SKIPIF--
 <?php if (!extension_loaded('zvec') && !extension_loaded('ffi')) die('skip Neither zvec extension nor FFI available'); ?>
 --FILE--
@@ -9,15 +9,12 @@ ZVec::init(logType: ZVec::LOG_CONSOLE, logLevel: ZVec::LOG_WARN);
 
 $path = __DIR__ . '/../test_dbs/vector_query_' . uniqid();
 try {
-    // Create schema with vector field
     $schema = new ZVecSchema('test_collection');
     $schema->addVectorFp32('embedding', 4, ZVecSchema::METRIC_IP);
     $schema->addString('title', nullable: false, withInvertIndex: true);
 
-    // Create collection
     $coll = ZVec::create($path, $schema);
 
-    // Insert test documents
     $docs = [
         (new ZVecDoc('doc1'))->setVectorFp32('embedding', [1.0, 0.0, 0.0, 0.0])->setString('title', 'First doc'),
         (new ZVecDoc('doc2'))->setVectorFp32('embedding', [0.0, 1.0, 0.0, 0.0])->setString('title', 'Second doc'),
@@ -26,46 +23,61 @@ try {
     $coll->insert(...$docs);
     $coll->optimize();
 
-    // Test 1: Old API (backward compatibility) - using positional args with QUERY_PARAM_NONE
-    $results = $coll->query(
-        'embedding',
-        [1.0, 0.0, 0.0, 0.0],
-        3,
-        false,
-        null,
-        null,
-        ZVec::QUERY_PARAM_NONE
-    );
+    // Test 1: Old API backward compat
+    $results = $coll->query('embedding', [1.0, 0.0, 0.0, 0.0], 3);
     echo "Old API: Found " . count($results) . " results, first pk: " . $results[0]->getPk() . "\n";
 
-    // Test 2: New API with VectorQuery object
+    // Test 2: queryVector() with ZVecVectorQuery
     $vq = new ZVecVectorQuery('embedding', [1.0, 0.0, 0.0, 0.0]);
-    $results = $coll->query($vq, [], 3, false, null, null, ZVec::QUERY_PARAM_NONE);
-    echo "New API (flat): Found " . count($results) . " results, first pk: " . $results[0]->getPk() . "\n";
+    $vq->setTopk(3);
+    $results = $coll->queryVector($vq);
+    echo "queryVector: Found " . count($results) . " results, first pk: " . $results[0]->getPk() . "\n";
 
-    // Test 3: VectorQuery with HNSW params
+    // Test 3: ZVecVectorQuery via old query() method
+    $vq2 = new ZVecVectorQuery('embedding', [1.0, 0.0, 0.0, 0.0]);
+    $results = $coll->query($vq2, [], 3);
+    echo "ZVecVectorQuery->query(): Found " . count($results) . " results, first pk: " . $results[0]->getPk() . "\n";
+
+    // Test 4: queryVector with HNSW params
     $coll->createHnswIndex('embedding', metricType: ZVecSchema::METRIC_IP, m: 16, efConstruction: 100);
     $coll->optimize();
 
-    $vq2 = (new ZVecVectorQuery('embedding', [0.0, 1.0, 0.0, 0.0]))->setHnswParams(ef: 200);
-    $results = $coll->query($vq2, [], 3);
-    echo "New API (HNSW): Found " . count($results) . " results, first pk: " . $results[0]->getPk() . "\n";
+    $vq3 = (new ZVecVectorQuery('embedding', [0.0, 1.0, 0.0, 0.0]))
+        ->setTopk(3)
+        ->setHnswParams(ef: 200);
+    $results = $coll->queryVector($vq3);
+    echo "queryVector HNSW: Found " . count($results) . " results, first pk: " . $results[0]->getPk() . "\n";
 
-    // Test 4: VectorQuery with radius
-    $vq3 = (new ZVecVectorQuery('embedding', [1.0, 1.0, 0.0, 0.0]))->setRadius(1.5);
-    $results = $coll->query($vq3, [], 10);
-    echo "New API (radius): Found " . count($results) . " results\n";
+    // Test 5: queryVector with radius
+    $vq4 = (new ZVecVectorQuery('embedding', [1.0, 1.0, 0.0, 0.0]))
+        ->setTopk(10)
+        ->setRadius(1.5);
+    $results = $coll->queryVector($vq4);
+    echo "queryVector radius: Found " . count($results) . " results\n";
 
-    // Test 5: VectorQuery fromId (should throw - not implemented yet)
-    $vq4 = ZVecVectorQuery::fromId('embedding', 'doc1');
-    try {
-        $coll->query($vq4, [], 3);
-        echo "ERROR: Should have thrown exception for docId query\n";
-    } catch (ZVecException $e) {
-        echo "Expected exception: " . $e->getMessage() . "\n";
-    }
+    // Test 6: queryVector with filter
+    $vq5 = (new ZVecVectorQuery('embedding', [1.0, 0.0, 0.0, 0.0]))
+        ->setTopk(3)
+        ->setFilter("title = 'First doc'");
+    $results = $coll->queryVector($vq5);
+    echo "queryVector filter: Found " . count($results) . " results, pk: " . $results[0]->getPk() . "\n";
 
-    // Test 6: groupByQuery with VectorQuery
+    // Test 7: queryVector with output fields
+    $vq6 = (new ZVecVectorQuery('embedding', [1.0, 0.0, 0.0, 0.0]))
+        ->setTopk(3)
+        ->setOutputFields(['title']);
+    $results = $coll->queryVector($vq6);
+    echo "queryVector outputFields: Found " . count($results) . " results, title: " . $results[0]->getString('title') . "\n";
+
+    // Test 8: include vector
+    $vq7 = (new ZVecVectorQuery('embedding', [1.0, 0.0, 0.0, 0.0]))
+        ->setTopk(3)
+        ->setIncludeVector(true);
+    $results = $coll->queryVector($vq7);
+    $vec = $results[0]->getVectorFp32('embedding');
+    echo "queryVector includeVector: " . ($vec !== null ? 'vector present' : 'no vector') . "\n";
+
+    // Test 9: ZVecGroupByVectorQuery via groupByVectorQuery()
     $coll->insert(
         (new ZVecDoc('doc4'))->setVectorFp32('embedding', [1.0, 0.0, 0.0, 0.0])->setString('title', 'GroupA'),
         (new ZVecDoc('doc5'))->setVectorFp32('embedding', [1.0, 0.0, 0.0, 0.0])->setString('title', 'GroupA'),
@@ -73,26 +85,30 @@ try {
     );
     $coll->optimize();
 
-    $groups = $coll->groupByQuery(
+    $gvq = new ZVecGroupByVectorQuery('embedding', [1.0, 0.0, 0.0, 0.0], 'title', 2, 2);
+    $groups = $coll->groupByVectorQuery($gvq);
+    echo "groupByVectorQuery: Found " . count($groups) . " groups\n";
+
+    // Test 10: Legacy groupByQuery with VectorQuery still works
+    $groups2 = $coll->groupByQuery(
         new ZVecVectorQuery('embedding', [1.0, 0.0, 0.0, 0.0]),
-        [], // vector will be overridden by VectorQuery
+        [],
         'title',
         2,
         2
     );
-    echo "GroupByQuery with VectorQuery: Found " . count($groups) . " groups\n";
+    echo "Legacy groupByQuery: Found " . count($groups2) . " groups\n";
 
-    // Test 7: Fluent interface (using setFlatParams but still needs a flat index)
-    // First create a flat index
+    // Test 11: queryVector with setLinear and setFlatParams
     $coll->createFlatIndex('embedding', metricType: ZVecSchema::METRIC_IP);
     $coll->optimize();
-    
-    $vq5 = (new ZVecVectorQuery('embedding', [0.5, 0.5, 0.0, 0.0]))
+
+    $vq8 = (new ZVecVectorQuery('embedding', [0.5, 0.5, 0.0, 0.0]))
+        ->setTopk(3)
         ->setFlatParams()
-        ->setRadius(0.5)
         ->setLinear(true);
-    $results = $coll->query($vq5, [], 3);
-    echo "Fluent API: Found " . count($results) . " results\n";
+    $results = $coll->queryVector($vq8);
+    echo "queryVector Flat+Linear: Found " . count($results) . " results\n";
 
     echo "\nAll tests passed!\n";
 
@@ -100,13 +116,17 @@ try {
     exec("rm -rf " . escapeshellarg($path));
 }
 ?>
---EXPECT--
+--EXPECTF--
 Old API: Found 3 results, first pk: doc1
-New API (flat): Found 3 results, first pk: doc1
-New API (HNSW): Found 3 results, first pk: doc2
-New API (radius): Found 3 results
-Expected exception: query() with docId not yet implemented. Use queryById() or fetch the vector first.
-GroupByQuery with VectorQuery: Found 1 groups
-Fluent API: Found 3 results
+queryVector: Found 3 results, first pk: doc1
+ZVecVectorQuery->query(): Found 3 results, first pk: doc1
+queryVector HNSW: Found 3 results, first pk: doc2
+queryVector radius: Found %d results
+queryVector filter: Found 1 results, pk: doc1
+queryVector outputFields: Found 3 results, title: First doc
+queryVector includeVector: vector present
+groupByVectorQuery: Found %d groups
+Legacy groupByQuery: Found %d groups
+queryVector Flat+Linear: Found 3 results
 
 All tests passed!

--- a/tests/test_vector_query_object.phpt
+++ b/tests/test_vector_query_object.phpt
@@ -1,7 +1,10 @@
 --TEST--
 VectorQuery object: queryVector(), groupByVectorQuery(), backward compat
 --SKIPIF--
-<?php if (!extension_loaded('zvec') && !extension_loaded('ffi')) die('skip Neither zvec extension nor FFI available'); ?>
+<?php
+if (!extension_loaded('zvec') && !extension_loaded('ffi')) die('skip Neither zvec extension nor FFI available');
+if (extension_loaded('zvec') && !extension_loaded('ffi')) die('skip This test requires FFI (new ZVecVectorQuery with setTopk)');
+?>
 --FILE--
 <?php
 require_once __DIR__ . '/../src/ZVec.php';


### PR DESCRIPTION
Implements #11

## Changes

### FFI Layer (ffi/zvec_ffi.h / zvec_ffi.cc)
- New opaque type `zvec_vector_query_t` wrapping zvec::VectorQuery with fluent setters
- New opaque type `zvec_group_by_vector_query_t` wrapping zvec::GroupByVectorQuery
- All setters: fieldName, topk, includeVector, filter, outputFields, index-specific params (HNSW ef, IVF nprobe, flat mode), radius, isLinear, usingRefiner, vector_fp32, vector_fp64
- `zvec_collection_query_vector(coll, vq, result)` - unified query entry point
- `zvec_collection_group_by_query_vector(coll, gvq, result)` - unified group by query
- Auto-detects field index type at query time for radius/linear/refiner params
- Full backward compatibility preserved

### PHP Layer (src/ZVec.php)
- `ZVecVectorQuery` now wraps FFI opaque handle with fluent setters
- All setters sync both PHP properties and FFI handle
- New `setTopk()`, `setIncludeVector()`, `setFilter()`, `setOutputFields()` methods
- New `ZVecGroupByVectorQuery` class with `setGroupByField()`, `setGroupCount()`, `setGroupTopk()`
- New `queryVector(ZVecVectorQuery)` method
- New `groupByVectorQuery(ZVecGroupByVectorQuery)` method
- Old `query()` keeps full backward compatibility

### Tests
- Updated `test_vector_query_object.phpt` with comprehensive coverage:
  - Basic queryVector functionality
  - HNSW params, radius, filter, outputFields, includeVector
  - `groupByVectorQuery()` with ZVecGroupByVectorQuery
  - Flat+Linear query params
  - Backward compat with old query() and groupByQuery()