### PR TITLE
feat: add ZVecCollectionOptions class with createWith/openWith

### DIFF
--- a/php-ext/config.m4
+++ b/php-ext/config.m4
@@ -19,6 +19,7 @@ if test "$PHP_ZVEC" != "no"; then
 
   ZVEC_SOURCES="zvec.cc \
     zvec_exception.cc \
+    zvec_collection_options.cc \
     zvec_schema.cc \
     zvec_doc.cc \
     zvec_vector_query.cc \

--- a/php-ext/php_zvec.h
+++ b/php-ext/php_zvec.h
@@ -18,6 +18,7 @@ PHP_MSHUTDOWN_FUNCTION(zvec);
 PHP_MINFO_FUNCTION(zvec);
 
 void zvec_register_exception(INIT_FUNC_ARGS);
+void zvec_register_collection_options(INIT_FUNC_ARGS);
 void zvec_register_schema(INIT_FUNC_ARGS);
 void zvec_register_doc(INIT_FUNC_ARGS);
 void zvec_register_vector_query(INIT_FUNC_ARGS);
@@ -31,6 +32,7 @@ void zvec_register_openai_embedding(INIT_FUNC_ARGS);
 void zvec_register_qwen_embedding(INIT_FUNC_ARGS);
 
 extern zend_class_entry *zvec_exception_ce;
+extern zend_class_entry *zvec_collection_options_ce;
 extern zend_class_entry *zvec_schema_ce;
 extern zend_class_entry *zvec_doc_ce;
 extern zend_class_entry *zvec_vector_query_ce;

--- a/php-ext/zvec.cc
+++ b/php-ext/zvec.cc
@@ -6,6 +6,7 @@ extern "C" {
 
 PHP_MINIT_FUNCTION(zvec) {
     zvec_register_exception(INIT_FUNC_ARGS_PASSTHRU);
+    zvec_register_collection_options(INIT_FUNC_ARGS_PASSTHRU);
     zvec_register_schema(INIT_FUNC_ARGS_PASSTHRU);
     zvec_register_doc(INIT_FUNC_ARGS_PASSTHRU);
     zvec_register_vector_query(INIT_FUNC_ARGS_PASSTHRU);

--- a/php-ext/zvec_collection.cc
+++ b/php-ext/zvec_collection.cc
@@ -1496,7 +1496,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_zvec_open_with, 0, 2, ZVec, 0)
     ZEND_ARG_OBJ_INFO(0, options, ZVecCollectionOptions, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_zvec_get_options, 0, 0, ZVecCollectionOptions, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_zvec_get_options, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_zvec_void, 0, 0, 0)

--- a/php-ext/zvec_collection.cc
+++ b/php-ext/zvec_collection.cc
@@ -1,4 +1,5 @@
 #include "zvec_exception.h"
+#include "zvec_collection_options.h"
 #include "zvec_vector_query.h"
 #include "zvec_reranker.h"
 
@@ -195,6 +196,99 @@ PHP_METHOD(ZVec, open) {
     auto *intern = Z_ZVEC_COLLECTION_P(return_value);
     intern->collection = std::move(result).value();
     intern->closed = false;
+}
+
+PHP_METHOD(ZVec, createWith) {
+    char *path; size_t path_len;
+    zval *schema_zv, *opts_zv;
+    zend_bool read_only, enable_mmap;
+    zend_long max_buffer_size;
+
+    ZEND_PARSE_PARAMETERS_START(3, 3)
+        Z_PARAM_STRING(path, path_len)
+        Z_PARAM_OBJECT_OF_CLASS(schema_zv, zvec_schema_ce)
+        Z_PARAM_OBJECT_OF_CLASS(opts_zv, zvec_collection_options_ce)
+    ZEND_PARSE_PARAMETERS_END();
+
+    {
+        zval *prop = zend_read_property(zvec_collection_options_ce, Z_OBJ_P(opts_zv), "readOnly", sizeof("readOnly") - 1, 0, nullptr);
+        read_only = prop ? zval_is_true(prop) : 0;
+    }
+    {
+        zval *prop = zend_read_property(zvec_collection_options_ce, Z_OBJ_P(opts_zv), "enableMmap", sizeof("enableMmap") - 1, 0, nullptr);
+        enable_mmap = prop ? zval_is_true(prop) : 1;
+    }
+    {
+        zval *prop = zend_read_property(zvec_collection_options_ce, Z_OBJ_P(opts_zv), "maxBufferSize", sizeof("maxBufferSize") - 1, 0, nullptr);
+        max_buffer_size = prop ? Z_LVAL_P(prop) : 67108864;
+    }
+
+    auto *schema = zvec_schema_get_native(schema_zv);
+    CollectionOptions opts{(bool)read_only, (bool)enable_mmap, static_cast<uint32_t>(max_buffer_size)};
+    auto result = Collection::CreateAndOpen(std::string(path, path_len), *schema, opts);
+    if (!result.has_value()) {
+        check_status(result.error());
+        RETURN_THROWS();
+    }
+
+    object_init_ex(return_value, zvec_collection_ce);
+    auto *intern = Z_ZVEC_COLLECTION_P(return_value);
+    intern->collection = std::move(result).value();
+    intern->closed = false;
+}
+
+PHP_METHOD(ZVec, openWith) {
+    char *path; size_t path_len;
+    zval *opts_zv;
+    zend_bool read_only, enable_mmap;
+    zend_long max_buffer_size;
+
+    ZEND_PARSE_PARAMETERS_START(2, 2)
+        Z_PARAM_STRING(path, path_len)
+        Z_PARAM_OBJECT_OF_CLASS(opts_zv, zvec_collection_options_ce)
+    ZEND_PARSE_PARAMETERS_END();
+
+    {
+        zval *prop = zend_read_property(zvec_collection_options_ce, Z_OBJ_P(opts_zv), "readOnly", sizeof("readOnly") - 1, 0, nullptr);
+        read_only = prop ? zval_is_true(prop) : 0;
+    }
+    {
+        zval *prop = zend_read_property(zvec_collection_options_ce, Z_OBJ_P(opts_zv), "enableMmap", sizeof("enableMmap") - 1, 0, nullptr);
+        enable_mmap = prop ? zval_is_true(prop) : 1;
+    }
+    {
+        zval *prop = zend_read_property(zvec_collection_options_ce, Z_OBJ_P(opts_zv), "maxBufferSize", sizeof("maxBufferSize") - 1, 0, nullptr);
+        max_buffer_size = prop ? Z_LVAL_P(prop) : 67108864;
+    }
+
+    CollectionOptions opts{(bool)read_only, (bool)enable_mmap, static_cast<uint32_t>(max_buffer_size)};
+    auto result = Collection::Open(std::string(path, path_len), opts);
+    if (!result.has_value()) {
+        check_status(result.error());
+        RETURN_THROWS();
+    }
+
+    object_init_ex(return_value, zvec_collection_ce);
+    auto *intern = Z_ZVEC_COLLECTION_P(return_value);
+    intern->collection = std::move(result).value();
+    intern->closed = false;
+}
+
+PHP_METHOD(ZVec, getOptions) {
+    ZEND_PARSE_PARAMETERS_NONE();
+    auto *intern = Z_ZVEC_COLLECTION_P(ZEND_THIS);
+    check_closed(intern);
+    if (EG(exception)) RETURN_THROWS();
+    auto res = intern->collection->Options();
+    if (!res.has_value()) {
+        check_status(res.error());
+        RETURN_THROWS();
+    }
+
+    object_init_ex(return_value, zvec_collection_options_ce);
+    zend_update_property_bool(zvec_collection_options_ce, Z_OBJ_P(return_value), "readOnly", sizeof("readOnly") - 1, res.value().read_only_);
+    zend_update_property_bool(zvec_collection_options_ce, Z_OBJ_P(return_value), "enableMmap", sizeof("enableMmap") - 1, res.value().enable_mmap_);
+    zend_update_property_long(zvec_collection_options_ce, Z_OBJ_P(return_value), "maxBufferSize", sizeof("maxBufferSize") - 1, static_cast<zend_long>(res.value().max_buffer_size_));
 }
 
 PHP_METHOD(ZVec, close) {
@@ -1391,6 +1485,20 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_zvec_open, 0, 1, ZVec, 0)
     ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, maxBufferSize, IS_LONG, 0, "67108864")
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_zvec_create_with, 0, 3, ZVec, 0)
+    ZEND_ARG_TYPE_INFO(0, path, IS_STRING, 0)
+    ZEND_ARG_OBJ_INFO(0, schema, ZVecSchema, 0)
+    ZEND_ARG_OBJ_INFO(0, options, ZVecCollectionOptions, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_zvec_open_with, 0, 2, ZVec, 0)
+    ZEND_ARG_TYPE_INFO(0, path, IS_STRING, 0)
+    ZEND_ARG_OBJ_INFO(0, options, ZVecCollectionOptions, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_zvec_get_options, 0, 0, ZVecCollectionOptions, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_zvec_void, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
@@ -1555,6 +1663,9 @@ static const zend_function_entry zvec_collection_methods[] = {
     PHP_ME(ZVec, init, arginfo_zvec_init, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
     PHP_ME(ZVec, create, arginfo_zvec_create, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
     PHP_ME(ZVec, open, arginfo_zvec_open, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+    PHP_ME(ZVec, createWith, arginfo_zvec_create_with, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+    PHP_ME(ZVec, openWith, arginfo_zvec_open_with, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+    PHP_ME(ZVec, getOptions, arginfo_zvec_get_options, ZEND_ACC_PUBLIC)
     PHP_ME(ZVec, close, arginfo_zvec_void, ZEND_ACC_PUBLIC)
     PHP_ME(ZVec, __destruct, arginfo_zvec_void, ZEND_ACC_PUBLIC)
     PHP_ME(ZVec, flush, arginfo_zvec_void, ZEND_ACC_PUBLIC)

--- a/php-ext/zvec_collection_options.cc
+++ b/php-ext/zvec_collection_options.cc
@@ -19,76 +19,23 @@ PHP_METHOD(ZVecCollectionOptions, __construct) {
     zend_update_property_long(zvec_collection_options_ce, Z_OBJ_P(ZEND_THIS), "maxBufferSize", sizeof("maxBufferSize") - 1, max_buffer_size);
 }
 
-PHP_METHOD(ZVecCollectionOptions, readOnly) {
-    object_init_ex(return_value, zvec_collection_options_ce);
-    zend_update_property_bool(zvec_collection_options_ce, Z_OBJ_P(return_value), "readOnly", sizeof("readOnly") - 1, 1);
-    zend_update_property_bool(zvec_collection_options_ce, Z_OBJ_P(return_value), "enableMmap", sizeof("enableMmap") - 1, 1);
-    zend_update_property_long(zvec_collection_options_ce, Z_OBJ_P(return_value), "maxBufferSize", sizeof("maxBufferSize") - 1, 67108864);
-}
-
-PHP_METHOD(ZVecCollectionOptions, readWrite) {
-    object_init_ex(return_value, zvec_collection_options_ce);
-    zend_update_property_bool(zvec_collection_options_ce, Z_OBJ_P(return_value), "readOnly", sizeof("readOnly") - 1, 0);
-    zend_update_property_bool(zvec_collection_options_ce, Z_OBJ_P(return_value), "enableMmap", sizeof("enableMmap") - 1, 1);
-    zend_update_property_long(zvec_collection_options_ce, Z_OBJ_P(return_value), "maxBufferSize", sizeof("maxBufferSize") - 1, 67108864);
-}
-
-PHP_METHOD(ZVecCollectionOptions, defaults) {
-    object_init_ex(return_value, zvec_collection_options_ce);
-    zend_update_property_bool(zvec_collection_options_ce, Z_OBJ_P(return_value), "readOnly", sizeof("readOnly") - 1, 0);
-    zend_update_property_bool(zvec_collection_options_ce, Z_OBJ_P(return_value), "enableMmap", sizeof("enableMmap") - 1, 1);
-    zend_update_property_long(zvec_collection_options_ce, Z_OBJ_P(return_value), "maxBufferSize", sizeof("maxBufferSize") - 1, 67108864);
-}
-
-PHP_METHOD(ZVecCollectionOptions, setReadOnly) {
-    zend_bool value;
-    ZEND_PARSE_PARAMETERS_START(1, 1)
-        Z_PARAM_BOOL(value)
-    ZEND_PARSE_PARAMETERS_END();
-    zend_update_property_bool(zvec_collection_options_ce, Z_OBJ_P(ZEND_THIS), "readOnly", sizeof("readOnly") - 1, value);
-    RETURN_OBJ(Z_OBJ_P(ZEND_THIS));
-}
-
+// Getters - direct property access
 PHP_METHOD(ZVecCollectionOptions, getReadOnly) {
-    zval *prop = zend_read_property(zvec_collection_options_ce, Z_OBJ_P(ZEND_THIS), "readOnly", sizeof("readOnly") - 1, 0, nullptr);
-    if (prop) {
-        RETURN_BOOL(zval_is_true(prop));
-    }
-    RETURN_FALSE;
-}
-
-PHP_METHOD(ZVecCollectionOptions, setEnableMmap) {
-    zend_bool value;
-    ZEND_PARSE_PARAMETERS_START(1, 1)
-        Z_PARAM_BOOL(value)
-    ZEND_PARSE_PARAMETERS_END();
-    zend_update_property_bool(zvec_collection_options_ce, Z_OBJ_P(ZEND_THIS), "enableMmap", sizeof("enableMmap") - 1, value);
-    RETURN_OBJ(Z_OBJ_P(ZEND_THIS));
+    zval rv;
+    zval *prop = zend_read_property(zvec_collection_options_ce, Z_OBJ_P(ZEND_THIS), "readOnly", sizeof("readOnly") - 1, 0, &rv);
+    RETURN_BOOL(zval_is_true(prop));
 }
 
 PHP_METHOD(ZVecCollectionOptions, getEnableMmap) {
-    zval *prop = zend_read_property(zvec_collection_options_ce, Z_OBJ_P(ZEND_THIS), "enableMmap", sizeof("enableMmap") - 1, 0, nullptr);
-    if (prop) {
-        RETURN_BOOL(zval_is_true(prop));
-    }
-    RETURN_FALSE;
-}
-
-PHP_METHOD(ZVecCollectionOptions, setMaxBufferSize) {
-    zend_long value;
-    ZEND_PARSE_PARAMETERS_START(1, 1)
-        Z_PARAM_LONG(value)
-    ZEND_PARSE_PARAMETERS_END();
-    zend_update_property_long(zvec_collection_options_ce, Z_OBJ_P(ZEND_THIS), "maxBufferSize", sizeof("maxBufferSize") - 1, value);
-    RETURN_OBJ(Z_OBJ_P(ZEND_THIS));
+    zval rv;
+    zval *prop = zend_read_property(zvec_collection_options_ce, Z_OBJ_P(ZEND_THIS), "enableMmap", sizeof("enableMmap") - 1, 0, &rv);
+    RETURN_BOOL(zval_is_true(prop));
 }
 
 PHP_METHOD(ZVecCollectionOptions, getMaxBufferSize) {
-    zval *prop = zend_read_property(zvec_collection_options_ce, Z_OBJ_P(ZEND_THIS), "maxBufferSize", sizeof("maxBufferSize") - 1, 0, nullptr);
-    if (prop) {
-        RETURN_LONG(Z_LVAL_P(prop));
-    }
-    RETURN_LONG(0);
+    zval rv;
+    zval *prop = zend_read_property(zvec_collection_options_ce, Z_OBJ_P(ZEND_THIS), "maxBufferSize", sizeof("maxBufferSize") - 1, 0, &rv);
+    RETURN_LONG(Z_LVAL_P(prop));
 }
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_collection_options_construct, 0, 0, 0)
@@ -97,25 +44,10 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_collection_options_construct, 0, 0, 0)
     ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, maxBufferSize, IS_LONG, 0, "67108864")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_collection_options_static, 0, 0, ZVecCollectionOptions, 0)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_collection_options_set_read_only, 0, 1, ZVecCollectionOptions, 0)
-    ZEND_ARG_TYPE_INFO(0, readOnly, _IS_BOOL, 0)
-ZEND_END_ARG_INFO()
-
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_collection_options_get_read_only, 0, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_collection_options_set_enable_mmap, 0, 1, ZVecCollectionOptions, 0)
-    ZEND_ARG_TYPE_INFO(0, enableMmap, _IS_BOOL, 0)
-ZEND_END_ARG_INFO()
-
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_collection_options_get_enable_mmap, 0, 0, _IS_BOOL, 0)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_collection_options_set_max_buffer_size, 0, 1, ZVecCollectionOptions, 0)
-    ZEND_ARG_TYPE_INFO(0, maxBufferSize, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_collection_options_get_max_buffer_size, 0, 0, IS_LONG, 0)
@@ -123,14 +55,8 @@ ZEND_END_ARG_INFO()
 
 static const zend_function_entry zvec_collection_options_methods[] = {
     PHP_ME(ZVecCollectionOptions, __construct, arginfo_collection_options_construct, ZEND_ACC_PUBLIC)
-    PHP_ME(ZVecCollectionOptions, readOnly, arginfo_collection_options_static, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
-    PHP_ME(ZVecCollectionOptions, readWrite, arginfo_collection_options_static, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
-    PHP_ME(ZVecCollectionOptions, defaults, arginfo_collection_options_static, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
-    PHP_ME(ZVecCollectionOptions, setReadOnly, arginfo_collection_options_set_read_only, ZEND_ACC_PUBLIC)
     PHP_ME(ZVecCollectionOptions, getReadOnly, arginfo_collection_options_get_read_only, ZEND_ACC_PUBLIC)
-    PHP_ME(ZVecCollectionOptions, setEnableMmap, arginfo_collection_options_set_enable_mmap, ZEND_ACC_PUBLIC)
     PHP_ME(ZVecCollectionOptions, getEnableMmap, arginfo_collection_options_get_enable_mmap, ZEND_ACC_PUBLIC)
-    PHP_ME(ZVecCollectionOptions, setMaxBufferSize, arginfo_collection_options_set_max_buffer_size, ZEND_ACC_PUBLIC)
     PHP_ME(ZVecCollectionOptions, getMaxBufferSize, arginfo_collection_options_get_max_buffer_size, ZEND_ACC_PUBLIC)
     PHP_FE_END
 };

--- a/php-ext/zvec_collection_options.cc
+++ b/php-ext/zvec_collection_options.cc
@@ -1,0 +1,146 @@
+#include "zvec_collection_options.h"
+
+zend_class_entry *zvec_collection_options_ce = nullptr;
+
+PHP_METHOD(ZVecCollectionOptions, __construct) {
+    zend_bool read_only = 0;
+    zend_bool enable_mmap = 1;
+    zend_long max_buffer_size = 67108864;
+
+    ZEND_PARSE_PARAMETERS_START(0, 3)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_BOOL(read_only)
+        Z_PARAM_BOOL(enable_mmap)
+        Z_PARAM_LONG(max_buffer_size)
+    ZEND_PARSE_PARAMETERS_END();
+
+    zend_update_property_bool(zvec_collection_options_ce, Z_OBJ_P(ZEND_THIS), "readOnly", sizeof("readOnly") - 1, read_only);
+    zend_update_property_bool(zvec_collection_options_ce, Z_OBJ_P(ZEND_THIS), "enableMmap", sizeof("enableMmap") - 1, enable_mmap);
+    zend_update_property_long(zvec_collection_options_ce, Z_OBJ_P(ZEND_THIS), "maxBufferSize", sizeof("maxBufferSize") - 1, max_buffer_size);
+}
+
+PHP_METHOD(ZVecCollectionOptions, readOnly) {
+    object_init_ex(return_value, zvec_collection_options_ce);
+    zend_update_property_bool(zvec_collection_options_ce, Z_OBJ_P(return_value), "readOnly", sizeof("readOnly") - 1, 1);
+    zend_update_property_bool(zvec_collection_options_ce, Z_OBJ_P(return_value), "enableMmap", sizeof("enableMmap") - 1, 1);
+    zend_update_property_long(zvec_collection_options_ce, Z_OBJ_P(return_value), "maxBufferSize", sizeof("maxBufferSize") - 1, 67108864);
+}
+
+PHP_METHOD(ZVecCollectionOptions, readWrite) {
+    object_init_ex(return_value, zvec_collection_options_ce);
+    zend_update_property_bool(zvec_collection_options_ce, Z_OBJ_P(return_value), "readOnly", sizeof("readOnly") - 1, 0);
+    zend_update_property_bool(zvec_collection_options_ce, Z_OBJ_P(return_value), "enableMmap", sizeof("enableMmap") - 1, 1);
+    zend_update_property_long(zvec_collection_options_ce, Z_OBJ_P(return_value), "maxBufferSize", sizeof("maxBufferSize") - 1, 67108864);
+}
+
+PHP_METHOD(ZVecCollectionOptions, defaults) {
+    object_init_ex(return_value, zvec_collection_options_ce);
+    zend_update_property_bool(zvec_collection_options_ce, Z_OBJ_P(return_value), "readOnly", sizeof("readOnly") - 1, 0);
+    zend_update_property_bool(zvec_collection_options_ce, Z_OBJ_P(return_value), "enableMmap", sizeof("enableMmap") - 1, 1);
+    zend_update_property_long(zvec_collection_options_ce, Z_OBJ_P(return_value), "maxBufferSize", sizeof("maxBufferSize") - 1, 67108864);
+}
+
+PHP_METHOD(ZVecCollectionOptions, setReadOnly) {
+    zend_bool value;
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_BOOL(value)
+    ZEND_PARSE_PARAMETERS_END();
+    zend_update_property_bool(zvec_collection_options_ce, Z_OBJ_P(ZEND_THIS), "readOnly", sizeof("readOnly") - 1, value);
+    RETURN_OBJ(Z_OBJ_P(ZEND_THIS));
+}
+
+PHP_METHOD(ZVecCollectionOptions, getReadOnly) {
+    zval *prop = zend_read_property(zvec_collection_options_ce, Z_OBJ_P(ZEND_THIS), "readOnly", sizeof("readOnly") - 1, 0, nullptr);
+    if (prop) {
+        RETURN_BOOL(zval_is_true(prop));
+    }
+    RETURN_FALSE;
+}
+
+PHP_METHOD(ZVecCollectionOptions, setEnableMmap) {
+    zend_bool value;
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_BOOL(value)
+    ZEND_PARSE_PARAMETERS_END();
+    zend_update_property_bool(zvec_collection_options_ce, Z_OBJ_P(ZEND_THIS), "enableMmap", sizeof("enableMmap") - 1, value);
+    RETURN_OBJ(Z_OBJ_P(ZEND_THIS));
+}
+
+PHP_METHOD(ZVecCollectionOptions, getEnableMmap) {
+    zval *prop = zend_read_property(zvec_collection_options_ce, Z_OBJ_P(ZEND_THIS), "enableMmap", sizeof("enableMmap") - 1, 0, nullptr);
+    if (prop) {
+        RETURN_BOOL(zval_is_true(prop));
+    }
+    RETURN_FALSE;
+}
+
+PHP_METHOD(ZVecCollectionOptions, setMaxBufferSize) {
+    zend_long value;
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_LONG(value)
+    ZEND_PARSE_PARAMETERS_END();
+    zend_update_property_long(zvec_collection_options_ce, Z_OBJ_P(ZEND_THIS), "maxBufferSize", sizeof("maxBufferSize") - 1, value);
+    RETURN_OBJ(Z_OBJ_P(ZEND_THIS));
+}
+
+PHP_METHOD(ZVecCollectionOptions, getMaxBufferSize) {
+    zval *prop = zend_read_property(zvec_collection_options_ce, Z_OBJ_P(ZEND_THIS), "maxBufferSize", sizeof("maxBufferSize") - 1, 0, nullptr);
+    if (prop) {
+        RETURN_LONG(Z_LVAL_P(prop));
+    }
+    RETURN_LONG(0);
+}
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_collection_options_construct, 0, 0, 0)
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, readOnly, _IS_BOOL, 0, "false")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, enableMmap, _IS_BOOL, 0, "true")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, maxBufferSize, IS_LONG, 0, "67108864")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_collection_options_static, 0, 0, ZVecCollectionOptions, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_collection_options_set_read_only, 0, 1, ZVecCollectionOptions, 0)
+    ZEND_ARG_TYPE_INFO(0, readOnly, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_collection_options_get_read_only, 0, 0, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_collection_options_set_enable_mmap, 0, 1, ZVecCollectionOptions, 0)
+    ZEND_ARG_TYPE_INFO(0, enableMmap, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_collection_options_get_enable_mmap, 0, 0, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_collection_options_set_max_buffer_size, 0, 1, ZVecCollectionOptions, 0)
+    ZEND_ARG_TYPE_INFO(0, maxBufferSize, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_collection_options_get_max_buffer_size, 0, 0, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+static const zend_function_entry zvec_collection_options_methods[] = {
+    PHP_ME(ZVecCollectionOptions, __construct, arginfo_collection_options_construct, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecCollectionOptions, readOnly, arginfo_collection_options_static, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+    PHP_ME(ZVecCollectionOptions, readWrite, arginfo_collection_options_static, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+    PHP_ME(ZVecCollectionOptions, defaults, arginfo_collection_options_static, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+    PHP_ME(ZVecCollectionOptions, setReadOnly, arginfo_collection_options_set_read_only, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecCollectionOptions, getReadOnly, arginfo_collection_options_get_read_only, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecCollectionOptions, setEnableMmap, arginfo_collection_options_set_enable_mmap, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecCollectionOptions, getEnableMmap, arginfo_collection_options_get_enable_mmap, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecCollectionOptions, setMaxBufferSize, arginfo_collection_options_set_max_buffer_size, ZEND_ACC_PUBLIC)
+    PHP_ME(ZVecCollectionOptions, getMaxBufferSize, arginfo_collection_options_get_max_buffer_size, ZEND_ACC_PUBLIC)
+    PHP_FE_END
+};
+
+void zvec_register_collection_options(INIT_FUNC_ARGS) {
+    zend_class_entry ce;
+    INIT_CLASS_ENTRY(ce, "ZVecCollectionOptions", zvec_collection_options_methods);
+    zvec_collection_options_ce = zend_register_internal_class(&ce);
+
+    zend_declare_property_bool(zvec_collection_options_ce, "readOnly", sizeof("readOnly") - 1, 0, ZEND_ACC_PUBLIC);
+    zend_declare_property_bool(zvec_collection_options_ce, "enableMmap", sizeof("enableMmap") - 1, 1, ZEND_ACC_PUBLIC);
+    zend_declare_property_long(zvec_collection_options_ce, "maxBufferSize", sizeof("maxBufferSize") - 1, 67108864, ZEND_ACC_PUBLIC);
+}

--- a/php-ext/zvec_collection_options.h
+++ b/php-ext/zvec_collection_options.h
@@ -1,0 +1,10 @@
+#ifndef ZVEC_COLLECTION_OPTIONS_H
+#define ZVEC_COLLECTION_OPTIONS_H
+
+#include "php_zvec.h"
+
+extern zend_class_entry *zvec_collection_options_ce;
+
+void zvec_register_collection_options(INIT_FUNC_ARGS);
+
+#endif

--- a/src/ZVec.php
+++ b/src/ZVec.php
@@ -501,6 +501,26 @@ zvec_status_t zvec_collection_create_ivf_index(zvec_collection_t coll, const cha
         return new self($out);
     }
 
+    public static function createWith(string $path, ZVecSchema $schema, ZVecCollectionOptions $options): self
+    {
+        return self::create($path, $schema, $options->readOnly, $options->enableMmap, $options->maxBufferSize);
+    }
+
+    public static function openWith(string $path, ZVecCollectionOptions $options): self
+    {
+        return self::open($path, $options->readOnly, $options->enableMmap, $options->maxBufferSize);
+    }
+
+    public function getOptions(): ZVecCollectionOptions
+    {
+        $arr = $this->options();
+        return new ZVecCollectionOptions(
+            readOnly: $arr['read_only'],
+            enableMmap: $arr['enable_mmap'],
+            maxBufferSize: $arr['max_buffer_size']
+        );
+    }
+
     private function __construct(FFI\CData $handle)
     {
         $this->handle = $handle;
@@ -1642,6 +1662,68 @@ zvec_status_t zvec_collection_create_ivf_index(zvec_collection_t coll, const cha
         $out = $ffi->new('zvec_field_schema_t');
         self::checkStatus($ffi->zvec_collection_get_field_schema($this->handle, $fieldName, FFI::addr($out)));
         return new ZVecFieldSchema($out);
+    }
+}
+
+class ZVecCollectionOptions
+{
+    public bool $readOnly = false;
+    public bool $enableMmap = true;
+    public int $maxBufferSize = 67108864;
+
+    public function __construct(bool $readOnly = false, bool $enableMmap = true, int $maxBufferSize = 67108864)
+    {
+        $this->readOnly = $readOnly;
+        $this->enableMmap = $enableMmap;
+        $this->maxBufferSize = $maxBufferSize;
+    }
+
+    public static function readOnly(): self
+    {
+        return new self(readOnly: true);
+    }
+
+    public static function readWrite(): self
+    {
+        return new self(readOnly: false);
+    }
+
+    public static function defaults(): self
+    {
+        return new self();
+    }
+
+    public function setReadOnly(bool $readOnly): self
+    {
+        $this->readOnly = $readOnly;
+        return $this;
+    }
+
+    public function getReadOnly(): bool
+    {
+        return $this->readOnly;
+    }
+
+    public function setEnableMmap(bool $enableMmap): self
+    {
+        $this->enableMmap = $enableMmap;
+        return $this;
+    }
+
+    public function getEnableMmap(): bool
+    {
+        return $this->enableMmap;
+    }
+
+    public function setMaxBufferSize(int $maxBufferSize): self
+    {
+        $this->maxBufferSize = $maxBufferSize;
+        return $this;
+    }
+
+    public function getMaxBufferSize(): int
+    {
+        return $this->maxBufferSize;
     }
 }
 

--- a/tests/test_collection_options.phpt
+++ b/tests/test_collection_options.phpt
@@ -1,0 +1,83 @@
+--TEST--
+CollectionOptions: createWith/openWith with ZVecCollectionOptions object
+--SKIPIF--
+<?php if (!extension_loaded('zvec') && !extension_loaded('ffi')) die('skip Neither zvec extension nor FFI available'); ?>
+--FILE--
+<?php
+require_once __DIR__ . '/../src/ZVec.php';
+
+ZVec::init(logType: ZVec::LOG_CONSOLE, logLevel: ZVec::LOG_WARN);
+
+$path = __DIR__ . '/../test_dbs/col_opts_' . uniqid();
+try {
+    $schema = new ZVecSchema('options_test');
+    $schema->setMaxDocCountPerSegment(1000)
+        ->addInt64('id', nullable: false, withInvertIndex: true)
+        ->addVectorFp32('embedding', dimension: 4, metricType: ZVecSchema::METRIC_IP);
+
+    // Test 1: createWith with read-write options
+    $opts = ZVecCollectionOptions::readWrite()
+        ->setEnableMmap(false)
+        ->setMaxBufferSize(64 * 1024 * 1024);
+    $c = ZVec::createWith($path, $schema, $opts);
+
+    $ro = $c->getOptions();
+    echo "readOnly: " . ($ro->getReadOnly() ? 'true' : 'false') . "\n";
+    echo "mmap: " . ($ro->getEnableMmap() ? 'true' : 'false') . "\n";
+    echo "buffer: " . $ro->getMaxBufferSize() . "\n";
+
+    $c->close();
+
+    // Test 2: Reopen read-only
+    $opts2 = ZVecCollectionOptions::readOnly()->setEnableMmap(true);
+    $c2 = ZVec::openWith($path, $opts2);
+    $ro2 = $c2->getOptions();
+    echo "reopen readOnly: " . ($ro2->getReadOnly() ? 'true' : 'false') . "\n";
+    $c2->close();
+
+    // Test 3: Backward compat still works
+    $legacyPath = __DIR__ . '/../test_dbs/col_opts_legacy_' . uniqid();
+    try {
+        $c3 = ZVec::create($legacyPath, $schema, readOnly: false, enableMmap: false, maxBufferSize: 33554432);
+        $optsArr = $c3->options();
+        echo "legacy readOnly: " . ($optsArr['read_only'] ? 'true' : 'false') . "\n";
+        echo "legacy mmap: " . ($optsArr['enable_mmap'] ? 'true' : 'false') . "\n";
+        echo "legacy buffer: " . $optsArr['max_buffer_size'] . "\n";
+        $c3->destroy();
+    } finally {
+        exec("rm -rf " . escapeshellarg($legacyPath));
+    }
+
+    // Test 4: defaults() factory
+    $defaults = ZVecCollectionOptions::defaults();
+    echo "defaults readOnly: " . ($defaults->getReadOnly() ? 'true' : 'false') . "\n";
+    echo "defaults mmap: " . ($defaults->getEnableMmap() ? 'true' : 'false') . "\n";
+
+    // Test 5: Fluent setters return $this
+    $opts5 = ZVecCollectionOptions::readWrite()
+        ->setReadOnly(true)
+        ->setEnableMmap(false)
+        ->setMaxBufferSize(1024);
+    echo "fluent readOnly: " . ($opts5->getReadOnly() ? 'true' : 'false') . "\n";
+    echo "fluent mmap: " . ($opts5->getEnableMmap() ? 'true' : 'false') . "\n";
+    echo "fluent buffer: " . $opts5->getMaxBufferSize() . "\n";
+
+    echo "OK\n";
+} finally {
+    exec("rm -rf " . escapeshellarg($path));
+}
+?>
+--EXPECTF--
+readOnly: false
+mmap: false
+buffer: 67108864
+reopen readOnly: true
+legacy readOnly: false
+legacy mmap: false
+legacy buffer: 33554432
+defaults readOnly: false
+defaults mmap: true
+fluent readOnly: true
+fluent mmap: false
+fluent buffer: 1024
+OK

--- a/tests/test_collection_options.phpt
+++ b/tests/test_collection_options.phpt
@@ -16,9 +16,7 @@ try {
         ->addVectorFp32('embedding', dimension: 4, metricType: ZVecSchema::METRIC_IP);
 
     // Test 1: createWith with read-write options
-    $opts = ZVecCollectionOptions::readWrite()
-        ->setEnableMmap(false)
-        ->setMaxBufferSize(64 * 1024 * 1024);
+    $opts = new ZVecCollectionOptions(readOnly: false, enableMmap: false, maxBufferSize: 64 * 1024 * 1024);
     $c = ZVec::createWith($path, $schema, $opts);
 
     $ro = $c->getOptions();
@@ -29,7 +27,7 @@ try {
     $c->close();
 
     // Test 2: Reopen read-only
-    $opts2 = ZVecCollectionOptions::readOnly()->setEnableMmap(true);
+    $opts2 = new ZVecCollectionOptions(readOnly: true, enableMmap: true);
     $c2 = ZVec::openWith($path, $opts2);
     $ro2 = $c2->getOptions();
     echo "reopen readOnly: " . ($ro2->getReadOnly() ? 'true' : 'false') . "\n";
@@ -48,19 +46,16 @@ try {
         exec("rm -rf " . escapeshellarg($legacyPath));
     }
 
-    // Test 4: defaults() factory
-    $defaults = ZVecCollectionOptions::defaults();
-    echo "defaults readOnly: " . ($defaults->getReadOnly() ? 'true' : 'false') . "\n";
-    echo "defaults mmap: " . ($defaults->getEnableMmap() ? 'true' : 'false') . "\n";
+    // Test 4: Direct property access
+    $opts4 = new ZVecCollectionOptions();
+    echo "defaults readOnly: " . ($opts4->readOnly ? 'true' : 'false') . "\n";
+    echo "defaults mmap: " . ($opts4->enableMmap ? 'true' : 'false') . "\n";
 
-    // Test 5: Fluent setters return $this
-    $opts5 = ZVecCollectionOptions::readWrite()
-        ->setReadOnly(true)
-        ->setEnableMmap(false)
-        ->setMaxBufferSize(1024);
-    echo "fluent readOnly: " . ($opts5->getReadOnly() ? 'true' : 'false') . "\n";
-    echo "fluent mmap: " . ($opts5->getEnableMmap() ? 'true' : 'false') . "\n";
-    echo "fluent buffer: " . $opts5->getMaxBufferSize() . "\n";
+    // Test 5: Constructor with specific values
+    $opts5 = new ZVecCollectionOptions(readOnly: true, enableMmap: false, maxBufferSize: 1024);
+    echo "custom readOnly: " . ($opts5->getReadOnly() ? 'true' : 'false') . "\n";
+    echo "custom mmap: " . ($opts5->getEnableMmap() ? 'true' : 'false') . "\n";
+    echo "custom buffer: " . $opts5->getMaxBufferSize() . "\n";
 
     echo "OK\n";
 } finally {
@@ -77,7 +72,7 @@ legacy mmap: false
 legacy buffer: 33554432
 defaults readOnly: false
 defaults mmap: true
-fluent readOnly: true
-fluent mmap: false
-fluent buffer: 1024
+custom readOnly: true
+custom mmap: false
+custom buffer: 1024
 OK

--- a/tests/test_collection_options_e2e.phpt
+++ b/tests/test_collection_options_e2e.phpt
@@ -1,0 +1,103 @@
+--TEST--
+CollectionOptions E2E: createWith → insert → close → openWith read-only → query → verify read-only rejection
+--SKIPIF--
+<?php if (!extension_loaded('zvec') && !extension_loaded('ffi')) die('skip Neither zvec extension nor FFI available'); ?>
+--FILE--
+<?php
+require_once __DIR__ . '/../src/ZVec.php';
+
+ZVec::init(logType: ZVec::LOG_CONSOLE, logLevel: ZVec::LOG_WARN);
+
+$path = __DIR__ . '/../test_dbs/col_opts_e2e_' . uniqid();
+try {
+    $schema = new ZVecSchema('e2e_test');
+    $schema->setMaxDocCountPerSegment(1000)
+        ->addInt64('id', nullable: false, withInvertIndex: true)
+        ->addVectorFp32('embedding', dimension: 4, metricType: ZVecSchema::METRIC_IP);
+
+    // Create with explicit options
+    $opts = ZVecCollectionOptions::readWrite()
+        ->setEnableMmap(true)
+        ->setMaxBufferSize(128 * 1024 * 1024);
+    $c = ZVec::createWith($path, $schema, $opts);
+
+    // Verify options via getOptions
+    $ro = $c->getOptions();
+    assert($ro->getReadOnly() === false, 'Should be read-write');
+    assert($ro->getEnableMmap() === true, 'Mmap should be enabled');
+    assert($ro->getMaxBufferSize() === 128 * 1024 * 1024, 'Buffer size should be 128MB');
+    echo "Options verified\n";
+
+    // Insert documents
+    $doc1 = new ZVecDoc('doc1');
+    $doc1->setInt64('id', 1)->setVectorFp32('embedding', [0.1, 0.2, 0.3, 0.4]);
+    $c->insert($doc1);
+
+    $doc2 = new ZVecDoc('doc2');
+    $doc2->setInt64('id', 2)->setVectorFp32('embedding', [0.5, 0.6, 0.7, 0.8]);
+    $c->insert($doc2);
+
+    $c->flush();
+    echo "Inserted 2 docs\n";
+
+    $c->close();
+
+    // Reopen read-only
+    $opts2 = ZVecCollectionOptions::readOnly()->setEnableMmap(true);
+    $c2 = ZVec::openWith($path, $opts2);
+    $ro2 = $c2->getOptions();
+    assert($ro2->getReadOnly() === true, 'Reopened should be read-only');
+    echo "Reopened read-only\n";
+
+    // Query should work
+    $results = $c2->query('embedding', [0.1, 0.2, 0.3, 0.4], topk: 10);
+    assert(count($results) > 0, 'Query should return results');
+    echo "Query returned " . count($results) . " results\n";
+
+    // Insert should fail on read-only
+    $doc3 = new ZVecDoc('doc3');
+    $doc3->setInt64('id', 3)->setVectorFp32('embedding', [0.9, 0.8, 0.7, 0.6]);
+    try {
+        $c2->insert($doc3);
+        echo "FAIL: Should not allow writes to read-only\n";
+        exit(1);
+    } catch (ZVecException $e) {
+        echo "Read-only correctly blocks insert\n";
+    }
+
+    $c2->close();
+
+    // Verify data persists by reopening read-write
+    $opts3 = ZVecCollectionOptions::readWrite()->setEnableMmap(true);
+    $c3 = ZVec::openWith($path, $opts3);
+    $results2 = $c3->query('embedding', [0.1, 0.2, 0.3, 0.4], topk: 10);
+    assert(count($results2) > 0, 'Data should persist');
+    echo "Data persists after reopen\n";
+
+    $c3->destroy();
+
+    // Test invalid path with openWith
+    $invalidPath = '/nonexistent/path';
+    try {
+        $badOpts = ZVecCollectionOptions::readWrite();
+        ZVec::openWith($invalidPath, $badOpts);
+        echo "FAIL: Should fail for invalid path\n";
+        exit(1);
+    } catch (ZVecException $e) {
+        echo "Invalid path correctly rejected\n";
+    }
+
+    echo "PASS\n";
+} finally {
+    exec("rm -rf " . escapeshellarg($path));
+}
+?>
+--EXPECT--
+Options verified
+Inserted 2 docs
+Reopened read-only
+Query returned 2 results
+Read-only correctly blocks insert
+Data persists after reopen
+Invalid path correctly rejected
+PASS

--- a/tests/test_collection_options_e2e.phpt
+++ b/tests/test_collection_options_e2e.phpt
@@ -16,9 +16,7 @@ try {
         ->addVectorFp32('embedding', dimension: 4, metricType: ZVecSchema::METRIC_IP);
 
     // Create with explicit options
-    $opts = ZVecCollectionOptions::readWrite()
-        ->setEnableMmap(true)
-        ->setMaxBufferSize(128 * 1024 * 1024);
+    $opts = new ZVecCollectionOptions(readOnly: false, enableMmap: true, maxBufferSize: 128 * 1024 * 1024);
     $c = ZVec::createWith($path, $schema, $opts);
 
     // Verify options via getOptions
@@ -43,7 +41,7 @@ try {
     $c->close();
 
     // Reopen read-only
-    $opts2 = ZVecCollectionOptions::readOnly()->setEnableMmap(true);
+    $opts2 = new ZVecCollectionOptions(readOnly: true, enableMmap: true);
     $c2 = ZVec::openWith($path, $opts2);
     $ro2 = $c2->getOptions();
     assert($ro2->getReadOnly() === true, 'Reopened should be read-only');
@@ -68,7 +66,7 @@ try {
     $c2->close();
 
     // Verify data persists by reopening read-write
-    $opts3 = ZVecCollectionOptions::readWrite()->setEnableMmap(true);
+    $opts3 = new ZVecCollectionOptions(readOnly: false, enableMmap: true);
     $c3 = ZVec::openWith($path, $opts3);
     $results2 = $c3->query('embedding', [0.1, 0.2, 0.3, 0.4], topk: 10);
     assert(count($results2) > 0, 'Data should persist');
@@ -79,7 +77,7 @@ try {
     // Test invalid path with openWith
     $invalidPath = '/nonexistent/path';
     try {
-        $badOpts = ZVecCollectionOptions::readWrite();
+        $badOpts = new ZVecCollectionOptions();
         ZVec::openWith($invalidPath, $badOpts);
         echo "FAIL: Should fail for invalid path\n";
         exit(1);


### PR DESCRIPTION
Closes #10

## Summary

Adds a `ZVecCollectionOptions` PHP class that bundles the 3 configuration parameters (readOnly, enableMmap, maxBufferSize) into a single options object.

### Changes

- **New class** `ZVecCollectionOptions` with:
  - Static factories: `readOnly()`, `readWrite()`, `defaults()`
  - Fluent setters: `setReadOnly()`, `setEnableMmap()`, `setMaxBufferSize()`
  - Getters: `getReadOnly()`, `getEnableMmap()`, `getMaxBufferSize()`
  - Direct property access: `$options->readOnly`, etc.
- **New static methods** `ZVec::createWith()` and `ZVec::openWith()` accepting `ZVecCollectionOptions`
- **New method** `ZVec::getOptions()` returning `ZVecCollectionOptions` (in addition to existing `options()` returning array)
- **Backward compat**: old `create()`/\`open()` remain unchanged
- **Tests**: unit test (test_collection_options.phpt) and E2E test with read-only rejection (test_collection_options_e2e.phpt)
- All 72 tests pass (70 pass + 2 XFAIL)