### PR TITLE
fix: WeightedReRanker PHP_FLOAT_MIN produces wrong normalization for negative IP scores (#50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **BUG-003: WeightedReRanker produces wrong normalization for negative IP scores** (#50)
+  - `PHP_FLOAT_MIN` (smallest positive float) replaced with `-PHP_FLOAT_MAX` (most negative finite float) as initial `max` value in score normalization — fixes incorrect min-max normalization when all scores are negative (IP, COSINE metrics)
+  - Magic number `1` replaced with `ZVecSchema::METRIC_L2` named constant for readability and maintainability
+  - Added `tests/bug_0050.phpt` — regression test verifying normalized scores in [0, 1] range for negative IP scores and correct L2 metric normalization
+
 ## [0.4.11] - 2026-05-10
 
 ### Added

--- a/src/ZVecWeightedReRanker.php
+++ b/src/ZVecWeightedReRanker.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 if (extension_loaded('zvec')) return;
 
+require_once __DIR__ . '/ZVec.php';
 require_once __DIR__ . '/ZVecReRanker.php';
 require_once __DIR__ . '/ZVecRerankedDoc.php';
 
@@ -70,7 +71,7 @@ class ZVecWeightedReRanker implements ZVecReRanker
                 continue;
             }
 
-            $fieldStats[$fieldName] = ['min' => PHP_FLOAT_MAX, 'max' => PHP_FLOAT_MIN];
+            $fieldStats[$fieldName] = ['min' => PHP_FLOAT_MAX, 'max' => -PHP_FLOAT_MAX];
             $allDocs[$fieldName] = [];
 
             foreach ($docs as $rank => $doc) {
@@ -121,7 +122,7 @@ class ZVecWeightedReRanker implements ZVecReRanker
 
                 // Normalize score based on metric type
                 // 1 = L2 (distance, lower is better), 2 = IP, 3 = COSINE (both higher is better)
-                if ($this->metricType === 1) {
+                if ($this->metricType === ZVecSchema::METRIC_L2) {
                     // L2: invert so lower distance => higher normalized score
                     $normalizedScore = ($stats['max'] - $score) / $range;
                 } else {

--- a/tests/bug_0050.phpt
+++ b/tests/bug_0050.phpt
@@ -1,0 +1,122 @@
+--TEST--
+Bug 0050: WeightedReRanker PHP_FLOAT_MIN produces wrong normalization for negative IP scores
+--SKIPIF--
+<?php if (!extension_loaded('zvec') && !extension_loaded('ffi')) die('skip Neither zvec extension nor FFI available'); ?>
+--FILE--
+<?php
+require_once __DIR__ . '/../src/ZVec.php';
+require_once __DIR__ . '/../src/ZVecWeightedReRanker.php';
+
+ZVec::init(logType: ZVec::LOG_CONSOLE, logLevel: ZVec::LOG_WARN);
+
+$path = __DIR__ . '/../test_dbs/bug_0050_' . uniqid();
+try {
+    // Create collection with IP metric
+    $schema = new ZVecSchema('bug_0050');
+    $schema->addVectorFp32('embedding', 4, ZVecSchema::METRIC_IP);
+    $collection = ZVec::create($path, $schema);
+
+    // Insert docs with varying scores (including negative for IP)
+    $docs = [
+        (new ZVecDoc('high_match'))
+            ->setVectorFp32('embedding', [0.9, 0.8, 0.7, 0.6]),
+        (new ZVecDoc('medium_match'))
+            ->setVectorFp32('embedding', [0.5, 0.4, 0.3, 0.2]),
+        (new ZVecDoc('negative_match'))
+            ->setVectorFp32('embedding', [-0.1, -0.2, -0.3, -0.4]),
+    ];
+    $collection->insert(...$docs);
+    $collection->optimize();
+
+    // Test 1: IP metric with mixed (positive + negative) scores
+    $reranker = new ZVecWeightedReRanker(
+        topn: 5,
+        metricType: ZVecSchema::METRIC_IP,
+        weights: ['embedding' => 1.0]
+    );
+
+    $query = new ZVecVectorQuery('embedding', [0.9, 0.8, 0.7, 0.6]);
+    $results = $collection->queryMulti(
+        vectorQueries: [$query],
+        reranker: $reranker,
+        topk: 10
+    );
+
+    foreach ($results as $doc) {
+        $score = $doc->combinedScore;
+        if ($score < 0.0 || $score > 1.0) {
+            echo "FAIL: Mixed-scores score {$score} out of [0, 1]\n";
+            exit(1);
+        }
+    }
+
+    $first = $results[0]->getPk();
+    if ($first !== 'high_match') {
+        echo "FAIL: Expected high_match first, got {$first}\n";
+        exit(1);
+    }
+    echo "Bug 0050: Mixed IP scores normalize correctly\n";
+
+    // Test 2: ALL-negative IP scores — the actual PHP_FLOAT_MIN bug scenario
+    // Query with a vector that will produce negative IP against all docs
+    $allNegQuery = new ZVecVectorQuery('embedding', [-0.5, -0.5, -0.5, -0.5]);
+    $resultsAllNeg = $collection->queryMulti(
+        vectorQueries: [$allNegQuery],
+        reranker: $reranker,
+        topk: 10
+    );
+
+    foreach ($resultsAllNeg as $doc) {
+        $score = $doc->combinedScore;
+        if ($score < 0.0 || $score > 1.0) {
+            echo "FAIL: All-negative score {$score} out of [0, 1] for doc {$doc->getPk()}\n";
+            exit(1);
+        }
+    }
+    echo "Bug 0050: All-negative IP scores normalize correctly (PHP_FLOAT_MIN fix)\n";
+
+    // Test 3: Verify L2 metric with ZVecSchema::METRIC_L2 constant
+    $collection2Path = __DIR__ . '/../test_dbs/bug_0050_l2_' . uniqid();
+    try {
+        $schemaL2 = new ZVecSchema('bug_0050_l2');
+        $schemaL2->addVectorFp32('embedding', 4, ZVecSchema::METRIC_L2);
+        $c2 = ZVec::create($collection2Path, $schemaL2);
+        $c2->insert(...$docs);
+        $c2->optimize();
+
+        $rerankerL2 = new ZVecWeightedReRanker(
+            topn: 5,
+            metricType: ZVecSchema::METRIC_L2,
+            weights: ['embedding' => 1.0]
+        );
+
+        $results2 = $c2->queryMulti(
+            vectorQueries: [new ZVecVectorQuery('embedding', [0.9, 0.8, 0.7, 0.6])],
+            reranker: $rerankerL2,
+            topk: 10
+        );
+
+        foreach ($results2 as $doc) {
+            $score = $doc->combinedScore;
+            if ($score < 0.0 || $score > 1.0) {
+                echo "FAIL: L2 Score {$score} out of [0, 1] range\n";
+                exit(1);
+            }
+        }
+        echo "Bug 0050: L2 metric normalization correct with METRIC_L2 constant\n";
+        $c2->close();
+    } finally {
+        exec("rm -rf " . escapeshellarg($collection2Path));
+    }
+
+    $collection->close();
+    echo "PASS\n";
+} finally {
+    exec("rm -rf " . escapeshellarg($path));
+}
+?>
+--EXPECT--
+Bug 0050: Mixed IP scores normalize correctly
+Bug 0050: All-negative IP scores normalize correctly (PHP_FLOAT_MIN fix)
+Bug 0050: L2 metric normalization correct with METRIC_L2 constant
+PASS


### PR DESCRIPTION
Fixes BUG-003 (#50): PHP_FLOAT_MIN is the smallest positive float, not the most negative. For IP/COSINE metrics with all-negative scores, the max tracker never updated, producing wrong combinedScore values.

Changes:
- PHP_FLOAT_MIN -> -PHP_FLOAT_MAX as initial max in score normalization
- Magic number 1 -> ZVecSchema::METRIC_L2 named constant
- Added require_once ZVec.php for explicit dependency
- New tests/bug_0050.phpt with all-negative-IP-score scenario

All 74 tests pass (72 PASS + 2 XFAIL as expected).

Closes #50