### PR TITLE
fix: prevent double-free on clone for all handle-holding classes (fix #58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **BUG-011: Clone-Safety Double-Free in Handle-Holding Classes** (#58)
+  - Added `private function __clone()` to `ZVec`, `ZVecSchema`, `ZVecIndexParams`, `ZVecCollectionStats`, `ZVecFieldSchema`, `ZVecDoc`, and `ZVecVectorQuery`
+  - Cloning any of these classes now throws `\Error` instead of creating a shallow copy that causes double-free on destruction
+  - Added `tests/bug_0011.phpt` — 13 test scenarios covering clone prevention and normal use verification
+
 - **BUG-012: `query()` with `ZVecVectorQuery` ignores query object's `topk`, `includeVector`, and `filter`** (#59)
   - Added `topk`, `includeVector`, `filter` public properties to `ZVecVectorQuery`
   - `setTopk()`, `setIncludeVector()`, `setFilter()` now store values in properties

--- a/src/ZVec.php
+++ b/src/ZVec.php
@@ -531,6 +531,10 @@ zvec_status_t zvec_collection_create_ivf_index(zvec_collection_t coll, const cha
         $this->close();
     }
 
+    private function __clone()
+    {
+    }
+
     public function close(): void
     {
         if (!$this->closed) {
@@ -1747,6 +1751,10 @@ class ZVecCollectionStats
         self::ffi()->zvec_collection_stats_free($this->handle);
     }
 
+    private function __clone()
+    {
+    }
+
     public function getDocCount(): int
     {
         return self::ffi()->zvec_collection_stats_get_doc_count($this->handle);
@@ -1814,6 +1822,10 @@ class ZVecFieldSchema
     public function __destruct()
     {
         self::ffi()->zvec_field_schema_free($this->handle);
+    }
+
+    private function __clone()
+    {
     }
 
     public function getName(): string
@@ -1900,6 +1912,10 @@ class ZVecIndexParams
     public function __destruct()
     {
         self::ffi()->zvec_index_params_free($this->handle);
+    }
+
+    private function __clone()
+    {
     }
 
     public function getHandle(): FFI\CData
@@ -2028,6 +2044,10 @@ class ZVecVectorQuery
             }
         } catch (\Throwable) {
         }
+    }
+
+    private function __clone()
+    {
     }
 
     public function getHandle(): FFI\CData
@@ -2341,6 +2361,10 @@ class ZVecSchema
         self::ffi()->zvec_schema_free($this->handle);
     }
 
+    private function __clone()
+    {
+    }
+
     public function getHandle(): FFI\CData
     {
         return $this->handle;
@@ -2546,6 +2570,10 @@ class ZVecDoc
         if ($this->ownsHandle) {
             self::ffi()->zvec_doc_free($this->handle);
         }
+    }
+
+    private function __clone()
+    {
     }
 
     public function getHandle(): FFI\CData

--- a/tests/bug_0011.phpt
+++ b/tests/bug_0011.phpt
@@ -1,0 +1,159 @@
+--TEST--
+BUG-011: Clone-Safety Double-Free — private __clone() prevents cloning on handle-holding classes
+--SKIPIF--
+<?php if (!extension_loaded('ffi')) die('skip FFI extension not available'); ?>
+--FILE--
+<?php
+declare(strict_types=1);
+require_once __DIR__ . '/../src/ZVec.php';
+
+ZVec::init(logType: ZVec::LOG_CONSOLE, logLevel: ZVec::LOG_WARN);
+
+$path = __DIR__ . '/../test_dbs/bug_0011_' . uniqid();
+$allOk = true;
+
+try {
+    // ===== 1. ZVecSchema =====
+    try {
+        $schema = new ZVecSchema('clone_test');
+        $schema->addInt64('id', nullable: false, withInvertIndex: true)
+            ->addVectorFp32('v', dimension: 4, metricType: ZVecSchema::METRIC_IP);
+        $clone = clone $schema;
+        echo "FAIL: ZVecSchema clone should throw\n";
+        $allOk = false;
+    } catch (\Error $e) {
+        echo "OK 1: ZVecSchema clone blocked - " . $e->getMessage() . "\n";
+    }
+
+    // ===== 2. ZVecIndexParams =====
+    try {
+        $params = ZVecIndexParams::forHnsw(ZVecSchema::METRIC_IP, 16, 200);
+        $clone = clone $params;
+        echo "FAIL: ZVecIndexParams clone should throw\n";
+        $allOk = false;
+    } catch (\Error $e) {
+        echo "OK 2: ZVecIndexParams clone blocked - " . $e->getMessage() . "\n";
+    }
+
+    // ===== 3. ZVecVectorQuery =====
+    try {
+        $query = new ZVecVectorQuery('v', [0.1, 0.2, 0.3, 0.4]);
+        $clone = clone $query;
+        echo "FAIL: ZVecVectorQuery clone should throw\n";
+        $allOk = false;
+    } catch (\Error $e) {
+        echo "OK 3: ZVecVectorQuery clone blocked - " . $e->getMessage() . "\n";
+    }
+
+    // ===== Create a collection for stats/fieldSchema tests =====
+    $schema2 = new ZVecSchema('clone_stats');
+    $schema2->addInt64('category', nullable: false, withInvertIndex: true)
+        ->addVectorFp32('v', dimension: 4, metricType: ZVecSchema::METRIC_IP);
+    $c = ZVec::create($path, $schema2);
+
+    $doc = new ZVecDoc('doc1');
+    $doc->setInt64('category', 1)->setVectorFp32('v', [0.1, 0.2, 0.3, 0.4]);
+    $c->insert($doc);
+
+    // Flush so stats are available
+    $c->flush();
+
+    // ===== 4. ZVecCollectionStats =====
+    try {
+        $stats = $c->getStatsStruct();
+        $clone = clone $stats;
+        echo "FAIL: ZVecCollectionStats clone should throw\n";
+        $allOk = false;
+    } catch (\Error $e) {
+        echo "OK 4: ZVecCollectionStats clone blocked - " . $e->getMessage() . "\n";
+    }
+
+    // ===== 5. ZVecFieldSchema =====
+    try {
+        $fieldSchema = $c->getFieldSchema('category');
+        $clone = clone $fieldSchema;
+        echo "FAIL: ZVecFieldSchema clone should throw\n";
+        $allOk = false;
+    } catch (\Error $e) {
+        echo "OK 5: ZVecFieldSchema clone blocked - " . $e->getMessage() . "\n";
+    }
+
+    // ===== 6. ZVecDoc (ownsHandle = true) =====
+    try {
+        $doc2 = new ZVecDoc('test_pk');
+        $doc2->setInt64('category', 99);
+        $clone = clone $doc2;
+        echo "FAIL: ZVecDoc clone should throw\n";
+        $allOk = false;
+    } catch (\Error $e) {
+        echo "OK 6: ZVecDoc clone blocked - " . $e->getMessage() . "\n";
+    }
+
+    // ===== 7. ZVec (collection) =====
+    try {
+        $clone = clone $c;
+        echo "FAIL: ZVec clone should throw\n";
+        $allOk = false;
+    } catch (\Error $e) {
+        echo "OK 7: ZVec clone blocked - " . $e->getMessage() . "\n";
+    }
+
+    // ===== Verify normal use (no clone) still works =====
+    // ZVecSchema — create and use
+    $s = new ZVecSchema('normal_use');
+    $s->addInt64('x', nullable: false);
+    $s = null;
+    echo "OK 8: ZVecSchema normal use works\n";
+
+    // ZVecIndexParams — create and use
+    $p = ZVecIndexParams::forHnsw(ZVecSchema::METRIC_IP, 16, 200);
+    $p = null;
+    echo "OK 9: ZVecIndexParams normal use works\n";
+
+    // ZVecVectorQuery — create and use
+    $q = new ZVecVectorQuery('v', [0.1, 0.2, 0.3, 0.4]);
+    $q = null;
+    echo "OK 10: ZVecVectorQuery normal use works\n";
+
+    // ZVecCollectionStats — create and use
+    $st = $c->getStatsStruct();
+    $count = $st->getDocCount();
+    $st = null;
+    echo "OK 11: ZVecCollectionStats normal use works (docCount=$count)\n";
+
+    // ZVecFieldSchema — create and use
+    $fs = $c->getFieldSchema('category');
+    $name = $fs->getName();
+    $fs = null;
+    echo "OK 12: ZVecFieldSchema normal use works (name=$name)\n";
+
+    // ZVecDoc — create and use
+    $d = new ZVecDoc('normal_doc');
+    $d->setInt64('category', 42);
+    $d = null;
+    echo "OK 13: ZVecDoc normal use works\n";
+
+    $c->close();
+
+    if ($allOk) {
+        echo "PASS: All clone-safety tests passed\n";
+    }
+} finally {
+    exec("rm -rf " . escapeshellarg($path));
+}
+?>
+--EXPECT--
+OK 1: ZVecSchema clone blocked - Call to private method ZVecSchema::__clone() from global scope
+OK 2: ZVecIndexParams clone blocked - Call to private method ZVecIndexParams::__clone() from global scope
+OK 3: ZVecVectorQuery clone blocked - Call to private method ZVecVectorQuery::__clone() from global scope
+OK 4: ZVecCollectionStats clone blocked - Call to private method ZVecCollectionStats::__clone() from global scope
+OK 5: ZVecFieldSchema clone blocked - Call to private method ZVecFieldSchema::__clone() from global scope
+OK 6: ZVecDoc clone blocked - Call to private method ZVecDoc::__clone() from global scope
+OK 7: ZVec clone blocked - Call to private method ZVec::__clone() from global scope
+OK 8: ZVecSchema normal use works
+OK 9: ZVecIndexParams normal use works
+OK 10: ZVecVectorQuery normal use works
+OK 11: ZVecCollectionStats normal use works (docCount=1)
+OK 12: ZVecFieldSchema normal use works (name=category)
+OK 13: ZVecDoc normal use works
+PASS: All clone-safety tests passed

--- a/tests/bug_0011.phpt
+++ b/tests/bug_0011.phpt
@@ -143,13 +143,13 @@ try {
 }
 ?>
 --EXPECT--
-OK 1: ZVecSchema clone blocked - Call to private method ZVecSchema::__clone() from global scope
-OK 2: ZVecIndexParams clone blocked - Call to private method ZVecIndexParams::__clone() from global scope
-OK 3: ZVecVectorQuery clone blocked - Call to private method ZVecVectorQuery::__clone() from global scope
-OK 4: ZVecCollectionStats clone blocked - Call to private method ZVecCollectionStats::__clone() from global scope
-OK 5: ZVecFieldSchema clone blocked - Call to private method ZVecFieldSchema::__clone() from global scope
-OK 6: ZVecDoc clone blocked - Call to private method ZVecDoc::__clone() from global scope
-OK 7: ZVec clone blocked - Call to private method ZVec::__clone() from global scope
+OK 1: ZVecSchema clone blocked - Call to private ZVecSchema::__clone() from global scope
+OK 2: ZVecIndexParams clone blocked - Call to private ZVecIndexParams::__clone() from global scope
+OK 3: ZVecVectorQuery clone blocked - Call to private ZVecVectorQuery::__clone() from global scope
+OK 4: ZVecCollectionStats clone blocked - Call to private ZVecCollectionStats::__clone() from global scope
+OK 5: ZVecFieldSchema clone blocked - Call to private ZVecFieldSchema::__clone() from global scope
+OK 6: ZVecDoc clone blocked - Call to private ZVecDoc::__clone() from global scope
+OK 7: ZVec clone blocked - Call to private ZVec::__clone() from global scope
 OK 8: ZVecSchema normal use works
 OK 9: ZVecIndexParams normal use works
 OK 10: ZVecVectorQuery normal use works


### PR DESCRIPTION
## Description

Adds `private function __clone()` to all 7 handle-holding classes (`ZVec`, `ZVecSchema`, `ZVecIndexParams`, `ZVecCollectionStats`, `ZVecFieldSchema`, `ZVecDoc`, `ZVecVectorQuery`) to prevent shallow copies that cause double-free on destruction.

Without this fix, cloning any of these objects creates a copy of the `FFI\\CData` handle pointer. When both the original and clone are destroyed, `_free()` is called twice on the same C pointer — undefined behavior, potential segfault.

## Changes

### src/ZVec.php
- Added `private function __clone() {}` to 7 classes after their `__destruct()` methods
- Each class holds `private/protected FFI\\CData ` and frees it in destructor

### tests/bug_0011.phpt (new)
- 13 test scenarios: 7 clone prevention tests + 6 normal use verification tests
- Uses proper .phpt format with try-finally cleanup

### CHANGELOG.md
- Added entry under Fixed section

## Testing

```
php run-tests.php tests/
...
Number of tests :    81                81
Tests passed    :    79 ( 97.5%) ( 97.5%)
Expected fail   :     2 (  2.5%) (  2.5%)
```

Closes #58