### PR TITLE
fix: extract shared writeDocs/writeDocsBatch helpers from insert/upsert/update (fix #85)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **SMELL-004: Triplicated Insert/Upsert/Update Code** (#85)
+  - Extracted shared `writeDocs()` and `writeDocsBatch()` private helpers from `insert()`, `upsert()`, `update()` and their batch variants
+  - Each public method is now a 1-line wrapper around the shared helper
+  - Eliminated ~74 lines of duplicated code — bug fixes to write logic now apply to all 6 operations at once
+  - Added `tests/test_write_helpers.phpt` — comprehensive test covering all 6 operations, error paths (duplicate insert, non-existent update)
+
 ### Fixed
 
 - **BUG-011: Clone-Safety Double-Free in Handle-Holding Classes** (#58)

--- a/src/ZVec.php
+++ b/src/ZVec.php
@@ -717,7 +717,7 @@ zvec_status_t zvec_collection_create_ivf_index(zvec_collection_t coll, const cha
         $this->createIndex($fieldName, ZVecIndexParams::forIvf($metricType, $nList, $nIters, $useSoar, $quantizeType), $concurrency);
     }
 
-    public function insert(ZVecDoc ...$docs): void
+    private function writeDocs(string $operation, ZVecDoc ...$docs): void
     {
         $this->checkClosed();
         $ffi = self::ffi();
@@ -726,37 +726,19 @@ zvec_status_t zvec_collection_create_ivf_index(zvec_collection_t coll, const cha
         foreach ($docs as $i => $doc) {
             $arr[$i] = $doc->getHandle();
         }
-        self::checkStatus($ffi->zvec_collection_insert($this->handle, $arr, $count));
+        self::checkStatus($ffi->{"zvec_collection_{$operation}"}($this->handle, $arr, $count));
     }
 
-    public function upsert(ZVecDoc ...$docs): void
-    {
-        $this->checkClosed();
-        $ffi = self::ffi();
-        $count = count($docs);
-        $arr = $ffi->new("zvec_doc_t[$count]");
-        foreach ($docs as $i => $doc) {
-            $arr[$i] = $doc->getHandle();
-        }
-        self::checkStatus($ffi->zvec_collection_upsert($this->handle, $arr, $count));
-    }
+    public function insert(ZVecDoc ...$docs): void { $this->writeDocs('insert', ...$docs); }
 
-    public function update(ZVecDoc ...$docs): void
-    {
-        $this->checkClosed();
-        $ffi = self::ffi();
-        $count = count($docs);
-        $arr = $ffi->new("zvec_doc_t[$count]");
-        foreach ($docs as $i => $doc) {
-            $arr[$i] = $doc->getHandle();
-        }
-        self::checkStatus($ffi->zvec_collection_update($this->handle, $arr, $count));
-    }
+    public function upsert(ZVecDoc ...$docs): void { $this->writeDocs('upsert', ...$docs); }
+
+    public function update(ZVecDoc ...$docs): void { $this->writeDocs('update', ...$docs); }
 
     /**
      * @return array<int, array{pk: string, ok: bool, error: string|null}>
      */
-    public function insertBatch(ZVecDoc ...$docs): array
+    private function writeDocsBatch(string $operation, ZVecDoc ...$docs): array
     {
         $this->checkClosed();
         $ffi = self::ffi();
@@ -765,10 +747,10 @@ zvec_status_t zvec_collection_create_ivf_index(zvec_collection_t coll, const cha
         foreach ($docs as $i => $doc) {
             $arr[$i] = $doc->getHandle();
         }
-        
+
         $result = $ffi->new('zvec_batch_result_t');
-        self::checkStatus($ffi->zvec_collection_insert_batch($this->handle, $arr, $count, FFI::addr($result)));
-        
+        self::checkStatus($ffi->{"zvec_collection_{$operation}_batch"}($this->handle, $arr, $count, FFI::addr($result)));
+
         $results = [];
         for ($i = 0; $i < $result->count; $i++) {
             $results[] = [
@@ -777,7 +759,7 @@ zvec_status_t zvec_collection_create_ivf_index(zvec_collection_t coll, const cha
                 'error' => $result->messages[$i] !== null ? FFI::string($result->messages[$i]) : null,
             ];
         }
-        
+
         $ffi->zvec_batch_result_free(FFI::addr($result));
         return $results;
     }
@@ -785,60 +767,17 @@ zvec_status_t zvec_collection_create_ivf_index(zvec_collection_t coll, const cha
     /**
      * @return array<int, array{pk: string, ok: bool, error: string|null}>
      */
-    public function upsertBatch(ZVecDoc ...$docs): array
-    {
-        $this->checkClosed();
-        $ffi = self::ffi();
-        $count = count($docs);
-        $arr = $ffi->new("zvec_doc_t[$count]");
-        foreach ($docs as $i => $doc) {
-            $arr[$i] = $doc->getHandle();
-        }
-        
-        $result = $ffi->new('zvec_batch_result_t');
-        self::checkStatus($ffi->zvec_collection_upsert_batch($this->handle, $arr, $count, FFI::addr($result)));
-        
-        $results = [];
-        for ($i = 0; $i < $result->count; $i++) {
-            $results[] = [
-                'pk' => FFI::string($result->doc_pks[$i]),
-                'ok' => $result->codes[$i] === 0,
-                'error' => $result->messages[$i] !== null ? FFI::string($result->messages[$i]) : null,
-            ];
-        }
-        
-        $ffi->zvec_batch_result_free(FFI::addr($result));
-        return $results;
-    }
+    public function insertBatch(ZVecDoc ...$docs): array { return $this->writeDocsBatch('insert', ...$docs); }
 
     /**
      * @return array<int, array{pk: string, ok: bool, error: string|null}>
      */
-    public function updateBatch(ZVecDoc ...$docs): array
-    {
-        $this->checkClosed();
-        $ffi = self::ffi();
-        $count = count($docs);
-        $arr = $ffi->new("zvec_doc_t[$count]");
-        foreach ($docs as $i => $doc) {
-            $arr[$i] = $doc->getHandle();
-        }
-        
-        $result = $ffi->new('zvec_batch_result_t');
-        self::checkStatus($ffi->zvec_collection_update_batch($this->handle, $arr, $count, FFI::addr($result)));
-        
-        $results = [];
-        for ($i = 0; $i < $result->count; $i++) {
-            $results[] = [
-                'pk' => FFI::string($result->doc_pks[$i]),
-                'ok' => $result->codes[$i] === 0,
-                'error' => $result->messages[$i] !== null ? FFI::string($result->messages[$i]) : null,
-            ];
-        }
-        
-        $ffi->zvec_batch_result_free(FFI::addr($result));
-        return $results;
-    }
+    public function upsertBatch(ZVecDoc ...$docs): array { return $this->writeDocsBatch('upsert', ...$docs); }
+
+    /**
+     * @return array<int, array{pk: string, ok: bool, error: string|null}>
+     */
+    public function updateBatch(ZVecDoc ...$docs): array { return $this->writeDocsBatch('update', ...$docs); }
 
     public function delete(string ...$pks): void
     {

--- a/tests/test_write_helpers.phpt
+++ b/tests/test_write_helpers.phpt
@@ -1,0 +1,155 @@
+--TEST--
+SMELL-004: Extracted writeDocs/writeDocsBatch helpers — all 6 operations work correctly
+--SKIPIF--
+<?php if (!extension_loaded('zvec') && !extension_loaded('ffi')) die('skip Neither zvec extension nor FFI available'); ?>
+--FILE--
+<?php
+require_once __DIR__ . '/../src/ZVec.php';
+
+ZVec::init(logType: ZVec::LOG_CONSOLE, logLevel: ZVec::LOG_WARN);
+
+$path = __DIR__ . '/../test_dbs/write_helpers_' . uniqid();
+
+try {
+    // ===== Create collection =====
+    $schema = new ZVecSchema('write_test');
+    $schema->setMaxDocCountPerSegment(1000)
+        ->addInt64('id', nullable: false, withInvertIndex: true)
+        ->addString('name', nullable: true, withInvertIndex: true)
+        ->addFloat('score', nullable: true)
+        ->addVectorFp32('embedding', dimension: 4, metricType: ZVecSchema::METRIC_IP);
+
+    $c = ZVec::create($path, $schema);
+    $c->createHnswIndex('embedding', metricType: ZVecSchema::METRIC_IP, m: 16, efConstruction: 200);
+
+    // ===== 1. insert() =====
+    $docInsert = new ZVecDoc('insert_doc');
+    $docInsert->setInt64('id', 1)
+        ->setString('name', 'Inserted')
+        ->setFloat('score', 10.0)
+        ->setVectorFp32('embedding', [1.0, 0.0, 0.0, 0.0]);
+    $c->insert($docInsert);
+    echo "insert() OK\n";
+
+    // ===== 2. upsert() — new doc =====
+    $docUpsertNew = new ZVecDoc('upsert_new');
+    $docUpsertNew->setInt64('id', 2)
+        ->setString('name', 'Upsert New')
+        ->setFloat('score', 20.0)
+        ->setVectorFp32('embedding', [0.0, 1.0, 0.0, 0.0]);
+    $c->upsert($docUpsertNew);
+    echo "upsert() new doc OK\n";
+
+    // ===== 3. upsert() — existing doc (update) =====
+    $docUpsertExisting = new ZVecDoc('insert_doc');
+    $docUpsertExisting->setInt64('id', 1)
+        ->setFloat('score', 15.0)
+        ->setString('name', 'Inserted Updated')
+        ->setVectorFp32('embedding', [0.9, 0.1, 0.0, 0.0]);
+    $c->upsert($docUpsertExisting);
+    echo "upsert() existing doc OK\n";
+
+    // ===== 4. update() =====
+    $docUpdate = new ZVecDoc('insert_doc');
+    $docUpdate->setInt64('id', 1)
+        ->setFloat('score', 99.0);
+    $c->update($docUpdate);
+    echo "update() OK\n";
+
+    // ===== Verify single-doc operations =====
+    $fetched = $c->fetch('insert_doc', 'upsert_new');
+    $docsByPk = [];
+    foreach ($fetched as $d) {
+        $docsByPk[$d->getPk()] = $d;
+    }
+    assert(isset($docsByPk['insert_doc']), 'insert_doc should exist');
+    assert($docsByPk['insert_doc']->getFloat('score') === 99.0, 'insert_doc score should be 99.0 (updated)');
+    assert($docsByPk['insert_doc']->getString('name') === 'Inserted Updated', 'insert_doc name should be "Inserted Updated" (upserted)');
+    assert(isset($docsByPk['upsert_new']), 'upsert_new should exist');
+    assert($docsByPk['upsert_new']->getFloat('score') === 20.0, 'upsert_new score should be 20.0');
+    echo "Single-doc verify OK\n";
+
+    // ===== 5. insertBatch() =====
+    $b1 = new ZVecDoc('batch1');
+    $b1->setInt64('id', 10)->setString('name', 'Batch1')->setFloat('score', 100.0)
+        ->setVectorFp32('embedding', [0.1, 0.0, 0.0, 0.0]);
+    $b2 = new ZVecDoc('batch2');
+    $b2->setInt64('id', 11)->setString('name', 'Batch2')->setFloat('score', 200.0)
+        ->setVectorFp32('embedding', [0.0, 0.1, 0.0, 0.0]);
+    $results = $c->insertBatch($b1, $b2);
+    assert(count($results) === 2, 'insertBatch should return 2 results');
+    assert($results[0]['ok'] === true, 'batch1 insert should succeed');
+    assert($results[1]['ok'] === true, 'batch2 insert should succeed');
+    echo "insertBatch() OK\n";
+
+    // ===== 6. upsertBatch() =====
+    $ub1 = new ZVecDoc('batch1');
+    $ub1->setInt64('id', 10)->setFloat('score', 150.0)->setVectorFp32('embedding', [0.1, 0.0, 0.0, 0.0]);
+    $ub2 = new ZVecDoc('batch3');
+    $ub2->setInt64('id', 12)->setString('name', 'Batch3')->setFloat('score', 300.0)
+        ->setVectorFp32('embedding', [0.0, 0.0, 0.1, 0.0]);
+    $results = $c->upsertBatch($ub1, $ub2);
+    assert(count($results) === 2, 'upsertBatch should return 2 results');
+    assert($results[0]['pk'] === 'batch1', 'first result pk should be batch1');
+    assert($results[1]['pk'] === 'batch3', 'second result pk should be batch3');
+    echo "upsertBatch() OK\n";
+
+    // ===== 7. updateBatch() =====
+    $up1 = new ZVecDoc('batch1');
+    $up1->setInt64('id', 10)->setFloat('score', 175.0);
+    $up2 = new ZVecDoc('batch2');
+    $up2->setInt64('id', 11)->setFloat('score', 250.0);
+    $results = $c->updateBatch($up1, $up2);
+    assert(count($results) === 2, 'updateBatch should return 2 results');
+    assert($results[0]['ok'] === true, 'batch1 update should succeed');
+    assert($results[1]['ok'] === true, 'batch2 update should succeed');
+    echo "updateBatch() OK\n";
+
+    // ===== Verify batch operations =====
+    $fetched = $c->fetch('batch1', 'batch2', 'batch3');
+    $docs = [];
+    foreach ($fetched as $d) {
+        $docs[$d->getPk()] = $d;
+    }
+    assert($docs['batch1']->getFloat('score') === 175.0, 'batch1 score should be 175.0 (updated)');
+    assert($docs['batch2']->getFloat('score') === 250.0, 'batch2 score should be 250.0 (updated)');
+    assert($docs['batch3']->getFloat('score') === 300.0, 'batch3 score should be 300.0 (upserted)');
+    echo "Batch verify OK\n";
+
+    // ===== 8. insertBatch with duplicate (error path) =====
+    $dup = new ZVecDoc('batch1');
+    $dup->setInt64('id', 10)->setFloat('score', 999.0)
+        ->setVectorFp32('embedding', [0.5, 0.5, 0.5, 0.5]);
+    $results = $c->insertBatch($dup);
+    assert($results[0]['ok'] === false, 'duplicate insert should fail');
+    assert($results[0]['error'] !== null, 'duplicate should have error message');
+    echo "insertBatch() duplicate error OK\n";
+
+    // ===== 9. updateBatch with non-existent doc (error path) =====
+    $nonExistent = new ZVecDoc('does_not_exist');
+    $nonExistent->setInt64('id', 999)->setFloat('score', 0.0);
+    $results = $c->updateBatch($nonExistent);
+    assert($results[0]['ok'] === false, 'update non-existent should fail');
+    echo "updateBatch() non-existent error OK\n";
+
+    $c->close();
+
+    echo "\nPASS: All write helpers pass\n";
+} finally {
+    exec("rm -rf " . escapeshellarg($path));
+}
+?>
+--EXPECT--
+insert() OK
+upsert() new doc OK
+upsert() existing doc OK
+update() OK
+Single-doc verify OK
+insertBatch() OK
+upsertBatch() OK
+updateBatch() OK
+Batch verify OK
+insertBatch() duplicate error OK
+updateBatch() non-existent error OK
+
+PASS: All write helpers pass


### PR DESCRIPTION
## Description

Eliminates ~74 lines of duplicated code in `insert()`, `upsert()`, `update()` and their batch variants by extracting shared private helper methods.

## Changes

### `src/ZVec.php`
- Added `writeDocs(string $operation, ZVecDoc ...$docs): void` — shared helper for single-doc operations
- Added `writeDocsBatch(string $operation, ZVecDoc ...$docs): array` — shared helper for batch operations
- `insert()`, `upsert()`, `update()` → 1-line wrappers around `writeDocs()`
- `insertBatch()`, `upsertBatch()`, `updateBatch()` → 1-line wrappers around `writeDocsBatch()`

### Tests
- Added `tests/test_write_helpers.phpt` — comprehensive coverage of all 6 operations including error paths

### Changelog
- Added `### Changed` entry for SMELL-004

## Testing
- All 82 tests pass (79 pass + 2 xfail + 1 pre-existing bug_0011 failure unrelated to this change)
- `php run-tests.php tests/` — ✅

Closes #85