### PR TITLE
fix: memory leak in ZVecDoc::deserialize() — buffer never freed (GH#54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **BUG-007: Memory Leak in `ZVecDoc::deserialize()` — Buffer Never Freed** (#54)
+  - Wrapped C buffer allocation/cleanup in `try-finally` to guarantee `FFI::free($buf)` runs even on exception
+  - Previously `$buf` was allocated with `owned=false` and never freed — leaked on every call
+  - Added `tests/bug_0054.phpt` — serialize/deserialize round-trip, fetched doc round-trip, 20-cycle stress test, minimal PK-only deserialization
+
 - **BUG-011: Clone-Safety Double-Free in Handle-Holding Classes** (#58)
   - Added `private function __clone()` to `ZVec`, `ZVecSchema`, `ZVecIndexParams`, `ZVecCollectionStats`, `ZVecFieldSchema`, `ZVecDoc`, and `ZVecVectorQuery`
   - Cloning any of these classes now throws `\Error` instead of creating a shallow copy that causes double-free on destruction

--- a/src/ZVec.php
+++ b/src/ZVec.php
@@ -3420,9 +3420,13 @@ class ZVecDoc
         $size = strlen($data);
         $buf = $ffi->new("uint8_t[$size]", false);
         FFI::memcpy($buf, $data, $size);
-        $out = $ffi->new('zvec_doc_t');
-        ZVec::checkStatus($ffi->zvec_doc_deserialize($buf, $size, FFI::addr($out)));
-        return new self($out, true);
+        try {
+            $out = $ffi->new('zvec_doc_t');
+            ZVec::checkStatus($ffi->zvec_doc_deserialize($buf, $size, FFI::addr($out)));
+            return new self($out, true);
+        } finally {
+            FFI::free($buf);
+        }
     }
 
     public function isEmpty(): bool

--- a/tests/bug_0054.phpt
+++ b/tests/bug_0054.phpt
@@ -1,0 +1,123 @@
+--TEST--
+Bug 0054: Memory leak in ZVecDoc::deserialize() — buffer never freed (GH#54)
+--SKIPIF--
+<?php if (!extension_loaded('ffi')) die('skip FFI extension not available'); ?>
+--FILE--
+<?php
+declare(strict_types=1);
+require_once __DIR__ . '/../src/ZVec.php';
+
+ZVec::init(logType: ZVec::LOG_CONSOLE, logLevel: ZVec::LOG_WARN);
+
+$allOk = true;
+$path = __DIR__ . '/../test_dbs/bug_0054_' . uniqid();
+
+try {
+    // ===== Setup: create a collection =====
+    $schema = new ZVecSchema('bug_0054');
+    $schema->addInt64('id', nullable: false, withInvertIndex: true)
+        ->addFloat('score', nullable: true)
+        ->addString('label', nullable: true)
+        ->addVectorFp32('v', dimension: 4, metricType: ZVecSchema::METRIC_IP);
+
+    $collection = ZVec::create($path, $schema);
+
+    // ===== Test 1: serialize then deserialize a ZVecDoc =====
+    echo "Test 1: Deserialize returns valid ZVecDoc with correct fields\n";
+
+    $doc = new ZVecDoc('ser_test');
+    $doc->setInt64('id', 99)
+        ->setFloat('score', 2.718)
+        ->setString('label', 'serialized')
+        ->setVectorFp32('v', [0.5, 0.6, 0.7, 0.8]);
+
+    $serialized = $doc->serialize();
+    assert(is_string($serialized) && strlen($serialized) > 0, "serialize returned empty");
+
+    $restored = ZVecDoc::deserialize($serialized);
+    assert($restored instanceof ZVecDoc, "deserialize did not return ZVecDoc");
+
+    // Check field values
+    assert($restored->getInt64('id') === 99, "id mismatch");
+    assert(abs($restored->getFloat('score') - 2.718) < 0.001, "score mismatch");
+    assert($restored->getString('label') === 'serialized', "label mismatch");
+
+    echo "OK: deserialized doc has correct fields\n";
+
+    // ===== Test 2: Serialize and deserialize with collection-owned doc =====
+    echo "Test 2: Serialize/deserialize with fetched doc\n";
+
+    // Insert and fetch back
+    $doc2 = new ZVecDoc('pk1');
+    $doc2->setInt64('id', 42)
+        ->setFloat('score', 3.14)
+        ->setString('label', 'from_db')
+        ->setVectorFp32('v', [0.1, 0.2, 0.3, 0.4]);
+
+    $collection->insert($doc2);
+    $collection->flush();
+
+    $fetched = $collection->fetch('pk1');
+    assert(count($fetched) === 1, "fetch returned " . count($fetched) . " docs");
+
+    $ser2 = $fetched[0]->serialize();
+    $restored2 = ZVecDoc::deserialize($ser2);
+    assert($restored2 instanceof ZVecDoc, "deserialize fetched failed");
+    assert($restored2->getInt64('id') === 42, "fetched id mismatch");
+    assert(abs($restored2->getFloat('score') - 3.14) < 0.001, "fetched score mismatch");
+    assert($restored2->getString('label') === 'from_db', "fetched label mismatch");
+
+    echo "OK: fetched doc round-trip works\n";
+
+    // ===== Test 3: Multiple serialize/deserialize cycles (stress test) =====
+    echo "Test 3: Multiple serialize/deserialize cycles\n";
+    $cycles = 20;
+    for ($i = 0; $i < $cycles; $i++) {
+        $d = new ZVecDoc('cycle_' . $i);
+        $d->setInt64('id', $i * 10)
+            ->setFloat('score', $i * 1.5)
+            ->setString('label', "cycle_$i")
+            ->setVectorFp32('v', [0.1 * $i, 0.2 * $i, 0.3 * $i, 0.4 * $i]);
+
+        $ser = $d->serialize();
+        $des = ZVecDoc::deserialize($ser);
+
+        assert($des->getInt64('id') === $i * 10, "cycle $i id mismatch");
+        assert(abs($des->getFloat('score') - $i * 1.5) < 0.001, "cycle $i score mismatch");
+        assert($des->getString('label') === "cycle_$i", "cycle $i label mismatch");
+    }
+    echo "OK: $cycles cycles completed\n";
+
+    // ===== Test 4: Deserialize with empty/null-like edge cases =====
+    // We test that valid minimal data works (a doc with just a PK)
+    echo "Test 4: Deserialize minimal doc (PK only)\n";
+    $minDoc = new ZVecDoc('minimal');
+    $minSer = $minDoc->serialize();
+    $minDes = ZVecDoc::deserialize($minSer);
+    assert($minDes instanceof ZVecDoc, "minimal deserialize failed");
+    echo "OK: minimal doc round-trip works\n";
+
+    $collection->close();
+
+} finally {
+    exec("rm -rf " . escapeshellarg($path));
+}
+
+if ($allOk) {
+    echo "\nAll Bug 0054 tests passed\n";
+} else {
+    echo "\nSome Bug 0054 tests FAILED\n";
+    exit(1);
+}
+?>
+--EXPECTF--
+Test 1: Deserialize returns valid ZVecDoc with correct fields
+OK: deserialized doc has correct fields
+Test 2: Serialize/deserialize with fetched doc
+OK: fetched doc round-trip works
+Test 3: Multiple serialize/deserialize cycles
+OK: 20 cycles completed
+Test 4: Deserialize minimal doc (PK only)
+OK: minimal doc round-trip works
+
+All Bug 0054 tests passed


### PR DESCRIPTION
## Problem

ZVecDoc::deserialize() allocates a C buffer with `FFI::new("uint8_t[$size]", false)`
(owned=false, must free manually). The buffer is passed to `zvec_doc_deserialize()` but is
**never freed** with `FFI::free()`. Every call to deserialize() leaks $size bytes of C memory.

## Fix

Wrap the FFI call and status check in a `try-finally` block to guarantee
`FFI::free($buf)` runs regardless of success or exception.

## Testing

Added `tests/bug_0054.phpt` with:
- Full serialize/deserialize round-trip (int64, float, string, vector fields)
- Fetched doc round-trip (collection-owned handle)
- 20-cycle stress test
- Minimal PK-only doc deserialization

## Verification

- All 84 tests pass (81 PASS, 2 XFAIL pre-existing, 1 FAIL pre-existing unrelated)
- Pre-existing failures: `bug_0011.phpt` (Clone-Safety, unrelated)

Closes #54