### PR TITLE
SMELL-016: Drop Field prefix from schema field methods

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,6 +208,19 @@ PHP 8.1+ required. Always use `declare(strict_types=1);` at the top of every fil
 | Parameters         | camelCase         | `$fieldName`, `$queryVector`        |
 | Private properties | camelCase (no `_` prefix) | `$handle`, `$closed`       |
 
+#### Schema Field Method Conventions
+
+`ZVecSchema` uses four naming patterns for field-adding methods:
+
+| Pattern | Examples | Description |
+|---------|----------|-------------|
+| `add<Type>()` | `addInt64()`, `addString()`, `addBool()`, `addBinary()` | Scalar and primitive types — no prefix |
+| `addArray<Type>()` | `addArrayInt32()`, `addArrayString()`, `addArrayBool()` | Array types — `Array` infix |
+| `addVector<Type>()` | `addVectorFp32()`, `addVectorBinary64()` | Dense vector types — `Vector` prefix |
+| `addSparseVector<Type>()` | `addSparseVectorFp32()`, `addSparseVectorFp16()` | Sparse vector types — `SparseVector` prefix |
+
+The deprecated `addField*()` methods (`addFieldBinary()`, `addFieldArrayString()`, etc.) remain as backward-compatible aliases that emit `E_USER_DEPRECATED` warnings.
+
 ### Type System
 
 - Use full type declarations on all properties, parameters, and return types.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **SMELL-016: Dropped `Field` prefix from schema field methods** (#107)
+  - New unprefixed methods: `addBinary()`, `addArrayString()`, `addArrayBool()`,
+    `addArrayInt32()`, `addArrayInt64()`, `addArrayUint32()`, `addArrayUint64()`,
+    `addArrayFloat()`, `addArrayDouble()`
+  - All existing `addField*()` methods remain as deprecated aliases
+  - Updated all internal call sites to use new method names
+
+### Deprecated
+
+- `addFieldBinary()` — use `addBinary()` instead
+- `addFieldArrayString()` — use `addArrayString()` instead
+- `addFieldArrayBool()` — use `addArrayBool()` instead
+- `addFieldArrayInt32()` — use `addArrayInt32()` instead
+- `addFieldArrayInt64()` — use `addArrayInt64()` instead
+- `addFieldArrayUint32()` — use `addArrayUint32()` instead
+- `addFieldArrayUint64()` — use `addArrayUint64()` instead
+- `addFieldArrayFloat()` — use `addArrayFloat()` instead
+- `addFieldArrayDouble()` — use `addArrayDouble()` instead
+
 ### Security
 
 - **SEC-002: Replace predictable tempnam() with cryptographically random temp directory to prevent symlink race** (#71)

--- a/src/ZVec.php
+++ b/src/ZVec.php
@@ -2467,55 +2467,118 @@ class ZVecSchema
         return $this;
     }
 
+    /** @deprecated Use addBinary() instead */
     public function addFieldBinary(string $name, bool $nullable = true): self
+    {
+        trigger_error('addFieldBinary() is deprecated, use addBinary() instead', E_USER_DEPRECATED);
+        return $this->addBinary($name, $nullable);
+    }
+
+    public function addBinary(string $name, bool $nullable = true): self
     {
         self::ffi()->zvec_schema_add_field_binary($this->handle, $name, $nullable ? 1 : 0);
         return $this;
     }
 
+    /** @deprecated Use addArrayString() instead */
     public function addFieldArrayString(string $name, bool $nullable = true): self
+    {
+        trigger_error('addFieldArrayString() is deprecated, use addArrayString() instead', E_USER_DEPRECATED);
+        return $this->addArrayString($name, $nullable);
+    }
+
+    public function addArrayString(string $name, bool $nullable = true): self
     {
         self::ffi()->zvec_schema_add_field_array_string($this->handle, $name, $nullable ? 1 : 0);
         return $this;
     }
 
+    /** @deprecated Use addArrayBool() instead */
     public function addFieldArrayBool(string $name, bool $nullable = true): self
+    {
+        trigger_error('addFieldArrayBool() is deprecated, use addArrayBool() instead', E_USER_DEPRECATED);
+        return $this->addArrayBool($name, $nullable);
+    }
+
+    public function addArrayBool(string $name, bool $nullable = true): self
     {
         self::ffi()->zvec_schema_add_field_array_bool($this->handle, $name, $nullable ? 1 : 0);
         return $this;
     }
 
+    /** @deprecated Use addArrayInt32() instead */
     public function addFieldArrayInt32(string $name, bool $nullable = true): self
+    {
+        trigger_error('addFieldArrayInt32() is deprecated, use addArrayInt32() instead', E_USER_DEPRECATED);
+        return $this->addArrayInt32($name, $nullable);
+    }
+
+    public function addArrayInt32(string $name, bool $nullable = true): self
     {
         self::ffi()->zvec_schema_add_field_array_int32($this->handle, $name, $nullable ? 1 : 0);
         return $this;
     }
 
+    /** @deprecated Use addArrayInt64() instead */
     public function addFieldArrayInt64(string $name, bool $nullable = true): self
+    {
+        trigger_error('addFieldArrayInt64() is deprecated, use addArrayInt64() instead', E_USER_DEPRECATED);
+        return $this->addArrayInt64($name, $nullable);
+    }
+
+    public function addArrayInt64(string $name, bool $nullable = true): self
     {
         self::ffi()->zvec_schema_add_field_array_int64($this->handle, $name, $nullable ? 1 : 0);
         return $this;
     }
 
+    /** @deprecated Use addArrayUint32() instead */
     public function addFieldArrayUint32(string $name, bool $nullable = true): self
+    {
+        trigger_error('addFieldArrayUint32() is deprecated, use addArrayUint32() instead', E_USER_DEPRECATED);
+        return $this->addArrayUint32($name, $nullable);
+    }
+
+    public function addArrayUint32(string $name, bool $nullable = true): self
     {
         self::ffi()->zvec_schema_add_field_array_uint32($this->handle, $name, $nullable ? 1 : 0);
         return $this;
     }
 
+    /** @deprecated Use addArrayUint64() instead */
     public function addFieldArrayUint64(string $name, bool $nullable = true): self
+    {
+        trigger_error('addFieldArrayUint64() is deprecated, use addArrayUint64() instead', E_USER_DEPRECATED);
+        return $this->addArrayUint64($name, $nullable);
+    }
+
+    public function addArrayUint64(string $name, bool $nullable = true): self
     {
         self::ffi()->zvec_schema_add_field_array_uint64($this->handle, $name, $nullable ? 1 : 0);
         return $this;
     }
 
+    /** @deprecated Use addArrayFloat() instead */
     public function addFieldArrayFloat(string $name, bool $nullable = true): self
+    {
+        trigger_error('addFieldArrayFloat() is deprecated, use addArrayFloat() instead', E_USER_DEPRECATED);
+        return $this->addArrayFloat($name, $nullable);
+    }
+
+    public function addArrayFloat(string $name, bool $nullable = true): self
     {
         self::ffi()->zvec_schema_add_field_array_float($this->handle, $name, $nullable ? 1 : 0);
         return $this;
     }
 
+    /** @deprecated Use addArrayDouble() instead */
     public function addFieldArrayDouble(string $name, bool $nullable = true): self
+    {
+        trigger_error('addFieldArrayDouble() is deprecated, use addArrayDouble() instead', E_USER_DEPRECATED);
+        return $this->addArrayDouble($name, $nullable);
+    }
+
+    public function addArrayDouble(string $name, bool $nullable = true): self
     {
         self::ffi()->zvec_schema_add_field_array_double($this->handle, $name, $nullable ? 1 : 0);
         return $this;

--- a/tests/test_field_schema.phpt
+++ b/tests/test_field_schema.phpt
@@ -22,8 +22,8 @@ try {
         ->addVectorFp16('vecf16', dimension: 16, metricType: ZVecSchema::METRIC_L2)
         ->addVectorInt8('veci8', dimension: 32, metricType: ZVecSchema::METRIC_IP)
         ->addSparseVectorFp32('sparse', metricType: ZVecSchema::METRIC_IP)
-        ->addFieldArrayInt32('arr_i32')
-        ->addFieldArrayString('arr_str');
+        ->addArrayInt32('arr_i32')
+        ->addArrayString('arr_str');
     $c = ZVec::create($path, $schema);
 
     // Test 1: Basic scalar field introspection

--- a/tests/test_new_types_array.phpt
+++ b/tests/test_new_types_array.phpt
@@ -10,14 +10,14 @@ $path = __DIR__ . '/../test_dbs/array_' . uniqid();
 try {
     $schema = new ZVecSchema('test');
     $schema->addVectorFp32('vec', dimension: 4, metricType: ZVecSchema::METRIC_IP);
-    $schema->addFieldArrayInt32('i32');
-    $schema->addFieldArrayInt64('i64');
-    $schema->addFieldArrayUint32('u32');
-    $schema->addFieldArrayUint64('u64');
-    $schema->addFieldArrayFloat('f32');
-    $schema->addFieldArrayDouble('f64');
-    $schema->addFieldArrayString('strs');
-    $schema->addFieldArrayBool('bools');
+    $schema->addArrayInt32('i32');
+    $schema->addArrayInt64('i64');
+    $schema->addArrayUint32('u32');
+    $schema->addArrayUint64('u64');
+    $schema->addArrayFloat('f32');
+    $schema->addArrayDouble('f64');
+    $schema->addArrayString('strs');
+    $schema->addArrayBool('bools');
     $coll = ZVec::create($path, $schema);
 
     $doc = new ZVecDoc('d1');

--- a/tests/test_new_types_binary.phpt
+++ b/tests/test_new_types_binary.phpt
@@ -10,7 +10,7 @@ $path = __DIR__ . '/../test_dbs/binary_' . uniqid();
 try {
     $schema = new ZVecSchema('test');
     $schema->addVectorFp32('vec', dimension: 4, metricType: ZVecSchema::METRIC_IP);
-    $schema->addFieldBinary('bin');
+    $schema->addBinary('bin');
     $coll = ZVec::create($path, $schema);
 
     $doc = new ZVecDoc('d1');

--- a/tests/test_new_types_e2e.phpt
+++ b/tests/test_new_types_e2e.phpt
@@ -11,9 +11,9 @@ try {
     $schema = new ZVecSchema('test');
     $schema->addVectorFp32('fp32', dimension: 4, metricType: ZVecSchema::METRIC_IP);
     $schema->addSparseVectorFp16('sv16', metricType: ZVecSchema::METRIC_IP);
-    $schema->addFieldBinary('bin');
-    $schema->addFieldArrayInt32('ids');
-    $schema->addFieldArrayString('tags');
+    $schema->addBinary('bin');
+    $schema->addArrayInt32('ids');
+    $schema->addArrayString('tags');
     $coll = ZVec::create($path, $schema);
 
     $doc = new ZVecDoc('d1');

--- a/tests/test_schema_naming.phpt
+++ b/tests/test_schema_naming.phpt
@@ -1,0 +1,187 @@
+--TEST--
+Schema naming: new unprefixed methods produce identical schema; deprecated addField*() delegates with warning
+--SKIPIF--
+<?php if (!extension_loaded('ffi')) die('skip FFI extension not available'); ?>
+--FILE--
+<?php
+require_once __DIR__ . '/../src/ZVec.php';
+ZVec::init(logType: ZVec::LOG_CONSOLE, logLevel: ZVec::LOG_WARN);
+
+$path = __DIR__ . '/../test_dbs/schema_naming_' . uniqid();
+try {
+    // Test 1: New unprefixed methods produce identical schema (binary field)
+    $schema1 = new ZVecSchema('test');
+    $schema1->addVectorFp32('vec', dimension: 4, metricType: ZVecSchema::METRIC_IP);
+    $schema1->addBinary('bin');
+
+    $schema2 = new ZVecSchema('test');
+    $schema2->addVectorFp32('vec', dimension: 4, metricType: ZVecSchema::METRIC_IP);
+    set_error_handler(function () { return true; }); // suppress deprecation warning
+    $schema2->addFieldBinary('bin');
+    restore_error_handler();
+
+    $coll1 = ZVec::create($path . '_1', $schema1);
+    $fs1 = $coll1->getFieldSchema('bin');
+    $coll1->destroy();
+
+    $coll2 = ZVec::create($path . '_2', $schema2);
+    $fs2 = $coll2->getFieldSchema('bin');
+    $coll2->destroy();
+
+    echo "1 binary type match: " . ($fs1->getDataType() === $fs2->getDataType() ? '1' : '0') . "\n";
+    echo "2 binary nullable match: " . ($fs1->isNullable() === $fs2->isNullable() ? '1' : '0') . "\n";
+
+    // Test 2: Array fields
+    $schema3 = new ZVecSchema('test');
+    $schema3->addVectorFp32('vec', dimension: 4, metricType: ZVecSchema::METRIC_IP);
+    $schema3->addArrayInt32('i32');
+    $schema3->addArrayInt64('i64');
+    $schema3->addArrayUint32('u32');
+    $schema3->addArrayUint64('u64');
+    $schema3->addArrayFloat('f32');
+    $schema3->addArrayDouble('f64');
+    $schema3->addArrayString('strs');
+    $schema3->addArrayBool('bools');
+
+    $schema4 = new ZVecSchema('test');
+    $schema4->addVectorFp32('vec', dimension: 4, metricType: ZVecSchema::METRIC_IP);
+    set_error_handler(function () { return true; }); // suppress deprecation warnings
+    $schema4->addFieldArrayInt32('i32');
+    $schema4->addFieldArrayInt64('i64');
+    $schema4->addFieldArrayUint32('u32');
+    $schema4->addFieldArrayUint64('u64');
+    $schema4->addFieldArrayFloat('f32');
+    $schema4->addFieldArrayDouble('f64');
+    $schema4->addFieldArrayString('strs');
+    $schema4->addFieldArrayBool('bools');
+    restore_error_handler();
+
+    $coll3 = ZVec::create($path . '_3', $schema3);
+    $coll4 = ZVec::create($path . '_4', $schema4);
+
+    $types = ['i32', 'i64', 'u32', 'u64', 'f32', 'f64', 'strs', 'bools'];
+    $allMatch = true;
+    foreach ($types as $t) {
+        $fs3 = $coll3->getFieldSchema($t);
+        $fs4 = $coll4->getFieldSchema($t);
+        if ($fs3->getDataType() !== $fs4->getDataType() || $fs3->isNullable() !== $fs4->isNullable()) {
+            $allMatch = false;
+            echo "MISMATCH on $t\n";
+        }
+    }
+    echo "3 array types all match: " . ($allMatch ? '1' : '0') . "\n";
+    $coll3->destroy();
+    $coll4->destroy();
+
+    // Test 3-4: All 9 deprecated addField*() methods emit E_USER_DEPRECATED
+    $deprecatedMethods = [
+        ['addFieldBinary', 'bin'],
+        ['addFieldArrayString', 'strs'],
+        ['addFieldArrayBool', 'flags'],
+        ['addFieldArrayInt32', 'i32'],
+        ['addFieldArrayInt64', 'i64'],
+        ['addFieldArrayUint32', 'u32'],
+        ['addFieldArrayUint64', 'u64'],
+        ['addFieldArrayFloat', 'f32'],
+        ['addFieldArrayDouble', 'f64'],
+    ];
+    $allDeprecated = true;
+    foreach ($deprecatedMethods as $i => [$method, $fieldName]) {
+        $caught = false;
+        set_error_handler(function ($errno, $errstr) use ($method, &$caught) {
+            if ($errno === E_USER_DEPRECATED && str_contains($errstr, $method)) {
+                $caught = true;
+            }
+            return true;
+        });
+        $s = new ZVecSchema('test');
+        $s->addVectorFp32('vec', dimension: 4, metricType: ZVecSchema::METRIC_IP);
+        $s->$method($fieldName);
+        restore_error_handler();
+        if (!$caught) {
+            $allDeprecated = false;
+            echo "MISSING DEPRECATION: $method\n";
+        }
+    }
+    echo "4 all deprecated warnings: " . ($allDeprecated ? '1' : '0') . "\n";
+    echo "5 deprecated count: " . count($deprecatedMethods) . "\n";
+
+    // Test 5 (renumbered): Deprecated methods still produce valid schema (round-trip via deprecated API)
+    $schema7 = new ZVecSchema('test');
+    $schema7->addVectorFp32('vec', dimension: 4, metricType: ZVecSchema::METRIC_IP);
+    set_error_handler(function () { return true; });
+    $schema7->addFieldBinary('bin');
+    $schema7->addFieldArrayString('tags');
+    $schema7->addFieldArrayBool('flags');
+    $schema7->addFieldArrayInt32('counts');
+    $schema7->addFieldArrayInt64('big_ids');
+    $schema7->addFieldArrayUint32('uids');
+    $schema7->addFieldArrayUint64('u64s');
+    $schema7->addFieldArrayFloat('scores');
+    $schema7->addFieldArrayDouble('vals');
+    restore_error_handler();
+    $coll7 = ZVec::create($path . '_7', $schema7);
+    $doc = new ZVecDoc('d1');
+    $doc->setVectorFp32('vec', [1.0, 0.0, 0.0, 0.0]);
+    $doc->setBinary('bin', "\x00\x01");
+    $doc->setArrayString('tags', ['a', 'b']);
+    $doc->setArrayBool('flags', [true, false]);
+    $doc->setArrayInt32('counts', [1, 2, 3]);
+    $doc->setArrayInt64('big_ids', [1000, 2000]);
+    $doc->setArrayUint32('uids', [10, 20]);
+    $doc->setArrayUint64('u64s', [100, 200]);
+    $doc->setArrayFloat('scores', [1.5, 2.5]);
+    $doc->setArrayDouble('vals', [3.14, 2.72]);
+    $coll7->insert($doc);
+    $fetched = $coll7->fetch('d1');
+    $d = $fetched[0];
+    echo "6 deprecated round-trip bin: " . bin2hex($d->getBinary('bin')) . "\n";
+    echo "7 deprecated round-trip tags: " . implode(',', $d->getArrayString('tags')) . "\n";
+    echo "8 deprecated round-trip flags: " . implode(',', array_map(fn($v) => $v ? '1' : '0', $d->getArrayBool('flags'))) . "\n";
+    echo "9 deprecated round-trip counts: " . implode(',', $d->getArrayInt32('counts')) . "\n";
+    echo "10 deprecated round-trip big_ids: " . implode(',', $d->getArrayInt64('big_ids')) . "\n";
+    echo "11 deprecated round-trip uids: " . implode(',', $d->getArrayUint32('uids')) . "\n";
+    echo "12 deprecated round-trip u64s: " . implode(',', $d->getArrayUint64('u64s')) . "\n";
+    echo "13 deprecated round-trip scores: " . implode(',', array_map(fn($v) => round($v, 1), $d->getArrayFloat('scores'))) . "\n";
+    echo "14 deprecated round-trip vals: " . implode(',', array_map(fn($v) => round($v, 1), $d->getArrayDouble('vals'))) . "\n";
+    $coll7->destroy();
+
+    // Test 6 (renumbered): New methods used in a full workflow
+    $schema8 = new ZVecSchema('test');
+    $schema8->addVectorFp32('vec', dimension: 4, metricType: ZVecSchema::METRIC_IP);
+    $schema8->addBinary('bin');
+    $schema8->addArrayString('tags');
+    $coll8 = ZVec::create($path . '_8', $schema8);
+    $doc8 = new ZVecDoc('d1');
+    $doc8->setVectorFp32('vec', [1.0, 0.0, 0.0, 0.0]);
+    $doc8->setBinary('bin', "data");
+    $doc8->setArrayString('tags', ['x', 'y']);
+    $coll8->insert($doc8);
+    $f = $coll8->fetch('d1')[0];
+    echo "15 new API bin: " . $f->getBinary('bin') . "\n";
+    echo "16 new API tags: " . implode(',', $f->getArrayString('tags')) . "\n";
+    $coll8->destroy();
+
+    echo "PASS\n";
+} finally {
+    exec("rm -rf " . escapeshellarg($path) . '*');
+}
+?>
+--EXPECT--
+1 binary type match: 1
+2 binary nullable match: 1
+3 array types all match: 1
+4 all deprecated warnings: 1
+5 deprecated count: 9
+6 deprecated round-trip bin: 0001
+7 deprecated round-trip tags: a,b
+8 deprecated round-trip flags: 1,0
+9 deprecated round-trip counts: 1,2,3
+10 deprecated round-trip big_ids: 1000,2000
+11 deprecated round-trip uids: 10,20
+12 deprecated round-trip u64s: 100,200
+13 deprecated round-trip scores: 1.5,2.5
+14 deprecated round-trip vals: 3.1,2.7
+15 new API bin: data
+16 new API tags: x,y
+PASS


### PR DESCRIPTION
Closes #107

## Summary
Standardizes ZVecSchema field-adding methods by dropping the redundant `Field` prefix, reducing from 3 naming conventions to 4 consistent patterns.

## Changes
### src/ZVec.php
- Added 9 new unprefixed methods: `addBinary()`, `addArrayString()`, `addArrayBool()`, `addArrayInt32()`, `addArrayInt64()`, `addArrayUint32()`, `addArrayUint64()`, `addArrayFloat()`, `addArrayDouble()`
- Old `addField*()` methods are now deprecated aliases with `@deprecated` PHPDoc and `E_USER_DEPRECATED` trigger_error, delegating to new methods

### tests/
- Updated 4 test files to use new unprefixed method names
- Added `tests/test_schema_naming.phpt` (comprehensive: schema equivalence, all 9 deprecation warnings, round-trip via deprecated API, new API workflow)

### Documentation
- AGENTS.md: Updated naming conventions table
- CHANGELOG.md: Entries under Changed and Deprecated

## Backward Compatibility
All existing code using `addField*()` continues to work — only difference is an `E_USER_DEPRECATED` warning.

## Testing
- 88/91 tests pass (1 pre-existing unrelated failure in bug_0011, 2 XFAIL)
- All 9 deprecated methods verified to emit `E_USER_DEPRECATED`
- Schema produced by old and new methods verified identical
