### PR TITLE
test: add installer unit tests (#104)

### DIFF
--- a/tests/test_installer_detect_version.phpt
+++ b/tests/test_installer_detect_version.phpt
@@ -1,0 +1,45 @@
+--TEST--
+Installer: detectVersion throws RuntimeException when composer metadata unavailable
+--FILE--
+<?php
+declare(strict_types=1);
+require_once __DIR__ . '/../src/Installer.php';
+
+use CrazyGoat\ZVec\Installer;
+
+// Test 1: detectVersion should throw RuntimeException when no installed.json
+$ref = new ReflectionMethod(Installer::class, 'detectVersion');
+
+try {
+    $ref->invoke(null);
+    echo "FAIL: Expected RuntimeException was not thrown\n";
+    exit(1);
+} catch (RuntimeException $e) {
+    $msg = $e->getMessage();
+    if (str_contains($msg, 'Could not determine package version')) {
+        echo "PASS: detectVersion throws RuntimeException with expected message\n";
+    } else {
+        echo "FAIL: Wrong exception message: {$msg}\n";
+        exit(1);
+    }
+    if (str_contains($msg, 'composer install')) {
+        echo "PASS: Exception message mentions composer install\n";
+    } else {
+        echo "FAIL: Exception message missing composer install hint\n";
+        exit(1);
+    }
+    if (str_contains($msg, 'vendor/bin/zvec-install')) {
+        echo "PASS: Exception message mentions vendor/bin/zvec-install\n";
+    } else {
+        echo "FAIL: Exception message missing vendor/bin/zvec-install hint\n";
+        exit(1);
+    }
+}
+
+echo "PASS: All detectVersion tests completed\n";
+?>
+--EXPECT--
+PASS: detectVersion throws RuntimeException with expected message
+PASS: Exception message mentions composer install
+PASS: Exception message mentions vendor/bin/zvec-install
+PASS: All detectVersion tests completed

--- a/tests/test_installer_lib_name.phpt
+++ b/tests/test_installer_lib_name.phpt
@@ -1,0 +1,42 @@
+--TEST--
+Installer: libName returns correct shared library name per platform
+--FILE--
+<?php
+declare(strict_types=1);
+require_once __DIR__ . '/../src/Installer.php';
+
+use CrazyGoat\ZVec\Installer;
+
+$ref = new ReflectionMethod(Installer::class, 'libName');
+$libName = $ref->invoke(null);
+
+$expected = PHP_OS_FAMILY === 'Darwin' ? 'libzvec_ffi.dylib' : 'libzvec_ffi.so';
+
+if ($libName === $expected) {
+    echo "PASS: libName returns '{$libName}' (expected '{$expected}')\n";
+} else {
+    echo "FAIL: libName returned '{$libName}', expected '{$expected}'\n";
+    exit(1);
+}
+
+// Verify it's a valid filename (no path traversal, no null bytes)
+if (strpos($libName, '/') !== false || strpos($libName, "\0") !== false) {
+    echo "FAIL: libName contains invalid characters\n";
+    exit(1);
+}
+echo "PASS: libName is a valid filename\n";
+
+// Verify it starts with expected prefix
+if (!str_starts_with($libName, 'libzvec_ffi.')) {
+    echo "FAIL: libName does not start with expected prefix\n";
+    exit(1);
+}
+echo "PASS: libName has correct prefix\n";
+
+echo "PASS: All libName tests completed\n";
+?>
+--EXPECT--
+PASS: libName returns 'libzvec_ffi.so' (expected 'libzvec_ffi.so')
+PASS: libName is a valid filename
+PASS: libName has correct prefix
+PASS: All libName tests completed

--- a/tests/test_installer_resolve_asset_name.phpt
+++ b/tests/test_installer_resolve_asset_name.phpt
@@ -1,0 +1,67 @@
+--TEST--
+Installer: resolveAssetName returns correct asset name for current platform
+--FILE--
+<?php
+declare(strict_types=1);
+require_once __DIR__ . '/../src/Installer.php';
+
+use CrazyGoat\ZVec\Installer;
+
+$ref = new ReflectionMethod(Installer::class, 'resolveAssetName');
+$result = $ref->invoke(null);
+
+// On supported platforms, should return a string
+if ($result === null) {
+    echo "PASS: resolveAssetName returns null on unsupported platform (" . PHP_OS_FAMILY . " " . php_uname('m') . ")\n";
+} else {
+    echo "PASS: resolveAssetName returns '{$result}'\n";
+
+    // Verify the asset name contains expected components
+    $os = PHP_OS_FAMILY;
+    $arch = php_uname('m');
+
+    if (!str_contains($result, '.tar.gz')) {
+        echo "FAIL: Asset name does not end with .tar.gz\n";
+        exit(1);
+    }
+    echo "PASS: Asset name ends with .tar.gz\n";
+
+    if (!str_contains($result, 'libzvec_ffi')) {
+        echo "FAIL: Asset name does not contain 'libzvec_ffi'\n";
+        exit(1);
+    }
+    echo "PASS: Asset name contains 'libzvec_ffi'\n";
+
+    // Platform-specific checks
+    if ($os === 'Linux') {
+        if (str_contains($result, 'ubuntu') || str_contains($result, 'alpine')) {
+            echo "PASS: Linux asset name contains distro identifier\n";
+        } else {
+            echo "FAIL: Linux asset name missing distro identifier\n";
+            exit(1);
+        }
+        if (str_contains($result, $arch)) {
+            echo "PASS: Linux asset name contains architecture\n";
+        } else {
+            echo "FAIL: Linux asset name missing architecture\n";
+            exit(1);
+        }
+    } elseif ($os === 'Darwin') {
+        if (str_contains($result, 'darwin')) {
+            echo "PASS: macOS asset name contains 'darwin'\n";
+        } else {
+            echo "FAIL: macOS asset name missing 'darwin'\n";
+            exit(1);
+        }
+    }
+}
+
+echo "PASS: All resolveAssetName tests completed\n";
+?>
+--EXPECTF--
+PASS: resolveAssetName returns '%s'
+PASS: Asset name ends with .tar.gz
+PASS: Asset name contains 'libzvec_ffi'
+PASS: Linux asset name contains distro identifier
+PASS: Linux asset name contains architecture
+PASS: All resolveAssetName tests completed

--- a/tests/test_installer_version_from_installed_json.phpt
+++ b/tests/test_installer_version_from_installed_json.phpt
@@ -1,0 +1,41 @@
+--TEST--
+Installer: versionFromInstalledJson returns version string or null
+--FILE--
+<?php
+declare(strict_types=1);
+require_once __DIR__ . '/../src/Installer.php';
+
+use CrazyGoat\ZVec\Installer;
+
+$ref = new ReflectionMethod(Installer::class, 'versionFromInstalledJson');
+
+$result = $ref->invoke(null);
+
+// Result should be null or a valid version string
+if ($result === null) {
+    echo "PASS: versionFromInstalledJson returns null (no composer metadata)\n";
+} else {
+    echo "PASS: versionFromInstalledJson returns '{$result}'\n";
+
+    // Verify it's a valid version format (vX.Y.Z)
+    if (preg_match('/^v\d+\.\d+\.\d+$/', $result)) {
+        echo "PASS: Version matches vX.Y.Z format\n";
+    } else {
+        echo "FAIL: Version '{$result}' does not match vX.Y.Z format\n";
+        exit(1);
+    }
+
+    // Verify it starts with 'v'
+    if (str_starts_with($result, 'v')) {
+        echo "PASS: Version starts with 'v'\n";
+    } else {
+        echo "FAIL: Version does not start with 'v'\n";
+        exit(1);
+    }
+}
+
+echo "PASS: All versionFromInstalledJson tests completed\n";
+?>
+--EXPECT--
+PASS: versionFromInstalledJson returns null (no composer metadata)
+PASS: All versionFromInstalledJson tests completed


### PR DESCRIPTION
## Summary

Adds 4 .phpt tests for previously untested private Installer methods:
- : verify correct .so/.dylib per platform
- : verify asset name for current platform
- : verify RuntimeException on missing composer metadata
- : verify version string or null return

## Test Coverage

| Method | Test File | Assertions |
|--------|-----------|------------|
|  |  | Returns correct name, valid filename, correct prefix |
|  |  | Returns string/null, contains .tar.gz, platform-specific checks |
|  |  | Throws RuntimeException with expected message |
|  |  | Returns null or vX.Y.Z format string |

## Test Results

All 101 tests pass (including 8 installer tests total).

## Related Issue

Closes #104