### PR TITLE
test: add missing index and column operation tests (TEST-005, #103)

### DIFF
--- a/tests/test_add_column_bool.phpt
+++ b/tests/test_add_column_bool.phpt
@@ -1,0 +1,71 @@
+--TEST--
+Column ops: addColumnBool is not supported for column DDL (BOOL is schema-only)
+--SKIPIF--
+<?php if (!extension_loaded('ffi')) die('skip FFI extension not available'); ?>
+--FILE--
+<?php
+require_once __DIR__ . '/../src/ZVec.php';
+ZVec::init(logType: ZVec::LOG_CONSOLE, logLevel: ZVec::LOG_WARN);
+
+$path = __DIR__ . '/../test_dbs/add_bool_' . uniqid();
+try {
+    $schema = new ZVecSchema('test');
+    $schema->setMaxDocCountPerSegment(1000)
+        ->addInt64('id', nullable: false)
+        ->addBool('active', nullable: true)
+        ->addVectorFp32('v', dimension: 4, metricType: ZVecSchema::METRIC_IP);
+
+    $c = ZVec::create($path, $schema);
+
+    // Insert doc with bool field set via schema
+    $doc = new ZVecDoc('d1');
+    $doc->setInt64('id', 1)
+        ->setBool('active', true)
+        ->setVectorFp32('v', [1.0, 0.0, 0.0, 0.0]);
+    $c->insert($doc);
+    $c->optimize();
+
+    // Verify bool field works via schema-defined column
+    $fetched = $c->fetch('d1');
+    assert(count($fetched) === 1, 'Expected 1 doc');
+    $active = $fetched[0]->getBool('active');
+    echo "d1 active=" . ($active ? 'true' : 'false') . " (expected: true)\n";
+
+    // Test: addColumnBool should fail — BOOL not supported for column DDL
+    try {
+        $c->addColumnBool('flag', nullable: true, defaultExpr: 'false');
+        echo "UNEXPECTED: addColumnBool succeeded\n";
+    } catch (ZVecException $e) {
+        echo "addColumnBool correctly rejected: " . $e->getMessage() . "\n";
+    }
+
+    // Test: Insert doc with bool field set to false
+    $doc2 = new ZVecDoc('d2');
+    $doc2->setInt64('id', 2)
+        ->setBool('active', false)
+        ->setVectorFp32('v', [0.0, 1.0, 0.0, 0.0]);
+    $c->insert($doc2);
+    $c->optimize();
+
+    $fetched2 = $c->fetch('d2');
+    assert(count($fetched2) === 1, 'Expected 1 doc');
+    $active2 = $fetched2[0]->getBool('active');
+    echo "d2 active=" . ($active2 ? 'true' : 'false') . " (expected: false)\n";
+
+    // Test: Query with bool in output fields
+    $results = $c->query('v', [1.0, 0.0, 0.0, 0.0], topk: 3, outputFields: ['id', 'active']);
+    assert(count($results) >= 2, 'Expected at least 2 results');
+    echo "Query with outputFields returned " . count($results) . " results\n";
+
+    $c->close();
+    echo "PASS: addColumnBool limitation verified; BOOL works via schema\n";
+} finally {
+    exec("rm -rf " . escapeshellarg($path));
+}
+?>
+--EXPECT--
+d1 active=true (expected: true)
+addColumnBool correctly rejected: Only support basic numeric data type [int32, int64, uint32, uint64, float, double]: FieldSchema{name:'flag',data_type:BOOL,nullable:true,dimension:0,index_params:null}
+d2 active=false (expected: false)
+Query with outputFields returned 2 results
+PASS: addColumnBool limitation verified; BOOL works via schema

--- a/tests/test_alter_column_nullable.phpt
+++ b/tests/test_alter_column_nullable.phpt
@@ -1,0 +1,68 @@
+--TEST--
+Column ops: alterColumn nullable false→true and nullable true→false limitation
+--SKIPIF--
+<?php if (!extension_loaded('ffi')) die('skip FFI extension not available'); ?>
+--FILE--
+<?php
+require_once __DIR__ . '/../src/ZVec.php';
+ZVec::init(logType: ZVec::LOG_CONSOLE, logLevel: ZVec::LOG_WARN);
+
+$path = __DIR__ . '/../test_dbs/alter_nullable_' . uniqid();
+try {
+    $schema = new ZVecSchema('test');
+    $schema->setMaxDocCountPerSegment(1000)
+        ->addInt64('id', nullable: false)
+        ->addInt64('value', nullable: true)
+        ->addVectorFp32('v', dimension: 4, metricType: ZVecSchema::METRIC_IP);
+
+    $c = ZVec::create($path, $schema);
+
+    $doc = new ZVecDoc('doc1');
+    $doc->setInt64('id', 1)
+        ->setInt64('value', 42)
+        ->setVectorFp32('v', [0.1, 0.2, 0.3, 0.4]);
+    $c->insert($doc);
+    $c->optimize();
+
+    // Test 1: Change nullable true→false on already-nullable column — should fail
+    try {
+        $c->alterColumn('value', nullable: false);
+        echo "UNEXPECTED: nullable true→false succeeded\n";
+    } catch (ZVecException $e) {
+        echo "Correctly rejected nullable true→false: " . $e->getMessage() . "\n";
+    }
+
+    // Test 2: Change nullable false→true on non-nullable column — may fail at C++ level
+    try {
+        $c->alterColumn('id', nullable: true);
+        echo "Changed nullable false→true on 'id' OK\n";
+
+        // Insert doc with null id — verify nullable works
+        $doc2 = new ZVecDoc('doc2');
+        $doc2->setFieldNull('id')
+            ->setInt64('value', 99)
+            ->setVectorFp32('v', [0.2, 0.3, 0.4, 0.5]);
+        $c->insert($doc2);
+        $c->optimize();
+        echo "Inserted doc with null id OK\n";
+    } catch (ZVecException $e) {
+        echo "nullable false→true rejected at C++ level: " . $e->getMessage() . "\n";
+    }
+
+    // Test 3: Verify original column is still readable
+    $fetched = $c->fetch('doc1');
+    assert(count($fetched) === 1, 'Expected 1 doc');
+    assert($fetched[0]->getInt64('value') === 42, 'Expected value=42 unchanged');
+    echo "Original column unchanged OK\n";
+
+    $c->close();
+    echo "PASS: alterColumn nullable operations verified\n";
+} finally {
+    exec("rm -rf " . escapeshellarg($path));
+}
+?>
+--EXPECTF--
+Correctly rejected nullable true→false: %s
+nullable false→true rejected at C++ level: %s
+Original column unchanged OK
+PASS: alterColumn nullable operations verified

--- a/tests/test_alter_column_rename_type_limitation.phpt
+++ b/tests/test_alter_column_rename_type_limitation.phpt
@@ -1,0 +1,71 @@
+--TEST--
+Column ops: alterColumn rename AND type in one call — limitation test
+--SKIPIF--
+<?php if (!extension_loaded('ffi')) die('skip FFI extension not available'); ?>
+--FILE--
+<?php
+require_once __DIR__ . '/../src/ZVec.php';
+ZVec::init(logType: ZVec::LOG_CONSOLE, logLevel: ZVec::LOG_WARN);
+
+$path = __DIR__ . '/../test_dbs/alter_rename_type_' . uniqid();
+try {
+    $schema = new ZVecSchema('test');
+    $schema->setMaxDocCountPerSegment(1000)
+        ->addInt64('id', nullable: false)
+        ->addInt64('value', nullable: true)
+        ->addVectorFp32('v', dimension: 4, metricType: ZVecSchema::METRIC_IP);
+
+    $c = ZVec::create($path, $schema);
+
+    $doc = new ZVecDoc('doc1');
+    $doc->setInt64('id', 1)
+        ->setInt64('value', 100)
+        ->setVectorFp32('v', [0.1, 0.2, 0.3, 0.4]);
+    $c->insert($doc);
+    $c->optimize();
+
+    // Test: Rename AND change type in one call — should fail (limitation)
+    try {
+        $c->alterColumn('value', newName: 'renamed_value', newDataType: ZVec::TYPE_FLOAT, nullable: true);
+        echo "UNEXPECTED: rename+type in one call succeeded\n";
+    } catch (ZVecException $e) {
+        echo "Correctly rejected rename+type in one call: " . $e->getMessage() . "\n";
+    }
+
+    // Verify original column is unchanged
+    $fetched = $c->fetch('doc1');
+    assert(count($fetched) === 1, 'Expected 1 doc');
+    assert($fetched[0]->getInt64('value') === 100, 'Expected value=100 unchanged');
+    echo "Original column unchanged after failed alter OK\n";
+
+    // Test: Rename first, then change type — should succeed (separate calls)
+    $c->alterColumn('value', newName: 'renamed_value');
+    echo "Rename in separate call OK\n";
+
+    $c->alterColumn('renamed_value', newDataType: ZVec::TYPE_FLOAT, nullable: true);
+    echo "Type change in separate call OK\n";
+
+    // Verify the column works with new name and type
+    $doc2 = new ZVecDoc('doc2');
+    $doc2->setInt64('id', 2)
+        ->setFloat('renamed_value', 3.14)
+        ->setVectorFp32('v', [0.2, 0.3, 0.4, 0.5]);
+    $c->insert($doc2);
+    $c->optimize();
+
+    $results = $c->query('v', [0.1, 0.2, 0.3, 0.4], topk: 5);
+    echo "Query after separate rename+type works, returned " . count($results) . " results\n";
+
+    $c->close();
+    echo "PASS: alterColumn rename+type limitation verified\n";
+} finally {
+    exec("rm -rf " . escapeshellarg($path));
+}
+?>
+--EXPECTF--
+Correctly rejected rename+type in one call: cannot specify both rename and new column schema
+Original column unchanged after failed alter OK
+Rename in separate call OK
+Type change in separate call OK
+Query after separate rename+type works, returned %d results
+PASS: alterColumn rename+type limitation verified

--- a/tests/test_index_already_exists.phpt
+++ b/tests/test_index_already_exists.phpt
@@ -1,0 +1,66 @@
+--TEST--
+Index ops: createIndex on already-indexed field behavior
+--SKIPIF--
+<?php if (!extension_loaded('ffi')) die('skip FFI extension not available'); ?>
+--FILE--
+<?php
+require_once __DIR__ . '/../src/ZVec.php';
+ZVec::init(logType: ZVec::LOG_CONSOLE, logLevel: ZVec::LOG_WARN);
+
+$path = __DIR__ . '/../test_dbs/idx_already_' . uniqid();
+try {
+    $schema = new ZVecSchema('test');
+    $schema->setMaxDocCountPerSegment(1000)
+        ->addInt64('id', nullable: false)
+        ->addVectorFp32('v', dimension: 4, metricType: ZVecSchema::METRIC_IP);
+
+    $c = ZVec::create($path, $schema);
+
+    $c->insert(
+        (new ZVecDoc('d1'))->setInt64('id', 1)->setVectorFp32('v', [1.0, 0.0, 0.0, 0.0]),
+        (new ZVecDoc('d2'))->setInt64('id', 2)->setVectorFp32('v', [0.0, 1.0, 0.0, 0.0])
+    );
+    $c->optimize();
+
+    // Create first index — should succeed
+    $params = ZVecIndexParams::forHnsw(
+        metricType: ZVecSchema::METRIC_IP,
+        m: 16,
+        efConstruction: 200
+    );
+    $c->createIndex('v', $params);
+    echo "First HNSW index created OK\n";
+
+    // Query works with first index
+    $results = $c->query('v', [1.0, 0.0, 0.0, 0.0], topk: 2);
+    assert(count($results) === 2, 'Expected 2 results');
+    echo "Query with first index returned " . count($results) . " results OK\n";
+
+    // Create second index on same field — may succeed (replaces) or throw
+    try {
+        $params2 = ZVecIndexParams::forFlat(
+            metricType: ZVecSchema::METRIC_IP
+        );
+        $c->createIndex('v', $params2);
+        echo "Second index (Flat) created — field supports index replacement\n";
+
+        // Verify query still works after index replacement
+        $results2 = $c->query('v', [1.0, 0.0, 0.0, 0.0], topk: 2);
+        assert(count($results2) === 2, 'Expected 2 results after index replacement');
+        echo "Query after index replacement returned " . count($results2) . " results OK\n";
+    } catch (ZVecException $e) {
+        echo "Index creation on already-indexed field rejected: " . $e->getMessage() . "\n";
+    }
+
+    $c->close();
+    echo "PASS: createIndex on already-indexed field handled correctly\n";
+} finally {
+    exec("rm -rf " . escapeshellarg($path));
+}
+?>
+--EXPECT--
+First HNSW index created OK
+Query with first index returned 2 results OK
+Second index (Flat) created — field supports index replacement
+Query after index replacement returned 2 results OK
+PASS: createIndex on already-indexed field handled correctly

--- a/tests/test_ivf_soar_unified.phpt
+++ b/tests/test_ivf_soar_unified.phpt
@@ -1,0 +1,84 @@
+--TEST--
+Index ops: IVF with useSoar=true via unified ZVecIndexParams::forIvf()
+--SKIPIF--
+<?php if (!extension_loaded('ffi')) die('skip FFI extension not available'); ?>
+--FILE--
+<?php
+require_once __DIR__ . '/../src/ZVec.php';
+ZVec::init(logType: ZVec::LOG_CONSOLE, logLevel: ZVec::LOG_WARN);
+
+$path = __DIR__ . '/../test_dbs/ivf_soar_' . uniqid();
+try {
+    $schema = new ZVecSchema('test');
+    $schema->setMaxDocCountPerSegment(1000)
+        ->addInt64('id', nullable: false)
+        ->addVectorFp32('v', dimension: 4, metricType: ZVecSchema::METRIC_IP);
+
+    $c = ZVec::create($path, $schema);
+
+    // Insert enough data for IVF to work
+    for ($i = 1; $i <= 50; $i++) {
+        $doc = new ZVecDoc("doc$i");
+        $doc->setInt64('id', $i)
+            ->setVectorFp32('v', [0.1 * $i, 0.2 * $i, 0.3 * $i, 0.4 * $i]);
+        $c->insert($doc);
+    }
+    $c->optimize();
+
+    // Test 1: Create IVF index with SOAR via unified API
+    $params = ZVecIndexParams::forIvf(
+        metricType: ZVecSchema::METRIC_IP,
+        nList: 10,
+        nIters: 5,
+        useSoar: true
+    );
+    $c->createIndex('v', $params);
+    $c->flush();
+    $c->optimize();
+    echo "Created IVF index with SOAR via unified API OK\n";
+
+    // Test 2: Query with IVF+SOAR
+    $results = $c->query(
+        'v', [0.1, 0.2, 0.3, 0.4],
+        topk: 5,
+        queryParamType: ZVec::QUERY_PARAM_IVF,
+        ivfNprobe: 3
+    );
+    assert(count($results) === 5, 'Expected 5 results with IVF+SOAR');
+    echo "Query with IVF+SOAR returned 5 results OK\n";
+
+    // Test 3: Drop and recreate without SOAR — compare
+    $c->dropIndex('v');
+    $params2 = ZVecIndexParams::forIvf(
+        metricType: ZVecSchema::METRIC_IP,
+        nList: 10,
+        nIters: 5,
+        useSoar: false
+    );
+    $c->createIndex('v', $params2);
+    $c->flush();
+    $c->optimize();
+    echo "Recreated IVF without SOAR via unified API OK\n";
+
+    // Test 4: Query with IVF without SOAR
+    $results2 = $c->query(
+        'v', [0.1, 0.2, 0.3, 0.4],
+        topk: 5,
+        queryParamType: ZVec::QUERY_PARAM_IVF,
+        ivfNprobe: 3
+    );
+    assert(count($results2) === 5, 'Expected 5 results with IVF no SOAR');
+    echo "Query with IVF no SOAR returned 5 results OK\n";
+
+    $c->close();
+    echo "PASS: IVF with useSoar=true via unified API works\n";
+} finally {
+    exec("rm -rf " . escapeshellarg($path));
+}
+?>
+--EXPECT--
+Created IVF index with SOAR via unified API OK
+Query with IVF+SOAR returned 5 results OK
+Recreated IVF without SOAR via unified API OK
+Query with IVF no SOAR returned 5 results OK
+PASS: IVF with useSoar=true via unified API works


### PR DESCRIPTION
## Summary

Adds 5 new .phpt tests covering previously untested scenarios from issue #103 (TEST-005: Index and Column Operations — Missing Coverage).

## New Tests

| Test File | Scenario | Key Finding |
|-----------|----------|-------------|
|  | createIndex on already-indexed field | C++ layer supports index replacement (no throw) |
|  | nullable false→true, true→false | Both directions rejected by C++ layer |
|  | rename+type in one call | C++ rejects with clear error message |
|  | addColumnBool with default | BOOL not supported for column DDL (schema-only) |
|  | IVF with useSoar=true via unified API | Works correctly via ZVecIndexParams::forIvf() |

## Test Results

All 106 tests pass (104 PASS + 2 XFAIL):
- 5 new tests: PASS
- Existing tests: no regressions

## Closes

Closes #103