### PR TITLE
fix: replace hardcoded 8192-byte buffers with retry logic (SMELL-015)

### DIFF
--- a/src/ZVec.php
+++ b/src/ZVec.php
@@ -352,18 +352,38 @@ class ZVec
     {
         $this->checkClosed();
         $ffi = self::ffi();
-        $buf = $ffi->new('char[8192]');
-        self::checkStatus($ffi->zvec_collection_schema($this->handle, $buf, 8192));
-        return FFI::string($buf);
+        $bufSize = 8192;
+        while (true) {
+            $buf = $ffi->new("char[$bufSize]");
+            self::checkStatus($ffi->zvec_collection_schema($this->handle, $buf, $bufSize));
+            $str = FFI::string($buf);
+            if (strlen($str) < $bufSize - 1) {
+                return $str;
+            }
+            $bufSize *= 2;
+            if ($bufSize > 1048576) {
+                throw new ZVecException('Schema string exceeds maximum buffer size of 1 MB');
+            }
+        }
     }
 
     public function path(): string
     {
         $this->checkClosed();
         $ffi = self::ffi();
-        $buf = $ffi->new('char[4096]');
-        self::checkStatus($ffi->zvec_collection_path($this->handle, $buf, 4096));
-        return FFI::string($buf);
+        $bufSize = 4096;
+        while (true) {
+            $buf = $ffi->new("char[$bufSize]");
+            self::checkStatus($ffi->zvec_collection_path($this->handle, $buf, $bufSize));
+            $str = FFI::string($buf);
+            if (strlen($str) < $bufSize - 1) {
+                return $str;
+            }
+            $bufSize *= 2;
+            if ($bufSize > 1048576) {
+                throw new ZVecException('Path string exceeds maximum buffer size of 1 MB');
+            }
+        }
     }
 
     /**
@@ -1317,9 +1337,19 @@ class ZVec
     {
         $this->checkClosed();
         $ffi = self::ffi();
-        $buf = $ffi->new('char[4096]');
-        self::checkStatus($ffi->zvec_collection_stats($this->handle, $buf, 4096));
-        return FFI::string($buf);
+        $bufSize = 4096;
+        while (true) {
+            $buf = $ffi->new("char[$bufSize]");
+            self::checkStatus($ffi->zvec_collection_stats($this->handle, $buf, $bufSize));
+            $str = FFI::string($buf);
+            if (strlen($str) < $bufSize - 1) {
+                return $str;
+            }
+            $bufSize *= 2;
+            if ($bufSize > 1048576) {
+                throw new ZVecException('Stats string exceeds maximum buffer size of 1 MB');
+            }
+        }
     }
 
     /**

--- a/src/ZVecDoc.php
+++ b/src/ZVecDoc.php
@@ -850,14 +850,27 @@ class ZVecDoc
         if (!$ffi->zvec_doc_has_field($this->handle, $field)) {
             return null;
         }
-        $buf = $ffi->new('char[8192]');
-        $count = $ffi->new('uint32_t');
-        $len = $ffi->zvec_doc_get_array_string($this->handle, $field, $buf, 8192, FFI::addr($count));
-        if ($len <= 0) {
+        $bufSize = 8192;
+        while (true) {
+            $buf = $ffi->new("char[$bufSize]");
+            $count = $ffi->new('uint32_t');
+            $len = $ffi->zvec_doc_get_array_string($this->handle, $field, $buf, $bufSize, FFI::addr($count));
+            if ($len > 0) {
+                $str = FFI::string($buf, $len);
+                return explode("\0", $str);
+            }
+            if ($len === 0) {
+                return [];
+            }
+            if ($len === -1) {
+                $bufSize *= 2;
+                if ($bufSize > 1048576) {
+                    throw new ZVecException("Array string field '$field' exceeds maximum buffer size of 1 MB");
+                }
+                continue;
+            }
             return [];
         }
-        $str = FFI::string($buf, $len);
-        return explode("\0", $str);
     }
 
     /**
@@ -869,16 +882,26 @@ class ZVecDoc
         if (!$ffi->zvec_doc_has_field($this->handle, $field)) {
             return null;
         }
-        $buf = $ffi->new('uint8_t[4096]');
-        $count = $ffi->zvec_doc_get_array_bool($this->handle, $field, $buf, 4096);
-        if ($count <= 0) {
+        $bufSize = 4096;
+        while (true) {
+            $buf = $ffi->new("uint8_t[$bufSize]");
+            $count = $ffi->zvec_doc_get_array_bool($this->handle, $field, $buf, $bufSize);
+            if ($count >= 0) {
+                $result = [];
+                for ($i = 0; $i < $count; $i++) {
+                    $result[] = $buf[$i] !== 0;
+                }
+                return $result;
+            }
+            if ($count === -1) {
+                $bufSize *= 2;
+                if ($bufSize > 1048576) {
+                    throw new ZVecException("Array bool field '$field' exceeds maximum buffer size of 1 MB");
+                }
+                continue;
+            }
             return [];
         }
-        $result = [];
-        for ($i = 0; $i < $count; $i++) {
-            $result[] = $buf[$i] !== 0;
-        }
-        return $result;
     }
 
     public function hasField(string $field): bool
@@ -897,13 +920,23 @@ class ZVecDoc
     public function fieldNames(): array
     {
         $ffi = self::ffi();
-        $buf = $ffi->new('char[8192]');
-        $len = $ffi->zvec_doc_field_names($this->handle, $buf, 8192);
-        if ($len < 0) {
+        $bufSize = 8192;
+        while (true) {
+            $buf = $ffi->new("char[$bufSize]");
+            $len = $ffi->zvec_doc_field_names($this->handle, $buf, $bufSize);
+            if ($len >= 0) {
+                $str = FFI::string($buf);
+                return $str === '' ? [] : explode("\n", $str);
+            }
+            if ($len === -1) {
+                $bufSize *= 2;
+                if ($bufSize > 1048576) {
+                    throw new ZVecException('Field names exceed maximum buffer size of 1 MB');
+                }
+                continue;
+            }
             return [];
         }
-        $str = FFI::string($buf);
-        return $str === '' ? [] : explode("\n", $str);
     }
 
     /**
@@ -912,13 +945,23 @@ class ZVecDoc
     public function vectorNames(): array
     {
         $ffi = self::ffi();
-        $buf = $ffi->new('char[8192]');
-        $len = $ffi->zvec_doc_vector_names($this->handle, $buf, 8192);
-        if ($len < 0) {
+        $bufSize = 8192;
+        while (true) {
+            $buf = $ffi->new("char[$bufSize]");
+            $len = $ffi->zvec_doc_vector_names($this->handle, $buf, $bufSize);
+            if ($len >= 0) {
+                $str = FFI::string($buf);
+                return $str === '' ? [] : explode("\n", $str);
+            }
+            if ($len === -1) {
+                $bufSize *= 2;
+                if ($bufSize > 1048576) {
+                    throw new ZVecException('Vector names exceed maximum buffer size of 1 MB');
+                }
+                continue;
+            }
             return [];
         }
-        $str = FFI::string($buf);
-        return $str === '' ? [] : explode("\n", $str);
     }
 
     // --- Enhanced Doc API ---

--- a/tests/test_buffer_retry.phpt
+++ b/tests/test_buffer_retry.phpt
@@ -1,0 +1,171 @@
+--TEST--
+Buffer retry logic: getArrayString, fieldNames, vectorNames, getArrayBool, schema, path, stats handle overflow
+--SKIPIF--
+<?php
+if (!extension_loaded('zvec') && !extension_loaded('ffi')) die('skip Neither zvec extension nor FFI available');
+if (!method_exists('ZVecSchema', 'addArrayString')) die('skip addArrayString not available');
+?>
+--FILE--
+<?php
+require_once __DIR__ . '/../src/ZVec.php';
+
+$path = __DIR__ . '/../test_dbs/buffer_retry_' . uniqid();
+
+try {
+    $schema = new ZVecSchema('test');
+    $schema->setMaxDocCountPerSegment(1000)
+        ->addInt64('id', nullable: false)
+        ->addString('name', nullable: false)
+        ->addArrayString('tags')
+        ->addArrayBool('flags')
+        ->addVectorFp32('embedding', dimension: 4, metricType: ZVecSchema::METRIC_IP);
+
+    $c = ZVec::create($path, $schema);
+
+    // Test 1: Normal-size data works
+    echo "=== Test 1: Normal data ===\n";
+    $doc = new ZVecDoc('doc_1');
+    $doc->setInt64('id', 1)
+        ->setString('name', 'Normal Doc')
+        ->setArrayString('tags', ['php', 'ffi', 'vector'])
+        ->setArrayBool('flags', [true, false, true])
+        ->setVectorFp32('embedding', [0.1, 0.2, 0.3, 0.4]);
+
+    $c->insert($doc);
+    $c->optimize();
+
+    $fetched = $c->fetch('doc_1')[0] ?? null;
+    if ($fetched === null) {
+        echo "FAIL: could not fetch doc_1\n";
+        exit(1);
+    }
+
+    $tags = $fetched->getArrayString('tags');
+    echo "getArrayString: " . implode(',', $tags ?? []) . "\n";
+    $flags = $fetched->getArrayBool('flags');
+    echo "getArrayBool: " . implode(',', array_map(fn($v) => $v ? 'true' : 'false', $flags ?? [])) . "\n";
+
+    $names = $fetched->fieldNames();
+    echo "fieldNames: " . implode(',', $names) . "\n";
+
+    // Test 2: Large array string that exceeds 8192 bytes
+    echo "\n=== Test 2: Large array string (>8192 bytes) ===\n";
+    $largeTags = [];
+    for ($i = 0; $i < 200; $i++) {
+        $largeTags[] = str_repeat('x', 50) . "_$i";
+    }
+
+    $doc2 = new ZVecDoc('doc_2');
+    $doc2->setInt64('id', 2)
+        ->setString('name', 'Large Doc')
+        ->setArrayString('tags', $largeTags)
+        ->setArrayBool('flags', array_fill(0, 200, true))
+        ->setVectorFp32('embedding', [0.5, 0.6, 0.7, 0.8]);
+
+    $c->insert($doc2);
+    $c->optimize();
+
+    $fetched2 = $c->fetch('doc_2')[0] ?? null;
+    if ($fetched2 === null) {
+        echo "FAIL: could not fetch doc_2\n";
+        exit(1);
+    }
+
+    $largeTagsResult = $fetched2->getArrayString('tags');
+    echo "getArrayString count: " . count($largeTagsResult ?? []) . " (expected: 200)\n";
+    $largeFlagsResult = $fetched2->getArrayBool('flags');
+    echo "getArrayBool count: " . count($largeFlagsResult ?? []) . " (expected: 200)\n";
+
+    // Test 3: Non-existent field returns null/empty
+    echo "\n=== Test 3: Non-existent field ===\n";
+    $missing = $fetched->getArrayString('nonexistent');
+    echo "getArrayString(nonexistent): " . ($missing === null ? 'null' : 'array') . "\n";
+    $missingBool = $fetched->getArrayBool('nonexistent');
+    echo "getArrayBool(nonexistent): " . ($missingBool === null ? 'null' : 'array') . "\n";
+
+    // Test 4: schema() and path() work
+    echo "\n=== Test 4: schema and path ===\n";
+    $schemaStr = $c->schema();
+    echo "schema ok: " . (strlen($schemaStr) > 0 ? 'yes' : 'no') . "\n";
+    $pathStr = $c->path();
+    echo "path ok: " . (strlen($pathStr) > 0 ? 'yes' : 'no') . "\n";
+
+    // Test 5: stats() works
+    echo "\n=== Test 5: stats ===\n";
+    $statsStr = $c->stats();
+    echo "stats ok: " . (strlen($statsStr) > 0 ? 'yes' : 'no') . "\n";
+
+    // Verify results
+    $ok = true;
+
+    if ($tags !== ['php', 'ffi', 'vector']) {
+        echo "\nFAIL: getArrayString returned wrong data\n";
+        $ok = false;
+    }
+    if ($flags !== [true, false, true]) {
+        echo "\nFAIL: getArrayBool returned wrong data\n";
+        $ok = false;
+    }
+    if (count($largeTagsResult ?? []) !== 200) {
+        echo "\nFAIL: getArrayString should return 200 tags for large data\n";
+        $ok = false;
+    }
+    if (count($largeFlagsResult ?? []) !== 200) {
+        echo "\nFAIL: getArrayBool should return 200 flags for large data\n";
+        $ok = false;
+    }
+    if ($missing !== null) {
+        echo "\nFAIL: getArrayString(nonexistent) should be null\n";
+        $ok = false;
+    }
+    if ($missingBool !== null) {
+        echo "\nFAIL: getArrayBool(nonexistent) should be null\n";
+        $ok = false;
+    }
+    if (strlen($schemaStr) === 0) {
+        echo "\nFAIL: schema() should return non-empty string\n";
+        $ok = false;
+    }
+    if (strlen($pathStr) === 0) {
+        echo "\nFAIL: path() should return non-empty string\n";
+        $ok = false;
+    }
+    if (strlen($statsStr) === 0) {
+        echo "\nFAIL: stats() should return non-empty string\n";
+        $ok = false;
+    }
+
+    $c->close();
+
+    if ($ok) {
+        echo "\nPASS: All buffer retry tests passed\n";
+    } else {
+        echo "\nFAIL: Some tests failed\n";
+        exit(1);
+    }
+} finally {
+    exec("rm -rf " . escapeshellarg($path));
+}
+?>
+--EXPECT--
+=== Test 1: Normal data ===
+getArrayString: php,ffi,vector
+getArrayBool: true,false,true
+fieldNames: flags,id,name,tags
+
+=== Test 2: Large array string (>8192 bytes) ===
+getArrayString count: 200 (expected: 200)
+getArrayBool count: 200 (expected: 200)
+
+=== Test 3: Non-existent field ===
+getArrayString(nonexistent): null
+getArrayBool(nonexistent): null
+
+=== Test 4: schema and path ===
+schema ok: yes
+path ok: yes
+
+=== Test 5: stats ===
+stats ok: yes
+
+PASS: All buffer retry tests passed


### PR DESCRIPTION
## Summary

Replaces fixed-size buffers in , , , , , , and  with exponential retry logic that doubles buffer on overflow (capped at 1 MB). Fixes silent data truncation for large string/array fields.

## Problem

Several methods allocated hardcoded 8192-byte (or 4096-byte) buffers for FFI calls. When data exceeded the buffer size:
-  /  /  / : C++ returns -1 on overflow, PHP returned empty result
-  /  / : C++ silently truncated via 

Large fields (>8KB) were silently lost.

## Solution

Exponential retry pattern: start with 8192, double on overflow, cap at 1 MB.

For methods where C++ returns -1 on overflow:


For methods where C++ silently truncates:


## Changes

- : , , ,  — retry on -1
- : , ,  — retry when string fills buffer
- : Tests normal data, large arrays (>8KB), and non-existent fields

## Testing

All 113 tests pass (2 pre-existing XFAIL: bug_0002, test_fp64_vectors).

Closes #96