### PR TITLE
fix(sec-010): strip C++ source paths from exception messages

### DIFF
--- a/ffi/zvec_ffi.cc
+++ b/ffi/zvec_ffi.cc
@@ -50,12 +50,18 @@ static void set_last_error(int code, const char* msg, const char* file, int line
     g_last_error.function = func;
 }
 
+// Helper to strip __FILE__ to basename only (reduces information disclosure)
+static const char* strip_path(const char* path) {
+    const char* slash = strrchr(path, '/');
+    return slash ? slash + 1 : path;
+}
+
 // MAKE_STATUS wraps make_status and captures source location on error
 #define MAKE_STATUS(s) \
     ([&]() -> zvec_status_t { \
         auto _st = make_status(s); \
         if (_st.code != 0) { \
-            set_last_error(_st.code, _st.message, __FILE__, __LINE__, __func__); \
+            set_last_error(_st.code, _st.message, strip_path(__FILE__), __LINE__, __func__); \
         } \
         return _st; \
     })()
@@ -64,7 +70,7 @@ static void set_last_error(int code, const char* msg, const char* file, int line
 #define SET_FFI_ERROR(st) \
     do { \
         if ((st).code != 0) { \
-            set_last_error((st).code, (st).message, __FILE__, __LINE__, __func__); \
+            set_last_error((st).code, (st).message, strip_path(__FILE__), __LINE__, __func__); \
         } \
     } while(0)
 

--- a/src/ZVec.php
+++ b/src/ZVec.php
@@ -18,6 +18,7 @@ class ZVec
 {
     private static ?FFI $ffi = null;
     private static ?string $allowedBasePath = null;
+    private static bool $verboseErrors = false;
     private FFI\CData $handle;
     private bool $closed = false;
     private bool $destroyed = false;
@@ -73,10 +74,15 @@ class ZVec
             $details = $ffi->new('zvec_error_details_t');
             $ffi->zvec_get_last_error_details(FFI::addr($details));
             $msg = $details->message !== null ? FFI::string($details->message) : FFI::string($status->message);
-            $file = $details->file !== null ? FFI::string($details->file) : null;
-            $line = $details->line;
-            $function = $details->function !== null ? FFI::string($details->function) : null;
-            throw new ZVecException($msg, $status->code, null, $file, $line, $function);
+
+            if (self::$verboseErrors) {
+                $file = $details->file !== null ? FFI::string($details->file) : null;
+                $line = $details->line;
+                $function = $details->function !== null ? FFI::string($details->function) : null;
+                throw new ZVecException($msg, $status->code, null, $file, $line, $function);
+            }
+
+            throw new ZVecException($msg, $status->code);
         }
     }
 
@@ -700,8 +706,11 @@ class ZVec
         float $invertToForwardScanRatio = 0.0,
         float $bruteForceByKeysRatio = 0.0,
         int $memoryLimitMb = 0,
-        ?string $allowedBasePath = null
+        ?string $allowedBasePath = null,
+        bool $verboseErrors = false,
     ): void {
+        self::$verboseErrors = $verboseErrors;
+
         if ($allowedBasePath !== null && !is_dir($allowedBasePath)) {
             throw new ZVecException("Allowed base path does not exist: {$allowedBasePath}");
         }
@@ -758,13 +767,21 @@ class ZVec
         $ffi = self::ffi();
         $details = $ffi->new('zvec_error_details_t');
         $ffi->zvec_get_last_error_details(FFI::addr($details));
-        return [
+        $result = [
             'code' => $details->code,
             'message' => $details->message !== null ? FFI::string($details->message) : null,
             'file' => $details->file !== null ? FFI::string($details->file) : null,
             'line' => $details->line,
             'function' => $details->function !== null ? FFI::string($details->function) : null,
         ];
+
+        if (!self::$verboseErrors) {
+            $result['file'] = null;
+            $result['line'] = 0;
+            $result['function'] = null;
+        }
+
+        return $result;
     }
 
     public static function clearError(): void

--- a/tests/test_error_details.phpt
+++ b/tests/test_error_details.phpt
@@ -5,7 +5,7 @@ Error details: source location in exceptions, error code strings
 --FILE--
 <?php
 require_once __DIR__ . '/../src/ZVec.php';
-ZVec::init(logType: ZVec::LOG_CONSOLE, logLevel: ZVec::LOG_WARN);
+ZVec::init(logType: ZVec::LOG_CONSOLE, logLevel: ZVec::LOG_WARN, verboseErrors: true);
 
 // Test with nonexistent path - should get file/line/function
 try {

--- a/tests/test_verbose_errors_default.phpt
+++ b/tests/test_verbose_errors_default.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Verbose errors: default (disabled) strips file/line/function from exceptions
+--SKIPIF--
+<?php if (extension_loaded('zvec')) die('skip verboseErrors is FFI-only, not available with native zvec extension'); ?>
+<?php if (!extension_loaded('ffi')) die('skip FFI extension not available'); ?>
+--FILE--
+<?php
+require_once __DIR__ . '/../src/ZVec.php';
+
+ZVec::init(logType: ZVec::LOG_CONSOLE, logLevel: ZVec::LOG_WARN);
+
+try {
+    $c = ZVec::open('/tmp/nonexistent_' . uniqid());
+    echo "FAIL: Should have thrown exception\n";
+    exit(1);
+} catch (ZVecException $e) {
+    $file = $e->getErrorFile();
+    $line = $e->getErrorLine();
+    $func = $e->getErrorFunction();
+
+    if ($file === null && $line === null && $func === null) {
+        echo "PASS: verboseErrors=false strips file/line/function\n";
+    } else {
+        echo "FAIL: Expected null details, got file=$file line=$line func=$func\n";
+        exit(1);
+    }
+}
+?>
+--EXPECT--
+PASS: verboseErrors=false strips file/line/function

--- a/tests/test_verbose_errors_enabled.phpt
+++ b/tests/test_verbose_errors_enabled.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Verbose errors: enabled preserves file/line/function in exceptions
+--SKIPIF--
+<?php if (extension_loaded('zvec')) die('skip verboseErrors is FFI-only, not available with native zvec extension'); ?>
+<?php if (!extension_loaded('ffi')) die('skip FFI extension not available'); ?>
+--FILE--
+<?php
+require_once __DIR__ . '/../src/ZVec.php';
+
+ZVec::init(logType: ZVec::LOG_CONSOLE, logLevel: ZVec::LOG_WARN, verboseErrors: true);
+
+try {
+    $c = ZVec::open('/tmp/nonexistent_' . uniqid());
+    echo "FAIL: Should have thrown exception\n";
+    exit(1);
+} catch (ZVecException $e) {
+    $file = $e->getErrorFile();
+    $line = $e->getErrorLine();
+    $func = $e->getErrorFunction();
+
+    if ($file !== null && $line !== null && $func !== null) {
+        echo "PASS: verboseErrors=true preserves file/line/function\n";
+        echo "file contains basename only: " . (str_contains($file, '/') ? 'FAIL' : 'OK') . "\n";
+    } else {
+        echo "FAIL: Expected non-null details, got file=$file line=$line func=$func\n";
+        exit(1);
+    }
+}
+?>
+--EXPECT--
+PASS: verboseErrors=true preserves file/line/function
+file contains basename only: OK

--- a/tests/test_verbose_errors_getlasterrordetails.phpt
+++ b/tests/test_verbose_errors_getlasterrordetails.phpt
@@ -1,0 +1,44 @@
+--TEST--
+Verbose errors: getLastErrorDetails respects verboseErrors flag
+--SKIPIF--
+<?php if (extension_loaded('zvec')) die('skip verboseErrors is FFI-only, not available with native zvec extension'); ?>
+<?php if (!extension_loaded('ffi')) die('skip FFI extension not available'); ?>
+--FILE--
+<?php
+require_once __DIR__ . '/../src/ZVec.php';
+
+// Test with verboseErrors=false (default)
+ZVec::init(logType: ZVec::LOG_CONSOLE, logLevel: ZVec::LOG_WARN);
+try {
+    ZVec::open('/tmp/nonexistent_' . uniqid());
+} catch (ZVecException $e) {
+    // Expected
+}
+
+$details = ZVec::getLastErrorDetails();
+if ($details['file'] === null && $details['line'] === 0 && $details['function'] === null) {
+    echo "PASS: verboseErrors=false strips getLastErrorDetails\n";
+} else {
+    echo "FAIL: file={$details['file']} line={$details['line']} function={$details['function']}\n";
+    exit(1);
+}
+
+// Test with verboseErrors=true
+ZVec::init(logType: ZVec::LOG_CONSOLE, logLevel: ZVec::LOG_WARN, verboseErrors: true);
+try {
+    ZVec::open('/tmp/nonexistent_' . uniqid());
+} catch (ZVecException $e) {
+    // Expected
+}
+
+$details = ZVec::getLastErrorDetails();
+if ($details['file'] !== null && $details['line'] > 0 && $details['function'] !== null) {
+    echo "PASS: verboseErrors=true preserves getLastErrorDetails\n";
+} else {
+    echo "FAIL: file={$details['file']} line={$details['line']} function={$details['function']}\n";
+    exit(1);
+}
+?>
+--EXPECT--
+PASS: verboseErrors=false strips getLastErrorDetails
+PASS: verboseErrors=true preserves getLastErrorDetails

--- a/tests/test_verbose_errors_path_stripped.phpt
+++ b/tests/test_verbose_errors_path_stripped.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Verbose errors: C++ file path stripped to basename only
+--SKIPIF--
+<?php if (extension_loaded('zvec')) die('skip verboseErrors is FFI-only, not available with native zvec extension'); ?>
+<?php if (!extension_loaded('ffi')) die('skip FFI extension not available'); ?>
+--FILE--
+<?php
+require_once __DIR__ . '/../src/ZVec.php';
+
+ZVec::init(logType: ZVec::LOG_CONSOLE, logLevel: ZVec::LOG_WARN, verboseErrors: true);
+
+try {
+    $c = ZVec::open('/tmp/nonexistent_' . uniqid());
+    echo "FAIL: Should have thrown exception\n";
+    exit(1);
+} catch (ZVecException $e) {
+    $file = $e->getErrorFile();
+
+    if ($file === null) {
+        echo "FAIL: file is null\n";
+        exit(1);
+    }
+
+    if (!str_contains($file, '/')) {
+        echo "PASS: C++ path stripped to basename: $file\n";
+    } else {
+        echo "FAIL: C++ path still contains directory separator: $file\n";
+        exit(1);
+    }
+}
+?>
+--EXPECT--
+PASS: C++ path stripped to basename: zvec_ffi.cc


### PR DESCRIPTION
## Summary

Add `verboseErrors` parameter to `ZVec::init()` to control error detail disclosure. When `verboseErrors=false` (default), `ZVecException` omits file/line/function properties, preventing internal path leakage to end users.

Also strip `__FILE__` to basename in `MAKE_STATUS` macro via `strrchr()` to reduce information disclosure even in verbose mode.

## Changes

- **`src/ZVec.php`**: Add `private static bool $verboseErrors = false` and `bool $verboseErrors = false` parameter to `init()`. Modify `checkStatus()` to conditionally include file/line/function based on `$verboseErrors`.
- **`ffi/zvec_ffi.cc`**: Add `strip_path()` helper that uses `strrchr()` to extract basename. Update `MAKE_STATUS` and `SET_FFI_ERROR` macros to use `strip_path(__FILE__)`.
- **`tests/test_error_details.phpt`**: Updated to use `verboseErrors: true` since this test specifically verifies error detail availability.
- **New tests**: `test_verbose_errors_default.phpt`, `test_verbose_errors_enabled.phpt`, `test_verbose_errors_path_stripped.phpt`

## Security Impact

Before: `ZVecException: collection path not exist in /home/forge/php-zvec/ffi/zvec_ffi.cc:560 in function zvec_collection_open`
After: `ZVecException: collection path not exist` (default)

## Closes

Closes #78
