### PR TITLE
fix(BUG-009): require explicit nullable when alterColumn changes data type

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -282,6 +282,7 @@ $collection->alterColumn('value', newDataType: ZVec::TYPE_FLOAT, nullable: true)
 ```
 
 **Important limitations:**
+- `nullable` must be explicitly specified when `newDataType` is provided — otherwise throws `ZVecException`
 - Cannot rename AND change type in one call — requires two separate calls
 - Cannot change nullable: true → false (only false → true or keep same)
 - Only scalar numeric types: INT32, INT64, UINT32, UINT64, FLOAT, DOUBLE

--- a/src/ZVec.php
+++ b/src/ZVec.php
@@ -474,6 +474,14 @@ class ZVec
     public function alterColumn(string $columnName, ?string $newName = null, ?int $newDataType = null, ?bool $nullable = null, int $concurrency = 0): void
     {
         $this->checkClosed();
+
+        if ($newDataType !== null && $nullable === null) {
+            throw new ZVecException(
+                'nullable must be explicitly specified when changing data type. '
+                . 'Use alterColumn("name", newDataType: TYPE_FLOAT, nullable: true|false).'
+            );
+        }
+
         // Data type constants for alter column (scalar numeric only)
         // INT32 = 4, INT64 = 5, UINT32 = 6, UINT64 = 7, FLOAT = 8, DOUBLE = 9
         $dataType = $newDataType ?? 0; // 0 = UNDEFINED (no type change)

--- a/tests/bug_0009.phpt
+++ b/tests/bug_0009.phpt
@@ -1,0 +1,85 @@
+--TEST--
+BUG-009: alterColumn() must require explicit nullable when changing data type
+--SKIPIF--
+<?php if (!extension_loaded('ffi')) die('skip FFI extension not available'); ?>
+--FILE--
+<?php
+require_once __DIR__ . '/../src/ZVec.php';
+ZVec::init(logType: ZVec::LOG_CONSOLE, logLevel: ZVec::LOG_WARN);
+
+$path = __DIR__ . '/../test_dbs/bug_0009_' . uniqid();
+try {
+    $schema = new ZVecSchema('test');
+    $schema->setMaxDocCountPerSegment(1000)
+        ->addInt64('id', nullable: false)
+        ->addInt64('value', nullable: true)
+        ->addVectorFp32('v', dimension: 4, metricType: ZVecSchema::METRIC_IP);
+
+    $c = ZVec::create($path, $schema);
+
+    $doc = new ZVecDoc('doc1');
+    $doc->setInt64('id', 1)
+        ->setInt64('value', 42)
+        ->setVectorFp32('v', [0.1, 0.2, 0.3, 0.4]);
+    $c->insert($doc);
+    $c->optimize();
+
+    // Test 1: alterColumn with newDataType but no nullable — must throw
+    try {
+        $c->alterColumn('value', newDataType: ZVec::TYPE_FLOAT);
+        echo "FAIL: should have thrown ZVecException\n";
+    } catch (ZVecException $e) {
+        $msg = $e->getMessage();
+        assert(str_contains($msg, 'nullable must be explicitly specified'), "Expected clear error message, got: $msg");
+        echo "PASS: alterColumn(newDataType) without nullable throws ZVecException\n";
+    }
+
+    // Test 2: alterColumn with newDataType + nullable: true — should work
+    $c->alterColumn('value', newDataType: ZVec::TYPE_FLOAT, nullable: true);
+    $fetched = $c->fetch('doc1');
+    $score = $fetched[0]->getFloat('value');
+    assert(abs($score - 42.0) < 0.001, "Expected value≈42.0, got $score");
+    echo "PASS: alterColumn(newDataType, nullable: true) works\n";
+
+    // Test 3: alterColumn with newDataType + nullable: false — C++ rejects true→false
+    try {
+        $c->alterColumn('value', newDataType: ZVec::TYPE_DOUBLE, nullable: false);
+        echo "FAIL: nullable true→false should be rejected\n";
+    } catch (ZVecException $e) {
+        echo "PASS: alterColumn(newDataType, nullable: false) correctly rejected true→false\n";
+    }
+
+    // Test 4: rename only (no newDataType) — nullable not required
+    $c->alterColumn('value', newName: 'score');
+    $fetched = $c->fetch('doc1');
+    $score = $fetched[0]->getFloat('score');
+    assert(abs($score - 42.0) < 0.001, "Expected score≈42.0, got $score");
+    echo "PASS: rename-only without nullable works\n";
+
+    // Test 5: nullable-only change without newDataType — C++ rejects (requires new schema)
+    try {
+        $c->alterColumn('score', nullable: true);
+        echo "PASS: nullable-only change works\n";
+    } catch (ZVecException $e) {
+        echo "PASS: nullable-only rejected (C++ requires newDataType): " . $e->getMessage() . "\n";
+    }
+
+    // Test 6: Verify column still has correct data after all operations
+    $fetched = $c->fetch('doc1');
+    assert(abs($fetched[0]->getFloat('score') - 42.0) < 0.001, 'Expected score≈42.0 unchanged');
+    echo "PASS: data integrity verified after all operations\n";
+
+    $c->close();
+    echo "ALL TESTS PASSED\n";
+} finally {
+    exec("rm -rf " . escapeshellarg($path));
+}
+?>
+--EXPECT--
+PASS: alterColumn(newDataType) without nullable throws ZVecException
+PASS: alterColumn(newDataType, nullable: true) works
+PASS: alterColumn(newDataType, nullable: false) correctly rejected true→false
+PASS: rename-only without nullable works
+PASS: nullable-only rejected (C++ requires newDataType): New column schema is null
+PASS: data integrity verified after all operations
+ALL TESTS PASSED


### PR DESCRIPTION
## Summary

Fixes silent data constraint corruption in alterColumn(). When calling alterColumn() with newDataType but without specifying nullable, the method silently made columns NOT NULL because null was mapped to 0.

## Problem

```php
// Column score is nullable=true
$coll->alterColumn('score', newDataType: ZVec::TYPE_FLOAT);
// BUG: score is now nullable=false - silent data constraint corruption!
```

## Solution

Throw ZVecException when newDataType is set without explicit nullable:

```php
$coll->alterColumn('score', newDataType: ZVec::TYPE_FLOAT);
// Throws: nullable must be explicitly specified when changing data type.

// Correct usage:
$coll->alterColumn('score', newDataType: ZVec::TYPE_FLOAT, nullable: true);
```

## Changes

- src/ZVec.php:474-484 - Add guard clause in alterColumn()
- tests/bug_0009.phpt - Test exception is thrown, explicit nullable works

## Tests

All 136 tests pass. Closes #56.