### PR TITLE
fix: validate version argument with semver regex to prevent URL injection (closes #75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **SEC-007: Validate version argument with semver regex to prevent URL injection in FFI library download** (#75)
+  - Added `preg_match('/^v\d+\.\d+\.\d+(-[\w.-]*\w)?$/', $version)` validation in both `bin/zvec-install` and `Installer::install()`
+  - Rejects path traversal (`../../etc/passwd`), incomplete semver (`v0.4`), empty strings, and URL-unsafe characters (`+`)
+  - Accepts standard semver with optional pre-release suffixes (e.g. `v0.5.0-alpha1`, `v0.4.0-rc.2`)
+  - CLI entry point writes to STDERR and exits with code 1; programmatic path throws `RuntimeException`
+  - Added `tests/test_installer_version_validation.phpt` — 15 test cases covering valid versions, path traversal, null byte injection, and trailing special characters
+
 - **SEC-002: Replace predictable tempnam() with cryptographically random temp directory to prevent symlink race** (#71)
   - Replaced `tempnam()` + `.tar.gz` suffix with `mkdir()` + `random_bytes(8)` + `bin2hex()` for secure temp directory creation
   - Temp directory created with 0700 permissions (only current user can access)

--- a/bin/zvec-install
+++ b/bin/zvec-install
@@ -21,8 +21,8 @@ if ($argc > 1) {
         echo "  zvec-install v0.4.10  Install specific version\n";
         exit(0);
     }
-    $version = 'v' . ltrim($argv[1] ?? '', 'v');
-    if (!preg_match('/^v\d+\.\d+\.\d+[\w.-]*$/', $version)) {
+    $version = 'v' . ltrim($argv[1], 'v');
+    if (!preg_match('/^v\d+\.\d+\.\d+(-[\w.-]*\w)?$/', $version)) {
         fwrite(STDERR, "Invalid version format: {$version}\n");
         fwrite(STDERR, "Expected format: v0.4.0 or 0.4.0 (semver with optional pre-release suffix)\n");
         exit(1);

--- a/bin/zvec-install
+++ b/bin/zvec-install
@@ -21,7 +21,12 @@ if ($argc > 1) {
         echo "  zvec-install v0.4.10  Install specific version\n";
         exit(0);
     }
-    $version = 'v' . ltrim($argv[1], 'v');
+    $version = 'v' . ltrim($argv[1] ?? '', 'v');
+    if (!preg_match('/^v\d+\.\d+\.\d+[\w.-]*$/', $version)) {
+        fwrite(STDERR, "Invalid version format: {$version}\n");
+        fwrite(STDERR, "Expected format: v0.4.0 or 0.4.0 (semver with optional pre-release suffix)\n");
+        exit(1);
+    }
 }
 
 Installer::install($version);

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -34,7 +34,7 @@ class Installer
         }
 
         $version = $version ?? self::detectVersion();
-        if (!preg_match('/^v\d+\.\d+\.\d+[\w.-]*$/', $version)) {
+        if (!preg_match('/^v\d+\.\d+\.\d+(-[\w.-]*\w)?$/', $version)) {
             throw new RuntimeException("Invalid version format: {$version}. Expected semver format (e.g. v0.4.0)");
         }
         $url = "https://github.com/" . self::GITHUB_REPO . "/releases/download/{$version}/{$assetName}";

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -34,6 +34,9 @@ class Installer
         }
 
         $version = $version ?? self::detectVersion();
+        if (!preg_match('/^v\d+\.\d+\.\d+[\w.-]*$/', $version)) {
+            throw new RuntimeException("Invalid version format: {$version}. Expected semver format (e.g. v0.4.0)");
+        }
         $url = "https://github.com/" . self::GITHUB_REPO . "/releases/download/{$version}/{$assetName}";
 
         $libDir = self::LIB_DIR;

--- a/tests/test_installer_version_validation.phpt
+++ b/tests/test_installer_version_validation.phpt
@@ -1,0 +1,72 @@
+--TEST--
+SEC-007: Version argument validation in CLI installer
+--FILE--
+<?php
+declare(strict_types=1);
+require_once __DIR__ . '/../src/Installer.php';
+
+use CrazyGoat\ZVec\Installer;
+
+// Test 1: Valid versions pass validation (Installer::install() will attempt download,
+// but RuntimeException with "Invalid version format" should NOT be thrown)
+$validVersions = ['v0.4.0', 'v1.2.3', 'v0.5.0-alpha1', 'v0.4.0-rc.2'];
+foreach ($validVersions as $v) {
+    ob_start();
+    try {
+        Installer::install($v);
+        ob_end_clean();
+        // If no exception, platform returned early (no asset for platform)
+        echo "PASS: {$v} accepted\n";
+    } catch (RuntimeException $e) {
+        ob_end_clean();
+        if (str_contains($e->getMessage(), 'Invalid version format')) {
+            echo "FAIL: {$v} rejected as invalid but should be accepted\n";
+            exit(1);
+        }
+        // Download failure is expected (not a validation error)
+        echo "PASS: {$v} accepted (download error expected)\n";
+    }
+}
+
+// Test 2: Invalid versions are rejected with RuntimeException
+$invalidVersions = [
+    ['../../etc/passwd', 'path traversal'],
+    ['v0.4', 'incomplete semver'],
+    ['', 'empty string'],
+    ['foo/bar', 'slash in version'],
+    ["v0.4.0\x00exploit", 'null byte'],
+    ['not-a-version', 'just text'],
+    ['v1.2', 'missing patch'],
+    ['v0.4.0+build.123', 'plus in version (URL-unsafe)'],
+];
+foreach ($invalidVersions as [$v, $label]) {
+    try {
+        Installer::install($v);
+        echo "FAIL: {$label} ({$v}) should have been rejected\n";
+        exit(1);
+    } catch (RuntimeException $e) {
+        if (str_contains($e->getMessage(), 'Invalid version format')) {
+            echo "PASS: {$label} rejected\n";
+        } else {
+            echo "FAIL: {$label} threw wrong exception: {$e->getMessage()}\n";
+            exit(1);
+        }
+    }
+}
+
+echo "PASS: All version validation tests completed\n";
+?>
+--EXPECT--
+PASS: v0.4.0 accepted (download error expected)
+PASS: v1.2.3 accepted (download error expected)
+PASS: v0.5.0-alpha1 accepted (download error expected)
+PASS: v0.4.0-rc.2 accepted (download error expected)
+PASS: path traversal rejected
+PASS: incomplete semver rejected
+PASS: empty string rejected
+PASS: slash in version rejected
+PASS: null byte rejected
+PASS: just text rejected
+PASS: missing patch rejected
+PASS: plus in version (URL-unsafe) rejected
+PASS: All version validation tests completed

--- a/tests/test_installer_version_validation.phpt
+++ b/tests/test_installer_version_validation.phpt
@@ -15,7 +15,6 @@ foreach ($validVersions as $v) {
     try {
         Installer::install($v);
         ob_end_clean();
-        // If no exception, platform returned early (no asset for platform)
         echo "PASS: {$v} accepted\n";
     } catch (RuntimeException $e) {
         ob_end_clean();
@@ -23,7 +22,6 @@ foreach ($validVersions as $v) {
             echo "FAIL: {$v} rejected as invalid but should be accepted\n";
             exit(1);
         }
-        // Download failure is expected (not a validation error)
         echo "PASS: {$v} accepted (download error expected)\n";
     }
 }
@@ -38,6 +36,9 @@ $invalidVersions = [
     ['not-a-version', 'just text'],
     ['v1.2', 'missing patch'],
     ['v0.4.0+build.123', 'plus in version (URL-unsafe)'],
+    ['v0.4.0.', 'trailing dot'],
+    ['v0.4.0-', 'trailing hyphen'],
+    ['v0.4.0--', 'double trailing hyphen'],
 ];
 foreach ($invalidVersions as [$v, $label]) {
     try {
@@ -69,4 +70,7 @@ PASS: null byte rejected
 PASS: just text rejected
 PASS: missing patch rejected
 PASS: plus in version (URL-unsafe) rejected
+PASS: trailing dot rejected
+PASS: trailing hyphen rejected
+PASS: double trailing hyphen rejected
 PASS: All version validation tests completed


### PR DESCRIPTION
## Description

Closes #75

The CLI installer (`bin/zvec-install`) and `Installer::install()` accepted arbitrary version strings without validation. A crafted argument like `../../other/repo/v1.0.0` could manipulate the download URL structure.

## Changes

- Added `preg_match` validation with semver regex in both `bin/zvec-install` (CLI entry point) and `Installer::install()` (programmatic path)
- CLI path: writes to STDERR and exits with code 1 on invalid version
- Programmatic path: throws `RuntimeException` with descriptive message
- Regex accepts standard semver with optional pre-release suffixes (`v0.5.0-alpha1`, `v0.4.0-rc.2`)
- Regex rejects: path traversal, incomplete semver, empty strings, URL-unsafe characters (`+`), trailing dots/hyphens

## Testing

- Added `tests/test_installer_version_validation.phpt` - 15 test cases
  - 4 valid versions: `v0.4.0`, `v1.2.3`, `v0.5.0-alpha1`, `v0.4.0-rc.2`
  - 11 invalid versions: path traversal, incomplete semver, empty string, slashes, null bytes, just text, trailing dot/hyphen, plus sign
- All existing installer tests continue to pass (7/10 pass; 3 pre-existing platform-specific failures)

## Code Review

- [x] Passed subagent code review (2 rounds)
- [x] All review comments addressed (regex strictness, redundant null coalescing, additional test cases)

## Files Changed

- `bin/zvec-install` - version validation before `Installer::install()` call
- `src/Installer.php` - version validation in `install()` before URL construction
- `tests/test_installer_version_validation.phpt` - new test file
- `CHANGELOG.md` - entry under Security section