### PR TITLE
docs: add PHPDoc for ZVec::init() parameters and companion methods (closes #64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - All existing `addField*()` methods remain as deprecated aliases
   - Updated all internal call sites to use new method names
 
+- **DOC-005: Add PHPDoc for `ZVec::init()`, `isInitialized()`, and `shutdown()`** (#64)
+  - Added comprehensive PHPDoc block to `init()` documenting all 13 parameters with descriptions, valid constant ranges, default values, and 0-value semantics
+  - Added PHPDoc for `isInitialized()` with `@return bool` description
+  - Added PHPDoc for `shutdown()` with `@throws ZVecException` documentation
+  - Cover `$logType`, `$logLevel`, `$logDir`, `$logBasename`, `$logFileSize`, `$logOverdueDays`, `$queryThreads`, `$optimizeThreads`, `$invertToForwardScanRatio`, `$bruteForceByKeysRatio`, `$memoryLimitMb`, `$allowedBasePath`, and `$verboseErrors`
+
 ### Deprecated
 
 - `addFieldBinary()` — use `addBinary()` instead

--- a/src/ZVec.php
+++ b/src/ZVec.php
@@ -722,6 +722,46 @@ class ZVec
     public const QUANTIZE_INT4 = 3;
     public const QUANTIZE_RABITQ = 4;
 
+    /**
+     * Initialize the zvec library.
+     *
+     * Must be called once before any other ZVec operation.
+     * Subsequent calls are no-ops (idempotent).
+     *
+     * @param int $logType Log destination. One of:
+     *     LOG_CONSOLE (0) — stderr output
+     *     LOG_FILE    (1) — file output (requires $logDir)
+     * @param int $logLevel Log verbosity filter. One of:
+     *     LOG_DEBUG (0) — all messages
+     *     LOG_INFO  (1) — informational and above
+     *     LOG_WARN  (2) — warnings and above (default)
+     *     LOG_ERROR (3) — errors only
+     *     LOG_FATAL (4) — fatal errors only
+     * @param string|null $logDir Directory for log file output. Required when
+     *     $logType is LOG_FILE. Directory must exist and be writable.
+     * @param string|null $logBasename Log file name prefix (default: "zvec").
+     *     Final name: {basename}.YYYY-MM-DD.N.log
+     * @param int $logFileSize Maximum single log file size in bytes before
+     *     rotation. 0 = unlimited rotation.
+     * @param int $logOverdueDays Days after which old log files are auto-deleted.
+     *     0 = no auto-deletion.
+     * @param int $queryThreads Thread pool size for queries. 0 = auto-detect
+     *     (uses hardware concurrency).
+     * @param int $optimizeThreads Thread pool size for optimize operations.
+     *     0 = auto-detect.
+     * @param float $invertToForwardScanRatio Threshold controlling when the
+     *     query planner switches from inverted index to forward scan.
+     *     0.0 = use library default.
+     * @param float $bruteForceByKeysRatio Threshold for brute-force vs indexed
+     *     key lookup. 0.0 = use library default.
+     * @param int $memoryLimitMb Memory limit for the collection cache in MB.
+     *     0 = unlimited.
+     * @param string|null $allowedBasePath Restrict database paths to this directory.
+     *     All create/open calls will reject paths outside this tree. null = no restriction.
+     * @param bool $verboseErrors When true, error messages include file and line information.
+     * @throws ZVecException On FFI initialization failure (e.g., shared library
+     *     not found, GPU init failure), or when $allowedBasePath does not exist.
+     */
     public static function init(
         int $logType = self::LOG_CONSOLE,
         int $logLevel = self::LOG_WARN,
@@ -777,11 +817,24 @@ class ZVec
         }
     }
 
+    /**
+     * Check whether the zvec library has been initialized.
+     *
+     * @return bool true if init() was called successfully, false otherwise.
+     */
     public static function isInitialized(): bool
     {
         return self::ffi()->zvec_ffi_is_initialized() !== 0;
     }
 
+    /**
+     * Shut down the zvec library and release global resources.
+     *
+     * Idempotent — safe to call multiple times.
+     * After shutdown, init() must be called again before any operations.
+     *
+     * @throws ZVecException On FFI shutdown error.
+     */
     public static function shutdown(): void
     {
         self::ffi()->zvec_ffi_shutdown();

--- a/src/ZVec.php
+++ b/src/ZVec.php
@@ -739,7 +739,7 @@ class ZVec
      *     LOG_FATAL (4) — fatal errors only
      * @param string|null $logDir Directory for log file output. Required when
      *     $logType is LOG_FILE. Directory must exist and be writable.
-     * @param string|null $logBasename Log file name prefix (default: "zvec").
+     * @param string|null $logBasename Log file name prefix (default: null — library uses "zvec" internally).
      *     Final name: {basename}.YYYY-MM-DD.N.log
      * @param int $logFileSize Maximum single log file size in bytes before
      *     rotation. 0 = unlimited rotation.


### PR DESCRIPTION
## Description

Closes #64

## Changes

- Added comprehensive PHPDoc block to `ZVec::init()` documenting all 13 parameters with descriptions, valid constant ranges, default values, and 0-value semantics
- Added PHPDoc for `isInitialized()` with `@return bool` description
- Added PHPDoc for `shutdown()` with `@throws ZVecException` documentation
- Updated CHANGELOG.md under `[Unreleased] → ### Changed`

## Testing

- [x] `php -l src/ZVec.php` — no syntax errors
- [x] PHP-only change, no FFI rebuild needed
- [x] All 13 `@param` tags verified present via grep

## Code Review

- [x] Passed subagent code review (1 issue found: logBasename default, fixed)
- [x] All review comments addressed